### PR TITLE
Correct the embeddings JSON to match other ports of Cucumber

### DIFF
--- a/features/attachments.feature
+++ b/features/attachments.feature
@@ -50,16 +50,16 @@ Feature: Attachments
                   "keyword": "Before ",
                   "hidden": true,
                   "result": {
-                    "embeddings": [
-                      {
-                        "mime_type": "image/png",
-                        "data": "ZGF0YQ=="
-                      }
-                    ],
                     "duration": "<duration>",
                     "status": "passed"
                   },
-                  "match": {}
+                  "match": {},
+                  "embeddings": [
+                    {
+                      "mime_type": "image/png",
+                      "data": "ZGF0YQ=="
+                    }
+                  ]
                 },
                 {
                   "name": "This step is passing",
@@ -145,16 +145,16 @@ Feature: Attachments
                   "keyword": "Before ",
                   "hidden": true,
                   "result": {
-                    "embeddings": [
-                      {
-                        "mime_type": "image/png",
-                        "data": "ZGF0YQ=="
-                      }
-                    ],
                     "duration": "<duration>",
                     "status": "passed"
                   },
-                  "match": {}
+                  "match": {},
+                  "embeddings": [
+                    {
+                      "mime_type": "image/png",
+                      "data": "ZGF0YQ=="
+                    }
+                  ]
                 },
                 {
                   "name": "This step is passing",
@@ -226,16 +226,16 @@ Feature: Attachments
                   "keyword": "Around ",
                   "hidden": true,
                   "result": {
-                    "embeddings": [
-                      {
-                        "mime_type": "text/plain",
-                        "data": "text"
-                      }
-                    ],
                     "duration": "<duration>",
                     "status": "passed"
                   },
-                  "match": {}
+                  "match": {},
+                  "embeddings": [
+                    {
+                      "mime_type": "text/plain",
+                      "data": "dGV4dA=="
+                    }
+                  ]
                 },
                 {
                   "name": "This step is passing",
@@ -334,16 +334,16 @@ Feature: Attachments
                   "keyword": "Around ",
                   "hidden": true,
                   "result": {
-                    "embeddings": [
-                      {
-                        "mime_type": "text/plain",
-                        "data": "text"
-                      }
-                    ],
                     "duration": "<duration>",
                     "status": "passed"
                   },
-                  "match": {}
+                  "match": {},
+                  "embeddings": [
+                    {
+                      "mime_type": "text/plain",
+                      "data": "dGV4dA=="
+                    }
+                  ]
                 }
               ]
             }
@@ -402,16 +402,16 @@ Feature: Attachments
                   "keyword": "Before ",
                   "hidden": true,
                   "result": {
-                    "embeddings": [
-                      {
-                        "mime_type": "text/plain",
-                        "data": "text"
-                      }
-                    ],
                     "duration": "<duration>",
                     "status": "passed"
                   },
-                  "match": {}
+                  "match": {},
+                  "embeddings": [
+                    {
+                      "mime_type": "text/plain",
+                      "data": "dGV4dA=="
+                    }
+                  ]
                 },
                 {
                   "name": "This step is passing",
@@ -490,16 +490,16 @@ Feature: Attachments
                   "keyword": "After ",
                   "hidden": true,
                   "result": {
-                    "embeddings": [
-                      {
-                        "mime_type": "text/plain",
-                        "data": "text"
-                      }
-                    ],
                     "duration": "<duration>",
                     "status": "passed"
                   },
-                  "match": {}
+                  "match": {},
+                  "embeddings": [
+                    {
+                      "mime_type": "text/plain",
+                      "data": "dGV4dA=="
+                    }
+                  ]
                 }
               ]
             }
@@ -572,16 +572,16 @@ Feature: Attachments
                   "line": 4,
                   "keyword": "Given ",
                   "result": {
-                    "embeddings": [
-                      {
-                        "mime_type": "text/plain",
-                        "data": "text"
-                      }
-                    ],
                     "duration": "<duration>",
                     "status": "passed"
                   },
-                  "match": {}
+                  "match": {},
+                  "embeddings": [
+                    {
+                      "mime_type": "text/plain",
+                      "data": "dGV4dA=="
+                    }
+                  ]
                 }
               ]
             }

--- a/lib/cucumber/api/scenario.js
+++ b/lib/cucumber/api/scenario.js
@@ -25,7 +25,7 @@ var Scenario = function (astTreeWalker, astScenario) {
           buffers.push(chunk);
         })
         data.on('end', function() {
-          astTreeWalker.attach(Buffer.concat(buffers).toString('base64'), mimeType);
+          astTreeWalker.attach(Buffer.concat(buffers).toString(), mimeType);
 
           callback();
         });
