### PR TITLE
Load gherkin parser considering language comment

### DIFF
--- a/lib/cucumber/parser.js
+++ b/lib/cucumber/parser.js
@@ -1,6 +1,5 @@
 var Parser = function(featureSources, astFilter) {
   var Gherkin      = require('gherkin');
-  var GherkinLexer = require('gherkin/lib/gherkin/lexer/en');
   var Cucumber     = require('../cucumber');
 
   var features     = Cucumber.Ast.Features();
@@ -9,13 +8,25 @@ var Parser = function(featureSources, astFilter) {
 
   var self = {
     parse: function parse() {
-      var eventHandler = self.getEventHandlers();
-      var lexer = new GherkinLexer(self.getEventHandlers());
+      var lexers = {};
+      var lexer = function (lang) {
+        if (!(lang in lexers)) {
+          lexers[lang] = new (Gherkin.Lexer(lang))(self.getEventHandlers());
+        }
+
+        return lexers[lang];
+      };
+
       for (i in featureSources) {
         var currentSourceUri = featureSources[i][Parser.FEATURE_NAME_SOURCE_PAIR_URI_INDEX];
         var featureSource    = featureSources[i][Parser.FEATURE_NAME_SOURCE_PAIR_SOURCE_INDEX];
         self.setCurrentSourceUri(currentSourceUri);
-        lexer.scan(featureSource);
+        featureSource = featureSource.toString();
+
+        var languageMatch = /^# language: (.*)\n/.exec(featureSource);
+        var language = languageMatch == null ? 'en' : languageMatch[1];
+
+        lexer(language).scan(featureSource);
       }
       return features;
     },


### PR DESCRIPTION
Basic support for i18n.

Problem is all languages but not EN throwing that error:

```
/Users/vyacheslav/Code/cucumber-js/node_modules/gherkin/lib/gherkin/lexer/ru.js:1614
 throw "Lexing error on line " + this.line_number + ": '" + content + "'. See 
                                                                    ^
Lexing error on line 2: 'Функционал: Сложение чисел'. See http://wiki.github.com/cucumber/gherkin/lexingerror for more information.
```

I'm think problem in generated gherkin lexers.
But I can't find where is problem because generated lexers isn't readable by normal human.
