### PR TITLE
fix error in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,12 @@ It is possible to tell Cucumber to use another object instance than the construc
 
 var zombie = require('zombie');
 var WorldConstructor = function WorldConstructor(callback) {
-  this.browser = new zombie(); // this.browser will be available in step definitions
+
+  var browser = new zombie();
 
   var world = {
-    visit: function(url, callback) {
+    browser: browser,                        // this.browser will be available in step definitions
+    visit: function(url, callback) {         // this.visit will be available in step definitions
       this.browser.visit(url, callback);
     }
   };


### PR DESCRIPTION
As consequence of the [Issue#230](https://github.com/cucumber/cucumber-js/issues/230) I found an error in the documentation and fix it.

Maybe you want to consider changing the FIRST definition of the world overwrite because it's not working as it should according to the documentation [here](https://github.com/cucumber/cucumber-js#world).
