### PR TITLE
Cucumber.Cli argv bug fix

### DIFF
--- a/lib/cucumber/cli/configuration.js
+++ b/lib/cucumber/cli/configuration.js
@@ -1,8 +1,8 @@
 var Configuration = function(argv) {
   var Cucumber = require('../../cucumber');
 
-  var argumentParser = Cucumber.Cli.ArgumentParser();
-  argumentParser.parse(argv);
+  var argumentParser = Cucumber.Cli.ArgumentParser(argv);
+  argumentParser.parse();
 
   var self = {
     getFormatter: function getFormatter() {

--- a/spec/cucumber/cli/configuration_spec.js
+++ b/spec/cucumber/cli/configuration_spec.js
@@ -20,11 +20,11 @@ describe("Cucumber.Cli.Configuration", function () {
 
   describe("constructor", function () {
     it("creates an argument parser", function () {
-      expect(Cucumber.Cli.ArgumentParser).toHaveBeenCalledWith();
+      expect(Cucumber.Cli.ArgumentParser).toHaveBeenCalledWith(argv);
     });
 
     it("tells the argument parser to parse the arguments", function () {
-      expect(argumentParser.parse).toHaveBeenCalledWith(argv);
+      expect(argumentParser.parse).toHaveBeenCalledWith();
     });
   });
 


### PR DESCRIPTION
-Fixes mishandled process.argv when passed from Configuration to ArgumentParser. Instead of passing argv to parse() it should be passed in to ArgumentParser() per argument_parser_spec.js

Signed-off-by: Omar Gonzalez omar@almerblank.com
