### PR TITLE
incorrect require path in example/server.js

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -5,7 +5,7 @@ var browserify = require('browserify');
 var port       = process.env.PORT || 9797;
 var cukeBundle = browserify({
   mount: '/cucumber.js',
-  require: ['cucumber-html', './lib/cucumber', {'./gherkin/lexer/en': 'gherkin/lib/gherkin/lexer/en'}],
+  require: ['cucumber-html', '../lib/cucumber', {'./gherkin/lexer/en': 'gherkin/lib/gherkin/lexer/en'}],
   ignore: ['./cucumber/cli', 'connect']
 });
 


### PR DESCRIPTION
In order for the example to work I had to change the require path from ./lib/cucumber to ../lib/cucumber one folder up
