### PR TITLE
Support code loader now works with windows

### DIFF
--- a/lib/cucumber/cli/support_code_loader.js
+++ b/lib/cucumber/cli/support_code_loader.js
@@ -1,3 +1,4 @@
+var os = require('os');
 var SupportCodeLoader = function(supportCodeFilePaths) {
   var Cucumber = require('../../cucumber');
   var CoffeeScript = require('coffee-script');
@@ -65,5 +66,5 @@ var SupportCodeLoader = function(supportCodeFilePaths) {
   };
   return self;
 };
-SupportCodeLoader.PRIME_SUPPORT_CODE_PATH_REGEXP = /\/support\//i;
+SupportCodeLoader.PRIME_SUPPORT_CODE_PATH_REGEXP = os.platform().match(/^win/) ? /\\support\\/ : /\/support\//i;
 module.exports = SupportCodeLoader;


### PR DESCRIPTION
Hi,
   I found an issue when running cucumberjs under windows.  It was not loading the support files before the step definitions.  This was because the regexp in the support_code_loader.js file was hard coded to a 'normal' file path.  Obviously, windows has to be different as always, so I have added a test for the windows platform and used backslashes in the regexp when this test passes.
I have since ran the unit tests which all pass

I could not think of a way to test this change in the unit test as I needed to spy on 'os.platform()' and return different values.  This would have needed to have been done before the code was loaded.

I have also tested it using my test suite (which contains a good 200+ steps) and it works on both linux (which it always did) and windows (which didn't work previously).

This pull request as you can see contains the required change.

Hopefully you can include this in the next release and I can remove my fork from github.

Thanks

Gary
