### PR TITLE
Allow > 2 parameters in string step definitions

### DIFF
--- a/features/step_definition_string_pattern.feature
+++ b/features/step_definition_string_pattern.feature
@@ -14,3 +14,10 @@ Feature: step definitions with string pattern
     Then the feature passes
     And the mapping is run
     And the mapping receives the arguments
+
+  Scenario: step definition with string-based pattern and multiple parameters
+    Given a mapping with a string-based pattern and multiple parameters
+    When Cucumber executes a scenario that passes multiple arguments to that mapping
+    Then the feature passes
+    And the mapping is run
+    And the mapping receives the multipple arguments

--- a/features/step_definitions/cucumber_steps.js
+++ b/features/step_definitions/cucumber_steps.js
@@ -71,6 +71,11 @@ setTimeout(callback.pending, 10);\
     callback();
   });
 
+  Given(/^a mapping with a string-based pattern and multiple parameters$/, function(callback) {
+    this.addStringBasedPatternMappingWithMultipleParameters();
+    callback();
+  });
+
   Given(/^the following feature:$/, function(feature, callback) {
     this.featureSource = feature;
     callback();
@@ -126,6 +131,10 @@ setTimeout(callback.pending, 10);\
 
   this.When(/^Cucumber executes a scenario that passes arguments to that mapping$/, function(callback) {
     this.runAScenarioCallingMappingWithParameters(callback);
+  });
+
+  this.When(/^Cucumber executes a scenario that passes multiple arguments to that mapping$/, function(callback) {
+    this.runAScenarioCallingMappingWithMultipleParameters(callback);
   });
 
   When(/^Cucumber executes a scenario that calls a function on the explicit World object$/, function(callback) {
@@ -209,6 +218,11 @@ callback();\
 
   Then(/^the mapping receives the arguments$/, function(callback) {
     this.assertPassedMappingWithArguments();
+    callback();
+  });
+
+  Then(/^the mapping receives the multiple arguments$/, function(callback) {
+    this.assertPassedMappingWithMultipleArguments();
     callback();
   });
 

--- a/features/step_definitions/cucumber_world.js
+++ b/features/step_definitions/cucumber_world.js
@@ -74,6 +74,12 @@ proto.runAScenarioCallingMappingWithParameters = function runAScenarioCallingMap
   this.runFeature({}, callback);
 };
 
+proto.runAScenarioCallingMappingWithMultipleParameters = function runAScenarioCallingMappingWithMultipleParameters(callback) {
+  this.expectedMappingArguments = [5, "fresh cucumbers", 2, 'pickled gherkins'];
+  this.addScenario("", 'Given a mapping with ' + this.expectedMappingArguments[0] + ' ' + this.expectedMappingArguments[2] + ' "' + this.expectedMappingArguments[1] + '" "' + this.expectedMappingArguments[3] + '"');
+  this.runFeature({}, callback);
+};
+
 proto.runAScenarioCallingWorldFunction = function runAScenarioCallingWorldFunction(callback) {
   this.addScenario("", "Given a step");
   this.stepDefinitions += "Given(/^a step$/, function(callback) {\
@@ -109,6 +115,15 @@ proto.addStringBasedPatternMappingWithParameters = function addStringBasedPatter
   this.stepDefinitions += "Given('a mapping with $word_param \"$multi_word_param\"', function(p1, p2, callback) {\
   world.logCycleEvent('a string-based mapping');\
   world.actualMappingArguments = [p1, p2];\
+  callback();\
+});";
+};
+
+proto.addStringBasedPatternMappingWithMultipleParameters = function addStringBasedPatternMappingWithMultipleParameters() {
+  this.mappingName = "a string-based mapping with multiple parameters";
+  this.stepDefinitions += "Given('a mapping with $word_param_a $word_param_b \"$multi_word_param_a\" \"$multi_word_param_b\"', function(p1, p2, p3, p4, callback) {\
+  world.logCycleEvent('a string-based mapping with multiple parameters');\
+  world.actualMappingArguments = [p1, p2, p3, p4];\
   callback();\
 });";
 };
@@ -306,6 +321,16 @@ proto.assertPassedMappingWithArguments = function assertPassedMappingWithArgumen
   if (this.actualMappingArguments.length != this.expectedMappingArguments.length ||
       this.actualMappingArguments[0] != this.expectedMappingArguments[0] ||
       this.actualMappingArguments[1] != this.expectedMappingArguments[1])
+    throw(new Error("Expected arguments to be passed to mapping."));
+};
+
+proto.assertPassedMappingWithMultipleArguments = function assertPassedMappingWithMultipleArguments() {
+  this.assertPassedMapping();
+  if (this.actualMappingArguments.length != this.expectedMappingArguments.length ||
+      this.actualMappingArguments[0] != this.expectedMappingArguments[0] ||
+      this.actualMappingArguments[1] != this.expectedMappingArguments[1] ||
+      this.actualMappingArguments[2] != this.expectedMappingArguments[2] ||
+      this.actualMappingArguments[3] != this.expectedMappingArguments[3])
     throw(new Error("Expected arguments to be passed to mapping."));
 };
 

--- a/lib/cucumber/support_code/step_definition.js
+++ b/lib/cucumber/support_code/step_definition.js
@@ -116,10 +116,10 @@ var StepDefinition = function (pattern, code) {
   return self;
 };
 
-StepDefinition.DOLLAR_PARAMETER_REGEXP              = /\$[a-zA-Z_-]+/;
+StepDefinition.DOLLAR_PARAMETER_REGEXP              = /\$[a-zA-Z_-]+/g;
 StepDefinition.DOLLAR_PARAMETER_SUBSTITUTION        = '(.*)';
 StepDefinition.PREVIOUS_REGEXP_MATCH                = "\\$&";
-StepDefinition.QUOTED_DOLLAR_PARAMETER_REGEXP       = /"\$[a-zA-Z_-]+"/;
+StepDefinition.QUOTED_DOLLAR_PARAMETER_REGEXP       = /"\$[a-zA-Z_-]+"/g;
 StepDefinition.QUOTED_DOLLAR_PARAMETER_SUBSTITUTION = '"([^"]*)"';
 StepDefinition.STRING_PATTERN_REGEXP_PREFIX         = '^';
 StepDefinition.STRING_PATTERN_REGEXP_SUFFIX         = '$';


### PR DESCRIPTION
The current implementation does not do a global reg ex replace for string step definitions.. This means the maximum number of placeholders could be 1 quoted dollar placeholder and 1 dollar placeholder. You couldn't have 2 dollar placeholders. 

For example the following would happen..

```
'I have "$btnA" and "$btnB" buttons
-> ^I have "([^"]*)" and "(.*)"$ (still works by coincidence)
```

And...

```
'I have $countA accounts and $countB projects' 
-> ^I have (.*) accounts and $countB projects$ 
```
