### PR TITLE
remove cucumber.no.de link

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -111,4 +111,3 @@ This a reminder of the steps maintainers have to follow to release a new version
 * Push to main repo on Github
 * Wait for build to go green
 * Publish to NPM
-* Deploy to cucumber.no.de

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 It runs on both Node.js and *modern* web browsers.
 
-**Try it now: [http://cucumber.no.de](http://cucumber.no.de)!**
-
 ## Development status
 
 Cucumber.js is still a work in progress. Here is its current status.
@@ -449,7 +447,6 @@ A few example apps are available for you to browse:
 
 * [Rails app serving features in the browser](https://github.com/jbpros/cucumber-js-example)
 * [Express.js app running features in the cli](https://github.com/olivoil/NodeBDD)
-* [Try cucumber.js in the browser](http://cucumber.no.de/)
 
 ## Contribute
 


### PR DESCRIPTION
From #102, I just removed couple of lines mentioning [cucumber.no.de](http://cucumber.no.de) from README.md and CONTRIBUTOR.md. Not sure if there is a better alternative or not.. probably @jbpros would know..?

My first time trying out cucumber.js coming from rb, and was confused by the broken link. Maybe this will make other new comers less confused :)
