### PR TITLE
Add nested step functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 doc/
 tmp/
 npm-debug.log
+.*.sw?

--- a/features/nested_steps.feature
+++ b/features/nested_steps.feature
@@ -1,0 +1,25 @@
+Feature: Nested Steps
+
+
+  Background:
+    Given a scenario with:
+      """
+      Given two turtles
+      """
+    And the step "a turtle" has a passing mapping
+
+  Scenario: Use callback.step to call a single step
+    Given a step definition that looks like this:
+      """
+      Given(/^two turtles$/, function(callback) {
+        var World = this;
+	World.step("a turtle", function() {
+	  World.step("a turtle", function() {
+	    callback()
+	  });
+	});
+      });
+      """
+    When Cucumber runs the feature
+    Then the feature passes
+    And step "a turtle" invoked "2" times

--- a/features/step_definitions/cucumber_steps.js
+++ b/features/step_definitions/cucumber_steps.js
@@ -116,6 +116,11 @@ setTimeout(callback.pending, 10);\
     callback();
   });
 
+  Given(/^a step definition that looks like this:$/, function(step, callback) {
+    this.stepDefinitions += step;
+    callback();
+  });
+
   When(/^Cucumber executes the scenario$/, function(callback) {
     this.runFeature({}, callback);
   });
@@ -274,6 +279,15 @@ callback();\
 
   Then(/^the hook is not fired$/, function(callback) {
     this.assertCycleSequenceExcluding('hook');
+    callback();
+  });
+
+  Then(/^step "([^"]*)" invoked "(\d+)" times$/, function(step, count, callback) {
+    if (this.touchedStepsCount(step) == 2) {
+      this.assertSuccess();
+    } else {
+      this.assertFailure();
+    }
     callback();
   });
 };

--- a/features/step_definitions/cucumber_world.js
+++ b/features/step_definitions/cucumber_world.js
@@ -96,6 +96,19 @@ proto.isStepTouched = function isStepTouched(pattern) {
   return (this.touchedSteps.indexOf(pattern) >= 0);
 };
 
+proto.touchedStepsCount = function touchedStepsCount(pattern) {
+  var result = 0;
+  var list = this.touchedSteps;
+
+  for (var i = 0; i < list.length; ++i) {
+      if (list[i] == pattern) {
+	  ++result;
+      }
+  }
+
+  return result;
+}
+
 proto.addStringBasedPatternMapping = function addStringBasedPatternMapping() {
   this.mappingName = "/a string-based mapping with fancy characters |\\ ^*-{(})+[a].?";
   this.stepDefinitions += "Given('/a string-based mapping with fancy characters |\\\\ ^*-{(})+[a].?', function(callback) {\

--- a/lib/cucumber/support_code/library.js
+++ b/lib/cucumber/support_code/library.js
@@ -91,6 +91,19 @@ var Library = function(supportCodeDefinition) {
   supportCodeDefinition.call(supportCodeHelper);
   worldConstructor = supportCodeHelper.World;
 
+  var proto = worldConstructor.prototype;
+  proto.step = function (name, callback) {
+    var err = new Error;
+    var stack = err.stack.split('\n');
+    var re = new RegExp(/at ((.*)\s)?\(?([^:]+):(\d+):(\d+)\)?$/);
+    var caller = re.exec(stack[2]);
+
+    var w = this;
+    var stepDefinition = self.lookupStepDefinitionByName(name);
+    var fakeStep = Cucumber.Ast.Step("* ", name, caller[3], caller[4]);
+    stepDefinition.invoke(fakeStep, w, callback);
+  };
+
   return self;
 };
 


### PR DESCRIPTION
I wanted to add nested step functionality like ruby version has:
https://github.com/cucumber/cucumber/wiki/Calling-Steps-from-Step-Definitions

Can be used like so:
feature file:

```
Feature: Nested Steps

  Scenario: Simple step
    Given a turtle

  Scenario: Use World.step to call a single step
    Given two turtles
```

step definition:

```
var cucumberStepsTests = function() {
  var Given  = When = Then = this.defineStep;
  var World  = require('./cucumber_world').World;
  this.World = World;

  Given(/^a turtle$/, function(callback) {
    console.log('turtle!');
    callback();
  });

  Given(/^two turtles$/, function(callback) {
      var World = this;
    World.step("a turtle", function() {
        World.step("a turtle", function() {
            callback();
        });
    });
  });
};

module.exports = cucumberStepsTests;
```

Please share your thoughts.
