### PR TITLE
Fix spelling of "GitHub"

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -108,6 +108,6 @@ This a reminder of the steps maintainers have to follow to release a new version
 * Add new contributors to `package.json`, if any
 * Commit those changes as "*Release 0.1.2*" (where *0.1.2* is the actual version, of course)
 * Tag commit as "v0.1.2" with short description of main changes
-* Push to main repo on Github
+* Push to main repo on GitHub
 * Wait for build to go green
 * Publish to NPM

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Feature: Example feature
   So that I can concentrate on building awesome applications
 
   Scenario: Reading documentation
-    Given I am on the Cucumber.js Github repository
+    Given I am on the Cucumber.js GitHub repository
     When I go to the README file
     Then I should see "Usage" as the page title
 ```
@@ -254,7 +254,7 @@ Step definitions are run when steps match their name. `this` is an instance of `
 var myStepDefinitionsWrapper = function () {
   this.World = require("../support/world.js").World; // overwrite default World constructor
 
-  this.Given(/^I am on the Cucumber.js Github repository$/, function(callback) {
+  this.Given(/^I am on the Cucumber.js GitHub repository$/, function(callback) {
     // Express the regexp above with the code you wish you had.
     // `this` is set to a new this.World instance.
     // i.e. you may use this.browser to execute the step:


### PR DESCRIPTION
I didn't change `Github` in `History.md` on purpose.
