### PR TITLE
fix(cli): Remove UTF Bye Order Mark

### DIFF
--- a/lib/cucumber/cli/feature_source_loader.js
+++ b/lib/cucumber/cli/feature_source_loader.js
@@ -13,8 +13,7 @@ var FeatureSourceLoader = function(featureFilePaths) {
 
     getSource: function getSource(featureFilePath) {
       var featureSource = fs.readFileSync(featureFilePath, 'utf-8');
-      featureSource = featureSource.replace(/^\uFEFF/, '');
-      return featureSource;
+      return featureSource.replace(/^\uFEFF/, '');
     }
   };
   return self;


### PR DESCRIPTION
Solves the exception produced parsing .feature files created on Visual Studio
with a BOM (Byte Order Mark) initial character.

As seen on node-jshint:
https://github.com/ArturDorochowicz/node-jshint/commit/b36ac70f685d3108f7b4f952ee6b9d18140d61f6
