### PR TITLE
Add pretty formatter

### DIFF
--- a/lib/cucumber/ast/feature.js
+++ b/lib/cucumber/ast/feature.js
@@ -40,6 +40,10 @@ var Feature = function(keyword, name, description, line) {
       scenarios.add(scenario);
     },
 
+    getScenarios: function getScenarios() {
+        return scenarios;
+    },
+
     getLastScenario: function getLastScenario() {
       return scenarios.getLast();
     },

--- a/lib/cucumber/ast/scenario.js
+++ b/lib/cucumber/ast/scenario.js
@@ -40,6 +40,10 @@ var Scenario = function(keyword, name, description, line) {
       return steps.getLast();
     },
 
+    getSteps: function getSteps() {
+      return steps;
+    },
+
     addTags: function setTags(newTags) {
       tags = tags.concat(newTags);
     },

--- a/lib/cucumber/ast/step.js
+++ b/lib/cucumber/ast/step.js
@@ -1,6 +1,6 @@
 var Step = function(keyword, name, line) {
   var Cucumber = require('../../cucumber');
-  var docString, dataTable, previousStep;
+  var docString, dataTable, previousStep, stepResult;
 
   var self = {
     setPreviousStep: function setPreviousStep(newPreviousStep) {
@@ -67,6 +67,14 @@ var Step = function(keyword, name, line) {
       }
     },
 
+    getResult: function getResult() {
+      return stepResult;
+    },
+
+    setResult: function setResult(result) {
+      stepResult = result;
+    },
+
     isOutcomeStep: function isOutcomeStep() {
       var isOutcomeStep =
         self.hasOutcomeStepKeyword() || self.isRepeatingOutcomeStep();
@@ -131,7 +139,7 @@ var Step = function(keyword, name, line) {
 
     acceptVisitor: function acceptVisitor(visitor, callback) {
       self.execute(visitor, function(stepResult) {
-        visitor.visitStepResult(stepResult, callback);
+        visitor.visitStepResult(self, stepResult, callback);
       });
     },
 

--- a/lib/cucumber/cli.js
+++ b/lib/cucumber/cli.js
@@ -13,9 +13,9 @@ var Cli = function(argv) {
     },
 
     runSuiteWithConfiguration: function runSuiteWithConfiguration(configuration, callback) {
-      var runtime           = Cucumber.Runtime(configuration);
-      var progressFormatter = Cucumber.Listener.ProgressFormatter();
-      runtime.attachListener(progressFormatter);
+      var runtime   = Cucumber.Runtime(configuration);
+      var formatter = configuration.getFormatter();
+      runtime.attachListener(formatter);
       runtime.start(callback);
     },
 

--- a/lib/cucumber/cli/argument_parser.js
+++ b/lib/cucumber/cli/argument_parser.js
@@ -59,17 +59,22 @@ var ArgumentParser = function(argv) {
 
     getKnownOptionDefinitions: function getKnownOptionDefinitions() {
       var definitions = {};
-      definitions[ArgumentParser.REQUIRE_OPTION_NAME] = [path, Array];
-      definitions[ArgumentParser.TAGS_OPTION_NAME]    = [String, Array];
-      definitions[ArgumentParser.HELP_FLAG_NAME]      = Boolean;
-      definitions[ArgumentParser.VERSION_FLAG_NAME]   = Boolean;
+      definitions[ArgumentParser.REQUIRE_OPTION_NAME]    = [path, Array];
+      definitions[ArgumentParser.TAGS_OPTION_NAME]       = [String, Array];
+      definitions[ArgumentParser.FORMATTER_OPTION_NAME]  = String;
+      definitions[ArgumentParser.HELP_FLAG_NAME]         = Boolean;
+      definitions[ArgumentParser.VERSION_FLAG_NAME]      = Boolean;
       return definitions;
     },
 
     getShortenedOptionDefinitions: function getShortenedOptionDefinitions() {
       var definitions = {};
-      definitions[ArgumentParser.REQUIRE_OPTION_SHORT_NAME] = [ArgumentParser.LONG_OPTION_PREFIX + ArgumentParser.REQUIRE_OPTION_NAME];
-      definitions[ArgumentParser.HELP_FLAG_SHORT_NAME]      = [ArgumentParser.LONG_OPTION_PREFIX + ArgumentParser.HELP_FLAG_NAME];
+      definitions[ArgumentParser.REQUIRE_OPTION_SHORT_NAME] =
+          [ArgumentParser.LONG_OPTION_PREFIX + ArgumentParser.REQUIRE_OPTION_NAME];
+      definitions[ArgumentParser.FORMATTER_OPTION_SHORT_NAME] =
+          [ArgumentParser.LONG_OPTION_PREFIX + ArgumentParser.FORMATTER_OPTION_NAME];
+      definitions[ArgumentParser.HELP_FLAG_SHORT_NAME] =
+          [ArgumentParser.LONG_OPTION_PREFIX + ArgumentParser.HELP_FLAG_NAME];
       return definitions;
     },
 
@@ -107,6 +112,8 @@ ArgumentParser.REQUIRE_OPTION_NAME             = "require";
 ArgumentParser.REQUIRE_OPTION_SHORT_NAME       = "r";
 ArgumentParser.TAGS_OPTION_NAME                = "tags";
 ArgumentParser.TAGS_OPTION_SHORT_NAME          = "t";
+ArgumentParser.FORMATTER_OPTION_NAME           = "formattter";
+ArgumentParser.FORMATTER_OPTION_SHORT_NAME     = "f";
 ArgumentParser.HELP_FLAG_NAME                  = "help";
 ArgumentParser.HELP_FLAG_SHORT_NAME            = "h";
 ArgumentParser.DEFAULT_HELP_FLAG_VALUE         = false;

--- a/lib/cucumber/cli/configuration.js
+++ b/lib/cucumber/cli/configuration.js
@@ -35,6 +35,20 @@ var Configuration = function(argv) {
       return rules;
     },
 
+    getFormatter: function getFormatter() {
+        var formatter,
+            formatterOption = argumentParser.getOptionOrDefault("formatter", "progress");
+        switch(formatterOption) {
+            case "pretty":
+                formatter = new Cucumber.Listener.PrettyFormatter();
+                break;
+            case "progress":
+            default:
+                formatter = new Cucumber.Listener.ProgressFormatter();
+        }
+        return formatter;
+    },
+
     isHelpRequested: function isHelpRequested() {
       var isHelpRequested = argumentParser.isHelpRequested();
       return isHelpRequested;

--- a/lib/cucumber/listener.js
+++ b/lib/cucumber/listener.js
@@ -1,3 +1,4 @@
 var Listener               = {};
 Listener.ProgressFormatter = require('./listener/progress_formatter');
+Listener.PrettyFormatter   = require('./listener/pretty_formatter');
 module.exports             = Listener;

--- a/lib/cucumber/listener/pretty_formatter.js
+++ b/lib/cucumber/listener/pretty_formatter.js
@@ -1,0 +1,417 @@
+var PrettyFormatter = function(options) {
+  var Cucumber = require('../../cucumber');
+  var ansiColor    = require("ansi-color").set;
+
+  var logs                     = "";
+  var failedScenarioLogBuffer  = "";
+  var undefinedStepLogBuffer   = "";
+  var passedScenarioCount      = 0;
+  var undefinedScenarioCount   = 0;
+  var pendingScenarioCount     = 0;
+  var failedScenarioCount      = 0;
+  var passedStepCount          = 0;
+  var failedStepCount          = 0;
+  var skippedStepCount         = 0;
+  var undefinedStepCount       = 0;
+  var pendingStepCount         = 0;
+  var currentScenarioFailing   = false;
+  var currentScenarioUndefined = false;
+  var currentScenarioPending   = false;
+  var failedStepResults        = Cucumber.Type.Collection();
+
+  if (!options)
+    options = {};
+  if (options['logToConsole'] == undefined)
+    options['logToConsole'] = true;
+  var self = {
+    log: function log(string) {
+      logs += string;
+      if (options['logToConsole'])
+        process.stdout.write(string);
+      if (typeof(options['logToFunction']) == 'function')
+        options['logToFunction'](string);
+    },
+
+    getLogs: function getLogs() {
+      return logs;
+    },
+
+    hear: function hear(event, callback) {
+      if (self.hasHandlerForEvent(event)) {
+        var handler = self.getHandlerForEvent(event);
+        handler(event, callback);
+      } else {
+        callback();
+      }
+    },
+
+    hasHandlerForEvent: function hasHandlerForEvent(event) {
+      var handlerName = self.buildHandlerNameForEvent(event);
+      return self[handlerName] != undefined;
+    },
+
+    buildHandlerNameForEvent: function buildHandlerNameForEvent(event) {
+      var handlerName =
+        PrettyFormatter.EVENT_HANDLER_NAME_PREFIX +
+        event.getName() +
+        PrettyFormatter.EVENT_HANDLER_NAME_SUFFIX;
+      return handlerName;
+    },
+
+    getHandlerForEvent: function getHandlerForEvent(event) {
+      var eventHandlerName = self.buildHandlerNameForEvent(event);
+      return self[eventHandlerName];
+    },
+
+    handleBeforeScenarioEvent: function handleBeforeScenarioEvent(event, callback) {
+      self.prepareBeforeScenario();
+      callback();
+    },
+
+    handleStepResultEvent: function handleStepResult(event, callback) {
+      var stepResult = event.getPayloadItem('stepResult');
+      var step = event.getPayloadItem('step');
+      step.setResult(stepResult);
+      if (stepResult.isSuccessful())
+        self.handleSuccessfulStepResult();
+      else if (stepResult.isPending())
+        self.handlePendingStepResult();
+      else if (stepResult.isSkipped())
+        self.handleSkippedStepResult();
+      else if (stepResult.isUndefined())
+        self.handleUndefinedStepResult(stepResult);
+      else
+        self.handleFailedStepResult(stepResult);
+      callback();
+    },
+
+    handleSuccessfulStepResult: function handleSuccessfulStepResult() {
+      self.witnessPassedStep();
+    },
+
+    handlePendingStepResult: function handlePendingStepResult() {
+      self.witnessPendingStep();
+      self.markCurrentScenarioAsPending();
+    },
+
+    handleSkippedStepResult: function handleSkippedStepResult() {
+      self.witnessSkippedStep();
+    },
+
+    handleUndefinedStepResult: function handleUndefinedStepResult(stepResult) {
+      var step = stepResult.getStep();
+      self.storeUndefinedStep(step);
+      self.witnessUndefinedStep();
+      self.markCurrentScenarioAsUndefined();
+    },
+
+    handleFailedStepResult: function handleFailedStepResult(stepResult) {
+      self.storeFailedStepResult(stepResult);
+      self.witnessFailedStep();
+      self.markCurrentScenarioAsFailing();
+    },
+
+    handleAfterFeaturesEvent: function handleAfterFeaturesEvent(event, callback) {
+      self.logSummary();
+      callback();
+    },
+
+    handleAfterFeatureEvent: function handleAfterFeatureEvent(event, callback) {
+      var feature = event.getPayloadItem('feature');
+      self.logFeature(feature);
+      callback();
+    },
+
+    handleAfterScenarioEvent: function handleAfterScenarioEvent(event, callback) {
+      if (self.isCurrentScenarioFailing()) {
+        var scenario = event.getPayloadItem('scenario');
+        self.storeFailedScenario(scenario);
+        self.witnessFailedScenario();
+      } else if (self.isCurrentScenarioUndefined()) {
+        self.witnessUndefinedScenario();
+      } else if (self.isCurrentScenarioPending()) {
+        self.witnessPendingScenario();
+      } else {
+        self.witnessPassedScenario();
+      }
+      callback();
+    },
+
+    prepareBeforeScenario: function prepareBeforeScenario() {
+      currentScenarioFailing   = false;
+      currentScenarioPending   = false;
+      currentScenarioUndefined = false;
+    },
+
+    markCurrentScenarioAsFailing: function markCurrentScenarioAsFailing() {
+      currentScenarioFailing = true;
+    },
+
+    markCurrentScenarioAsUndefined: function markCurrentScenarioAsUndefined() {
+      currentScenarioUndefined = true;
+    },
+
+    markCurrentScenarioAsPending: function markCurrentScenarioAsPending() {
+      currentScenarioPending = true;
+    },
+
+    isCurrentScenarioFailing: function isCurrentScenarioFailing() {
+      return currentScenarioFailing;
+    },
+
+    isCurrentScenarioUndefined: function isCurrentScenarioUndefined() {
+      return currentScenarioUndefined;
+    },
+
+    isCurrentScenarioPending: function isCurrentScenarioPending() {
+      return currentScenarioPending;
+    },
+
+    storeFailedStepResult: function storeFailedStepResult(failedStepResult) {
+      failedStepResults.add(failedStepResult);
+    },
+
+    storeFailedScenario: function storeFailedScenario(failedScenario) {
+      var name = failedScenario.getName();
+      var line = failedScenario.getLine();
+      self.appendStringToFailedScenarioLogBuffer(":" + line + " # Scenario: " + name);
+    },
+
+    storeUndefinedStep: function storeUndefinedStep(step) {
+      var snippetBuilder = Cucumber.SupportCode.StepDefinitionSnippetBuilder(step);
+      var snippet        = snippetBuilder.buildSnippet();
+      self.appendStringToUndefinedStepLogBuffer(snippet);
+    },
+
+    appendStringToFailedScenarioLogBuffer: function appendStringToFailedScenarioLogBuffer(string) {
+      failedScenarioLogBuffer += string + "\n";
+    },
+
+    appendStringToUndefinedStepLogBuffer: function appendStringToUndefinedStepLogBuffer(string) {
+      if (undefinedStepLogBuffer.indexOf(string) == -1)
+        undefinedStepLogBuffer += string + "\n";
+    },
+
+    getFailedScenarioLogBuffer: function getFailedScenarioLogBuffer() {
+      return failedScenarioLogBuffer;
+    },
+
+    getUndefinedStepLogBuffer: function getUndefinedStepLogBuffer() {
+      return undefinedStepLogBuffer;
+    },
+
+    logFeature: function logFeature(feature) {
+      var description = feature.getDescription().split("\n").map(function(l) { return "  "+l; }).join("\n");
+      self.log(feature.getKeyword()+": "+feature.getName()+"\n");
+      self.log(description+"\n\n");
+      if (feature.hasBackground()) {
+        self.log(feature.getBackground().split("\n").map(function(l) { return "  "+l; }).join("\n")+"\n\n");
+      }
+      self.logScenarios(feature.getScenarios());
+    },
+
+    logScenarios: function logScenarios(scenarios) {
+      scenarios.syncForEach(function(scenario) {
+        self.log("  "+scenario.getKeyword()+": "+scenario.getName()+"\n");
+        self.logSteps(scenario.getSteps());
+      });
+    },
+
+    logSteps: function logSteps(steps) {
+      steps.syncForEach(function(step) {
+          var color, result = step.getResult();
+          if (result.isFailed()) {
+            color = PrettyFormatter.FAILED_STEP_COLOR;
+          } else if (result.isPending()) {
+            color = PrettyFormatter.PENDING_STEP_COLOR;
+          } else if (result.isSkipped()) {
+            color = PrettyFormatter.SKIPPED_STEP_COLOR;
+          } else if (result.isSuccessful()) {
+            color = PrettyFormatter.PASSED_STEP_COLOR;
+          } else if (result.isUndefined()) {
+            color = PrettyFormatter.UNDEFINED_STEP_COLOR;
+          }
+          self.log(ansiColor("    "+step.getKeyword()+step.getName()+"\n", color));
+          if (result.isFailed()) {
+            self.logFailedStepResult(result);
+          }
+        });
+    },
+
+    logSummary: function logSummary() {
+      self.log("\n");
+      self.logScenariosSummary();
+      self.logStepsSummary();
+      if (self.witnessedAnyUndefinedStep() && options["logSnippets"])
+        self.logUndefinedStepSnippets();
+    },
+
+    logFailedStepResult: function logFailedStepResult(stepResult) {
+      var failureMessage = stepResult.getFailureException();
+      self.log(ansiColor(failureMessage.stack || failureMessage, "red"));
+    },
+
+    logScenariosSummary: function logScenariosSummary() {
+      var scenarioCount          = self.getScenarioCount();
+      var passedScenarioCount    = self.getPassedScenarioCount();
+      var undefinedScenarioCount = self.getUndefinedScenarioCount();
+      var pendingScenarioCount   = self.getPendingScenarioCount();
+      var failedScenarioCount    = self.getFailedScenarioCount();
+      var details                = [];
+
+      self.log(scenarioCount + " scenario" + (scenarioCount != 1 ? "s" : ""));
+      if (scenarioCount > 0 ) {
+        if (failedScenarioCount > 0)
+          details.push(ansiColor(failedScenarioCount + " failed", PrettyFormatter.FAILED_STEP_COLOR));
+        if (undefinedScenarioCount > 0)
+          details.push(ansiColor(undefinedScenarioCount + " undefined", PrettyFormatter.UNDEFINED_STEP_COLOR));
+        if (pendingScenarioCount > 0)
+          details.push(ansiColor(pendingScenarioCount + " pending", PrettyFormatter.PENDING_STEP_COLOR));
+        if (passedScenarioCount > 0)
+          details.push(ansiColor(passedScenarioCount + " passed", PrettyFormatter.PASSED_STEP_COLOR));
+        self.log(" (" + details.join(', ') + ")");
+      }
+      self.log("\n");
+    },
+
+    logStepsSummary: function logStepsSummary() {
+      var stepCount          = self.getStepCount();
+      var passedStepCount    = self.getPassedStepCount();
+      var undefinedStepCount = self.getUndefinedStepCount();
+      var skippedStepCount   = self.getSkippedStepCount();
+      var pendingStepCount   = self.getPendingStepCount();
+      var failedStepCount    = self.getFailedStepCount();
+      var details            = [];
+
+      self.log(stepCount + " step" + (stepCount != 1 ? "s" : ""));
+      if (stepCount > 0) {
+        if (failedStepCount > 0)
+          details.push(ansiColor(failedStepCount    + " failed", PrettyFormatter.FAILED_STEP_COLOR));
+        if (undefinedStepCount > 0)
+          details.push(ansiColor(undefinedStepCount + " undefined", PrettyFormatter.UNDEFINED_STEP_COLOR));
+        if (pendingStepCount > 0)
+          details.push(ansiColor(pendingStepCount   + " pending", PrettyFormatter.PENDING_STEP_COLOR));
+        if (skippedStepCount > 0)
+          details.push(ansiColor(skippedStepCount   + " skipped", PrettyFormatter.SKIPPED_STEP_COLOR));
+        if (passedStepCount > 0)
+          details.push(ansiColor(passedStepCount    + " passed", PrettyFormatter.PASSED_STEP_COLOR));
+        self.log(" (" + details.join(', ') + ")");
+      }
+      self.log("\n");
+    },
+
+    logUndefinedStepSnippets: function logUndefinedStepSnippets() {
+      var undefinedStepLogBuffer = self.getUndefinedStepLogBuffer();
+      self.log("\nYou can implement step definitions for undefined steps with these snippets:\n\n");
+      self.log(undefinedStepLogBuffer);
+    },
+
+    witnessPassedScenario: function witnessPassedScenario() {
+      passedScenarioCount++;
+    },
+
+    witnessUndefinedScenario: function witnessUndefinedScenario() {
+      undefinedScenarioCount++;
+    },
+
+    witnessPendingScenario: function witnessPendingScenario() {
+      pendingScenarioCount++;
+    },
+
+    witnessFailedScenario: function witnessFailedScenario() {
+      failedScenarioCount++;
+    },
+
+    witnessPassedStep: function witnessPassedStep() {
+      passedStepCount++;
+    },
+
+    witnessUndefinedStep: function witnessUndefinedStep() {
+      undefinedStepCount++;
+    },
+
+    witnessPendingStep: function witnessPendingStep() {
+      pendingStepCount++;
+    },
+
+    witnessFailedStep: function witnessFailedStep() {
+      failedStepCount++;
+    },
+
+    witnessSkippedStep: function witnessSkippedStep() {
+      skippedStepCount++;
+    },
+
+    getScenarioCount: function getScenarioCount() {
+      var scenarioCount =
+        self.getPassedScenarioCount()    +
+        self.getUndefinedScenarioCount() +
+        self.getPendingScenarioCount()   +
+        self.getFailedScenarioCount();
+      return scenarioCount;
+    },
+
+    getPassedScenarioCount: function getPassedScenarioCount() {
+      return passedScenarioCount;
+    },
+
+    getUndefinedScenarioCount: function getUndefinedScenarioCount() {
+      return undefinedScenarioCount;
+    },
+
+    getPendingScenarioCount: function getPendingScenarioCount() {
+      return pendingScenarioCount;
+    },
+
+    getFailedScenarioCount: function getFailedScenarioCount() {
+      return failedScenarioCount;
+    },
+
+    getStepCount: function getStepCount() {
+      var stepCount =
+        self.getPassedStepCount()    +
+        self.getUndefinedStepCount() +
+        self.getSkippedStepCount()   +
+        self.getPendingStepCount()   +
+        self.getFailedStepCount();
+      return stepCount;
+    },
+
+    getPassedStepCount: function getPassedStepCount() {
+      return passedStepCount;
+    },
+
+    getPendingStepCount: function getPendingStepCount() {
+      return pendingStepCount;
+    },
+
+    getFailedStepCount: function getFailedStepCount() {
+      return failedStepCount;
+    },
+
+    getSkippedStepCount: function getSkippedStepCount() {
+      return skippedStepCount;
+    },
+
+    getUndefinedStepCount: function getUndefinedStepCount() {
+      return undefinedStepCount;
+    },
+
+    witnessedAnyFailedStep: function witnessedAnyFailedStep() {
+      return failedStepCount > 0;
+    },
+
+    witnessedAnyUndefinedStep: function witnessedAnyUndefinedStep() {
+      return undefinedStepCount > 0;
+    }
+  };
+  return self;
+};
+PrettyFormatter.PASSED_STEP_COLOR         = 'green';
+PrettyFormatter.SKIPPED_STEP_COLOR        = 'blue';
+PrettyFormatter.UNDEFINED_STEP_COLOR      = 'cyan';
+PrettyFormatter.PENDING_STEP_COLOR        = 'yellow';
+PrettyFormatter.FAILED_STEP_COLOR         = 'red';
+PrettyFormatter.EVENT_HANDLER_NAME_PREFIX = 'handle';
+PrettyFormatter.EVENT_HANDLER_NAME_SUFFIX = 'Event';
+module.exports                            = PrettyFormatter;

--- a/lib/cucumber/runtime/ast_tree_walker.js
+++ b/lib/cucumber/runtime/ast_tree_walker.js
@@ -70,12 +70,12 @@ var AstTreeWalker = function(features, supportCodeLibrary, listeners) {
       );
     },
 
-    visitStepResult: function visitStepResult(stepResult, callback) {
+    visitStepResult: function visitStepResult(step, stepResult, callback) {
       if (stepResult.isFailed())
         self.witnessFailedStep();
       else if (stepResult.isPending())
         self.witnessPendingStep();
-      var payload = { stepResult: stepResult };
+      var payload = { step: step, stepResult: stepResult };
       var event   = AstTreeWalker.Event(AstTreeWalker.STEP_RESULT_EVENT_NAME, payload);
       self.broadcastEvent(event, callback);
     },
@@ -172,14 +172,14 @@ var AstTreeWalker = function(features, supportCodeLibrary, listeners) {
 
     skipStep: function skipStep(step, callback) {
       var skippedStepResult = Cucumber.Runtime.SkippedStepResult({step: step});
-      var payload           = { stepResult: skippedStepResult };
+      var payload           = { step: step, stepResult: skippedStepResult };
       var event             = AstTreeWalker.Event(AstTreeWalker.STEP_RESULT_EVENT_NAME, payload);
       self.broadcastEvent(event, callback);
     },
 
     skipUndefinedStep: function skipUndefinedStep(step, callback) {
       var undefinedStepResult = Cucumber.Runtime.UndefinedStepResult({step: step});
-      var payload = { stepResult: undefinedStepResult };
+      var payload = { step: step, stepResult: undefinedStepResult };
       var event   = AstTreeWalker.Event(AstTreeWalker.STEP_RESULT_EVENT_NAME, payload);
       self.broadcastEvent(event, callback);
     }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   , "cucumber-html": "0.2.0"
   , "findit": "0.1.1"
   , "coffee-script": "1.1.2"
+  , "ansi-color": "0.2.1"
   }
 , "scripts" :
   { "test" : "./bin/cucumber.js && jasmine-node spec" }


### PR DESCRIPTION
This adds a pretty formatter to cucumber-js. It makes some changes to the Core API to enable traversing from the feature object down to the steps with their step results. Tests for this are in another commit that will be part of another pull request.
