### PR TITLE
Add options parameter to JsonFormatter

### DIFF
--- a/lib/cucumber/listener/json_formatter.js
+++ b/lib/cucumber/listener/json_formatter.js
@@ -1,10 +1,17 @@
-var JsonFormatter = function() {
+var JsonFormatter = function(options) {
   var Cucumber             = require('../../cucumber');
   var GherkinJsonFormatter = require('gherkin/lib/gherkin/formatter/json_formatter');
-  var gherkinJsonFormatter =  new GherkinJsonFormatter(process.stdout);
 
   var currentFeatureId     = 'undefined';
-  var self                 = Cucumber.Listener();
+  var self                 = Cucumber.Listener.Formatter(options);
+
+  var formatterIo = {
+    write: function(string){
+      self.log(string);
+    }
+  };
+  var gherkinJsonFormatter =  new GherkinJsonFormatter(formatterIo);
+
   var parentFeatureTags;
 
   self.getGherkinFormatter = function() {


### PR DESCRIPTION
JsonFormatter is the only formatter not using Cucumber.Listener.Formatter. Listener.Formatter add an option to define the logging callback which can be usefull. I needed to use the formatter without process.stdout in a browser so I added a new 'options' parameter used by Listener.Formatter. 'self' now inherit from Listener.Formatter instead of Listener.

This change is needed to use JsonFormatter in a browser.
