### PR TITLE
Also add tags when building a scenario

### DIFF
--- a/lib/cucumber/ast/scenario_outline.js
+++ b/lib/cucumber/ast/scenario_outline.js
@@ -13,6 +13,7 @@ var ScenarioOutline = function (keyword, name, description, uri, line) {
     var newSteps = self.applyExampleRow(row.example, self.getSteps());
     var subScenario = Cucumber.Ast.Scenario(keyword, name, description, uri, line);
     subScenario.setSteps(newSteps);
+    subScenario.addTags(self.getTags());
     return subScenario;
   }
 


### PR DESCRIPTION
Command line parameters for tag filters won't be applied to scenario outlines without this patch.
