### PR TITLE
Add error formatting option

### DIFF
--- a/lib/cucumber/cli/argument_parser.js
+++ b/lib/cucumber/cli/argument_parser.js
@@ -61,12 +61,18 @@ var ArgumentParser = function(argv) {
       var format = self.getOptionOrDefault(ArgumentParser.FORMAT_OPTION_NAME, ArgumentParser.DEFAULT_FORMAT_VALUE);
       return format;
     },
+    
+    getErrorFormatter: function getErrorFormatter() {
+      var error_formatter = self.getOptionOrDefault(ArgumentParser.ERROR_FORMATTER_OPTION_NAME, ArgumentParser.DEFAULT_ERROR_FORMATTER_VALUE);
+      return error_formatter;
+    },
 
     getKnownOptionDefinitions: function getKnownOptionDefinitions() {
       var definitions = {};
       definitions[ArgumentParser.REQUIRE_OPTION_NAME]              = [path, Array];
       definitions[ArgumentParser.TAGS_OPTION_NAME]                 = [String, Array];
       definitions[ArgumentParser.FORMAT_OPTION_NAME]               = String;
+      definitions[ArgumentParser.ERROR_FORMATTER_OPTION_NAME]      = path;
       definitions[ArgumentParser.HELP_FLAG_NAME]                   = Boolean;
       definitions[ArgumentParser.VERSION_FLAG_NAME]                = Boolean;
       definitions[ArgumentParser.COFFEE_SCRIPT_SNIPPETS_FLAG_NAME] = Boolean;
@@ -77,6 +83,7 @@ var ArgumentParser = function(argv) {
       var definitions = {};
       definitions[ArgumentParser.REQUIRE_OPTION_SHORT_NAME] = [ArgumentParser.LONG_OPTION_PREFIX + ArgumentParser.REQUIRE_OPTION_NAME];
       definitions[ArgumentParser.FORMAT_OPTION_SHORT_NAME] = [ArgumentParser.LONG_OPTION_PREFIX + ArgumentParser.FORMAT_OPTION_NAME];
+      definitions[ArgumentParser.ERROR_FORMATTER_OPTION_SHORT_NAME] = [ArgumentParser.LONG_OPTION_PREFIX + ArgumentParser.ERROR_FORMATTER_OPTION_NAME];
       definitions[ArgumentParser.HELP_FLAG_SHORT_NAME]      = [ArgumentParser.LONG_OPTION_PREFIX + ArgumentParser.HELP_FLAG_NAME];
       return definitions;
     },
@@ -101,7 +108,7 @@ var ArgumentParser = function(argv) {
     },
 
     getOptions: function getOptions() {
-      return options;
+      return options||{};
     },
 
     getOptionOrDefault: function getOptionOrDefault(optionName, defaultValue) {
@@ -120,8 +127,11 @@ ArgumentParser.LONG_OPTION_PREFIX                        = "--";
 ArgumentParser.REQUIRE_OPTION_NAME                       = "require";
 ArgumentParser.REQUIRE_OPTION_SHORT_NAME                 = "r";
 ArgumentParser.FORMAT_OPTION_NAME                        = "format";
+ArgumentParser.ERROR_FORMATTER_OPTION_NAME               = "error_formatter";
+ArgumentParser.ERROR_FORMATTER_OPTION_SHORT_NAME         = "e";
 ArgumentParser.FORMAT_OPTION_SHORT_NAME                  = "f";
 ArgumentParser.DEFAULT_FORMAT_VALUE                      = "progress";
+ArgumentParser.DEFAULT_ERROR_FORMATTER_VALUE             = "full";
 ArgumentParser.TAGS_OPTION_NAME                          = "tags";
 ArgumentParser.TAGS_OPTION_SHORT_NAME                    = "t";
 ArgumentParser.HELP_FLAG_NAME                            = "help";

--- a/lib/cucumber/cli/configuration.js
+++ b/lib/cucumber/cli/configuration.js
@@ -28,6 +28,10 @@ var Configuration = function(argv) {
       return formatter;
     },
 
+    getErrorFormatter: function getErrorFormatter(){
+      return argumentParser.getErrorFormatter();
+    },
+
     getFeatureSources: function getFeatureSources() {
       var featureFilePaths    = argumentParser.getFeatureFilePaths();
       var featureSourceLoader = Cucumber.Cli.FeatureSourceLoader(featureFilePaths);
@@ -85,5 +89,4 @@ var Configuration = function(argv) {
 Configuration.JSON_FORMAT_NAME     = "json";
 Configuration.PRETTY_FORMAT_NAME   = "pretty";
 Configuration.PROGRESS_FORMAT_NAME = "progress";
-Configuration.SUMMARY_FORMAT_NAME  = "summary";
 module.exports = Configuration;

--- a/lib/cucumber/listener/error_formatter.js
+++ b/lib/cucumber/listener/error_formatter.js
@@ -1,0 +1,10 @@
+module.exports = function(failure) {
+  var failureDescription = failure.stack || failure;
+  var Configuration = require('../cli/configuration');
+  var formatter = Configuration(process.argv).getErrorFormatter();
+  
+  if (formatter != 'full') {
+    return require(formatter)(failure)
+  }
+  return failureDescription;
+}

--- a/lib/cucumber/listener/pretty_formatter.js
+++ b/lib/cucumber/listener/pretty_formatter.js
@@ -108,8 +108,7 @@ var PrettyFormatter = function(options) {
 
     if (stepResult.isFailed()) {
       var failure            = stepResult.getFailureException();
-      var failureDescription = failure.stack || failure;
-      self.logIndented(failureDescription + "\n", 3);
+      self.logIndented(require("./error_formatter")(failure.stack || failure) + "\n", 3);
     }
     callback();
   };

--- a/lib/cucumber/listener/summary_formatter.js
+++ b/lib/cucumber/listener/summary_formatter.js
@@ -1,7 +1,6 @@
 var SummaryFormatter = function (options) {
   var Cucumber = require('../../cucumber');
 
-
   var failedScenarioLogBuffer = "";
   var undefinedStepLogBuffer  = "";
   var failedStepResults       = Cucumber.Type.Collection();
@@ -110,7 +109,7 @@ var SummaryFormatter = function (options) {
 
   self.logFailedStepResult = function logFailedStepResult(stepResult) {
     var failureMessage = stepResult.getFailureException();
-    self.log(failureMessage.stack || failureMessage);
+    self.log(require("./error_formatter")(failureMessage.stack || failureMessage));
     self.log("\n\n");
   };
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
   ],
   "version": "0.4.0",
   "homepage": "http://github.com/cucumber/cucumber-js",
-  "author": "Julien Biezemans <jb@jbpros.com> (http://jbpros.net)",
+  "author": {
+    "name": "Julien Biezemans",
+    "email": "jb@jbpros.com",
+    "url": "http://jbpros.net"
+  },
   "contributors": [
     "Julien Biezemans <jb@jbpros.com> (http://jbpros.net)",
     "Fernando Acorreia <fernandoacorreia@gmail.com>",
@@ -49,8 +53,8 @@
     "url": "git://github.com/cucumber/cucumber-js.git"
   },
   "bugs": {
-    "email": "cukes@googlegroups.com",
-    "url": "http://github.com/cucumber/cucumber-js/issues"
+    "url": "http://github.com/cucumber/cucumber-js/issues",
+    "email": "cukes@googlegroups.com"
   },
   "directories": {
     "lib": "./lib"
@@ -90,5 +94,25 @@
       "url": "http://github.com/cucumber/cucumber.js/LICENSE"
     }
   ],
-  "optionalDependencies": {}
+  "optionalDependencies": {},
+  "_id": "cucumber@0.3.3",
+  "dist": {
+    "shasum": "5c7851bfe1da42778557eb585631ec44123230ca",
+    "tarball": "http://registry.npmjs.org/cucumber/-/cucumber-0.3.3.tgz"
+  },
+  "_from": "cucumber@~0.3.1",
+  "_npmVersion": "1.3.11",
+  "_npmUser": {
+    "name": "jbpros",
+    "email": "jb@jbpros.com"
+  },
+  "maintainers": [
+    {
+      "name": "jbpros",
+      "email": "jb@jbpros.com"
+    }
+  ],
+  "_shasum": "5c7851bfe1da42778557eb585631ec44123230ca",
+  "_resolved": "https://registry.npmjs.org/cucumber/-/cucumber-0.3.3.tgz",
+  "readme": "ERROR: No README data found!"
 }


### PR DESCRIPTION
Before this there was no way to control the output of error messages, resulting in a long stack trace. This allows the use of a custom error formatter using a --error_formatter= argument. 
