### PR TITLE
Build failing on node.js v0.6 and v0.8 - remove Bower to fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
     "connect": "2.13.0",
     "jasmine-node": "1.11.0",
     "mkdirp": "0.3.5",
-    "rimraf": "2.2.2",
-    "bower": "~1.2.7"
+    "rimraf": "2.2.2"
   },
   "scripts": {
     "test": "./bin/cucumber.js && jasmine-node spec"


### PR DESCRIPTION
Hi.  The Travis CI build has been failing for node.js v0.6 and v0.8 since 22 May.  The last green build I can see was on 18 March.  

https://travis-ci.org/cucumber/cucumber-js/builds

The builds are failing during the `npm install`.  The build also fails when running it locally under node.js v0.6 and v0.8 (using nvm).  

Looking at the build output, the npm install errors all mention Bower.  Here's an example: 

``` shell
npm ERR! Error: ENOENT, lstat '/home/travis/build/cucumber/cucumber-js/node_modules/bower/node_modules/mout/src/math/round.js'
npm ERR! If you need help, you may report this log at:
npm ERR! <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR! <npm-@googlegroups.com>
npm ERR! System Linux 2.6.32-042stab079.5
npm ERR! command "/home/travis/.nvm/v0.8.26/bin/node" "/home/travis/.nvm/v0.8.26/bin/npm" "install"
npm ERR! cwd /home/travis/build/cucumber/cucumber-js
npm ERR! node -v v0.8.26
npm ERR! npm -v 1.2.30
npm ERR! path /home/travis/build/cucumber/cucumber-js/node_modules/bower/node_modules/mout/src/math/round.js
npm ERR! fstream_path /home/travis/build/cucumber/cucumber-js/node_modules/bower/node_modules/mout/src/math/round.js
npm ERR! fstream_type File
npm ERR! fstream_class FileWriter
npm ERR! code ENOENT
npm ERR! errno 34
npm ERR! fstream_stack /home/travis/.nvm/v0.8.26/lib/node_modules/npm/node_modules/fstream/lib/writer.js:284:26
npm ERR! fstream_stack Object.oncomplete (fs.js:297:15)
npm http 200 https://registry.npmjs.org/chalk/-/chalk-0.1.1.tgz
npm http 200 https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz
npm http 200 https://registry.npmjs.org/mout/-/mout-0.9.1.tgz
npm http 200 https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz
npm http 200 https://registry.npmjs.org/read
npm http 200 https://registry.npmjs.org/throttleit
npm http 200 https://registry.npmjs.org/configstore
npm http 200 https://registry.npmjs.org/ansi-styles
npm http 200 https://registry.npmjs.org/has-color
npm ERR! Error: No compatible version found: minimatch@'^0.3.0'
npm ERR! Valid install targets:
npm ERR! ["0.0.1","0.0.2","0.0.4","0.0.5","0.1.1","0.1.2","0.1.3","0.1.4","0.1.5","0.2.0","0.2.2","0.2.3","0.2.4","0.2.5","0.2.6","0.2.7","0.2.8","0.2.9","0.2.10","0.2.11","0.2.12","0.2.13","0.2.14","0.3.0"]
npm ERR! at installTargetsError (/home/travis/.nvm/v0.8.26/lib/node_modules/npm/lib/cache.js:719:10)
npm ERR! at /home/travis/.nvm/v0.8.26/lib/node_modules/npm/lib/cache.js:641:10
npm ERR! at RegClient.get_ (/home/travis/.nvm/v0.8.26/lib/node_modules/npm/node_modules/npm-registry-client/lib/get.js:101:14)
npm ERR! at RegClient.<anonymous> (/home/travis/.nvm/v0.8.26/lib/node_modules/npm/node_modules/npm-registry-client/lib/get.js:37:12)
npm ERR! at fs.readFile (fs.js:176:14)
npm ERR! at Object.oncomplete (fs.js:297:15)
npm ERR! If you need help, you may report this log at:
npm ERR! <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR! <npm-@googlegroups.com>
npm ERR! System Linux 2.6.32-042stab079.5
npm ERR! command "/home/travis/.nvm/v0.8.26/bin/node" "/home/travis/.nvm/v0.8.26/bin/npm" "install"
npm ERR! cwd /home/travis/build/cucumber/cucumber-js
npm ERR! node -v v0.8.26
npm ERR! npm -v 1.2.30
```

It looks like bower dropped support for node.js v0.8 a couple of months ago: https://github.com/bower/bower/commit/cea53ddd1f17ee741f86f1ae4d3cc5e8c80fd7e2

cucumber-js uses an older version of Bower but I wonder if some of Bower's dependencies no longer support node.js v0.8/v0.6.  

Removing bower as a dev dependency makes the build go green.  I think Bower isn't normally needed for development of cucumber-js.  I think it was only needed the first time cucumber-js was registered with the Bower registry (http://bower.io/#registering-packages) which is a one off activity.  Would you be happy with removing Bower as a dependency?  
