### PR TITLE
Internet Explorer compatibility fix and bugfix

### DIFF
--- a/lib/cucumber/ast/data_table/row.js
+++ b/lib/cucumber/ast/data_table/row.js
@@ -1,7 +1,7 @@
 var Row = function(cells, uri, line) {
   var Cucumber = require('../../../cucumber');
 
-  self = {
+  var self = {
     raw: function raw() {
       return cells;
     },

--- a/lib/cucumber/support_code/library.js
+++ b/lib/cucumber/support_code/library.js
@@ -91,7 +91,7 @@ var Library = function(supportCodeDefinition) {
       var world = new worldConstructor(function (explicitWorld) {
         process.nextTick(function () { // release the constructor
           callback(explicitWorld || world);
-        });
+        }, explicitWorld || world);
       });
     }
   };

--- a/release/cucumber.js
+++ b/release/cucumber.js
@@ -340,7 +340,11 @@ process.nextTick = (function () {
     ;
 
     if (canSetImmediate) {
-        return window.setImmediate;
+        // Wrap setImmediate in an anonymous function that will call setImmediate with an explicit context to mitigate
+        // an IE-specific issue with function pointers.
+        return function (fn, context) {
+            setImmediate.call(context, fn);
+        };
     }
 
     if (canPost) {
@@ -4399,9 +4403,10 @@ require.define("/cucumber/support_code/library",function(require,module,exports,
 
     instantiateNewWorld: function instantiateNewWorld(callback) {
       var world = new worldConstructor(function (explicitWorld) {
+        // pass a context to nextTick for use by the IE-specific nextTick handler
         process.nextTick(function () { // release the constructor
           callback(explicitWorld || world);
-        });
+        }, explicitWorld || world);
       });
     }
   };
@@ -5790,7 +5795,7 @@ module.exports = DataTable;
 require.define("/cucumber/ast/data_table/row",function(require,module,exports,__dirname,__filename,process){var Row = function(cells, uri, line) {
   var Cucumber = require('../../../cucumber');
 
-  self = {
+  var self = {
     raw: function raw() {
       return cells;
     },


### PR DESCRIPTION
* IE9-10 require explicit contexts to be passed to function pointers in certain cases (http://msdn.microsoft.com/en-us/library/ie/gg622930%28v=vs.85%29.aspx). The `process.nextTick` implementation used for IE, which is based on `setImmediate`, was updated to accept and pass an explicit context to the callback.
* The implementation for DataTable.Row did not declare `self` to be a local variable, and IE9 wouldn't allow a new value to be assigned to it.