@@ -34,7 +34,7 @@ var Scenario = function (astTreeWalker, astScenario) {
         if (!mimeType)
           throw Error(Scenario.ATTACH_MISSING_MIME_TYPE_ARGUMENT);
 
-        astTreeWalker.attach(data.toString('base64'), mimeType);
+        astTreeWalker.attach(data.toString(), mimeType);
 
         if (callback) {
           callback();

--- a/lib/cucumber/listener/json_formatter.js
+++ b/lib/cucumber/listener/json_formatter.js
@@ -16,7 +16,7 @@ var JsonFormatter = function(options) {
 
   self.getGherkinFormatter = function getGherkinFormatter() {
     return gherkinJsonFormatter;
-  }
+  };
 
   self.formatStep = function formatStep(step) {
     var stepProperties = {
@@ -124,11 +124,12 @@ var JsonFormatter = function(options) {
 
     var stepOutput = {};
     var resultStatus;
+    var attachments;
 
     if (stepResult.isSuccessful()) {
       resultStatus = 'passed';
       if (stepResult.hasAttachments()) {
-        stepOutput['embeddings'] = self.getEmbeddingsFromStepResult(stepResult);
+        attachments = stepResult.getAttachments();
       }
       stepOutput['duration'] = stepResult.getDuration();
     }
@@ -149,7 +150,7 @@ var JsonFormatter = function(options) {
         stepOutput['error_message'] = (failureMessage.stack || failureMessage);
       }
       if (stepResult.hasAttachments()) {
-        stepOutput['embeddings'] = self.getEmbeddingsFromStepResult(stepResult);
+        attachments = stepResult.getAttachments();
       }
       stepOutput['duration'] = stepResult.getDuration();
     }
@@ -157,17 +158,12 @@ var JsonFormatter = function(options) {
     stepOutput['status'] = resultStatus;
     gherkinJsonFormatter.result(stepOutput);
     gherkinJsonFormatter.match({location: undefined});
+    if (attachments) {
+      attachments.syncForEach(function(attachment) {
+        gherkinJsonFormatter.embedding(attachment.getMimeType(), attachment.getData());
+      });
+    }
     callback();
-  }
-
-  self.getEmbeddingsFromStepResult = function getEmbeddingsFromStepResult(stepResult) {
-    var embeddings = [];
-
-    stepResult.getAttachments().syncForEach(function(attachment) {
-      embeddings.push({mime_type: attachment.getMimeType(), data: attachment.getData()});
-    });
-
-    return embeddings;
   }
 
   self.handleAfterFeaturesEvent = function handleAfterFeaturesEvent(event, callback) {

--- a/spec/cucumber/api/scenario_spec.js
+++ b/spec/cucumber/api/scenario_spec.js
@@ -156,8 +156,8 @@ describe("Cucumber.Api.Scenario", function() {
               endListener();
             });
 
-            it("instructs the ast tree walker to create an attachment containing the base 64 encoded contents of the stream", function() {
-              expect(astTreeWalker.attach).toHaveBeenCalledWith("Zmlyc3QgY2h1bmtzZWNvbmQgY2h1bms=", mimeType);
+            it("instructs the ast tree walker to create an attachment containing the contents of the stream", function() {
+              expect(astTreeWalker.attach).toHaveBeenCalledWith("first chunksecond chunk", mimeType);
             });
 
             it("calls back", function() {
@@ -179,9 +179,9 @@ describe("Cucumber.Api.Scenario", function() {
         expect(function() { scenario.attach(buffer); }).toThrow(new Error("Cucumber.Api.Scenario.attach() expects a mimeType"));
       });
 
-      it("instructs the ast tree walker to create an attachment containing the base 64 encoded contents of the buffer", function() {
+      it("instructs the ast tree walker to create an attachment containing the contents of the buffer", function() {
         scenario.attach(buffer, mimeType);
-        expect(astTreeWalker.attach).toHaveBeenCalledWith("ZGF0YQ==", mimeType);
+        expect(astTreeWalker.attach).toHaveBeenCalledWith("data", mimeType);
       });
 
       describe("when provided with a callback", function() {
@@ -224,4 +224,3 @@ describe("Cucumber.Api.Scenario", function() {
     });
   });
 });
-


### PR DESCRIPTION
This is a fix for #233.  It fixes two things: 
- The embeddings are no longer under the results.  The embeddings are now side-by-side with the results.  
- Text embeddings are now base64 encoded.  
