### PR TITLE
Add DataTable.rows()

### DIFF
--- a/features/data_table_rows.feature
+++ b/features/data_table_rows.feature
@@ -1,0 +1,17 @@
+Feature: Data Tables
+
+  Scenario: a data table can be read as an array of values
+    Given the following data table in a step:
+      """
+      | Latin           | English      |
+      | Cucumis sativus | Cucumber     |
+      | Cucumis anguria | Burr Gherkin |
+      """
+    When the data table is passed to a step mapping that gets the row arrays without the header
+    Then the data table is converted to the following:
+      """
+      [
+        [ "Cucumis sativus", "Cucumber" ],
+        [ "Cucumis anguria", "Burr Gherkin" ]
+      ]
+      """

--- a/features/step_definitions/cucumber_steps.js
+++ b/features/step_definitions/cucumber_steps.js
@@ -232,6 +232,14 @@ callback();\
     this.runFeature({}, callback);
   });
 
+  When(/^the data table is passed to a step mapping that gets the row arrays without the header$/, function(callback) {
+    this.stepDefinitions += "When(/^a step with data table:$/, function(dataTable, callback) {\
+world.dataTableLog = dataTable.rows();\
+callback();\
+});\n";
+    this.runFeature({}, callback);
+  });
+
   When(/^Cucumber executes scenarios tagged with "([^"]*)"$/, function(tag, callback) {
     this.runFeature({tags: [tag]}, callback);
   });

--- a/lib/cucumber/ast/data_table.js
+++ b/lib/cucumber/ast/data_table.js
@@ -1,11 +1,11 @@
 var DataTable  = function() {
   var Cucumber = require('../../cucumber');
 
-  var rows = Cucumber.Type.Collection();
+  var rowsCollection = Cucumber.Type.Collection();
 
   var self = {
     attachRow: function attachRow(row) {
-      rows.add(row);
+      rowsCollection.add(row);
     },
 
     getContents: function getContents() {
@@ -14,9 +14,19 @@ var DataTable  = function() {
 
     raw: function raw() {
       rawRows = [];
-      rows.syncForEach(function(row) {
+      rowsCollection.syncForEach(function(row) {
         var rawRow = row.raw();
         rawRows.push(rawRow);
+      });
+      return rawRows;
+    },
+
+    rows: function rows() {
+      rawRows = [];
+      rowsCollection.syncForEach(function(row, index) {
+        if (index > 0) {
+          rawRows.push(row.raw());
+        }
       });
       return rawRows;
     },

--- a/spec/cucumber/ast/data_table_spec.js
+++ b/spec/cucumber/ast/data_table_spec.js
@@ -63,6 +63,28 @@ describe("Cucumber.Ast.DataTable", function() {
     });
   });
 
+  describe("rows()", function() {
+    var rowArray;
+    beforeEach(function() {
+      rawRows = [
+        createSpy("raw row 1"),
+        createSpy("raw row 2")];
+      rowArray = [
+        createSpyWithStubs("row 1", {raw: rawRows[0]}),
+        createSpyWithStubs("row 2", {raw: rawRows[1]})
+      ];
+      rows.add(rowArray[0]);
+      rows.add(rowArray[1]);
+    });
+
+    it("gets the raw representation of the row without the header", function() {
+      dataTable.rows();
+      expect(rowArray[1].raw).toHaveBeenCalled();
+      expect(rowArray[0].raw).wasNotCalled();
+    });
+  });
+
+
   describe("hashes", function() {
     var raw, hashDataTable;
 


### PR DESCRIPTION
A method to get only the row values as an array similar to the ruby variant
Cucumber::Ast::Table#rows
