### PR TITLE
Add timestamp to JSON formatter output

### DIFF
--- a/lib/cucumber/listener/json_formatter.js
+++ b/lib/cucumber/listener/json_formatter.js
@@ -103,7 +103,7 @@ var JsonFormatter = function(options) {
     var scenario = event.getPayloadItem('scenario');
 
     var id = currentFeatureId + ';' + scenario.getName().replace(/ /g, '-').toLowerCase();
-    var scenarioProperties = {name: scenario.getName(), id: id, line: scenario.getLine(), keyword: 'Scenario',  description: scenario.getDescription(), type: 'scenario'};
+    var scenarioProperties = {name: scenario.getName(), id: id, line: scenario.getLine(), keyword: 'Scenario',  description: scenario.getDescription(), type: 'scenario', timestamp: new Date().getTime()};
 
     var tags = scenario.getTags();
     if (tags.length > 0) {


### PR DESCRIPTION
We're recording Selenium based tests and use this to compute time offsets to skip around in our screen recordings.

Currently there is no easy method to get an *absolute* time from Cucumber output. The only approach is to see when Cucumber starts/terminates and subtract `duration` properties from that time. This is skewed by various other things (for example browser starting up before the first step gets executed).

Summing up `duration` is quite a hassle, and can be easily circumvented by this patch. This is just a hack, and does not pass tests. Please help me finding the correct way to implement such a timestamp.