### PR TITLE
Update README.md to correct error in example for zombie initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Support files let you setup the environment in which steps will be run, and defi
 
 var zombie = require('zombie');
 var World = function World(callback) {
-  this.browser = new zombie.Browser(); // this.browser will be available in step definitions
+  this.browser = new zombie(); // this.browser will be available in step definitions
 
   this.visit = function(url, callback) {
     this.browser.visit(url, callback);
@@ -219,7 +219,7 @@ It is possible to tell Cucumber to use another object instance than the construc
 
 var zombie = require('zombie');
 var WorldConstructor = function WorldConstructor(callback) {
-  this.browser = new zombie.Browser(); // this.browser will be available in step definitions
+  this.browser = new zombie(); // this.browser will be available in step definitions
 
   var world = {
     visit: function(url, callback) {


### PR DESCRIPTION
No zombie.Browser() object in zombie anymore..

Using the example code results in an error:

<pre>
this.browser = new zombie.Browser(); // this.browser will be available in st
                 ^
TypeError: undefined is not a function
</pre>


So either do this (done in my patch):

``` javascript
  this.browser = new zombie()
```

Or do this (per the zombie examples):

``` javascript
     var Browser = require('zombie');
```

...

``` javascript
    this.browser = new Browser();
```
