### PR TITLE
Use nodejs domain error handler instead of uncaughtError handle

### DIFF
--- a/lib/cucumber/cli.js
+++ b/lib/cucumber/cli.js
@@ -1,8 +1,10 @@
+var cucumberDomain = require('domain').create();
+
 var Cli = function(argv) {
   var Cucumber = require('../cucumber');
 
   var self = {
-    run: function run(callback) {
+    run: function run(callback) { cucumberDomain.run(function () {
       var configuration = Cli.Configuration(argv);
       if (configuration.isHelpRequested())
         self.displayHelp(callback);
@@ -10,7 +12,7 @@ var Cli = function(argv) {
         self.displayVersion(callback);
       else
         self.runSuiteWithConfiguration(configuration, callback);
-    },
+    })},
 
     runSuiteWithConfiguration: function runSuiteWithConfiguration(configuration, callback) {
       var runtime   = Cucumber.Runtime(configuration);

--- a/lib/cucumber/util/exception.js
+++ b/lib/cucumber/util/exception.js
@@ -1,13 +1,17 @@
 var Exception = {
   registerUncaughtExceptionHandler: function registerUncaughtExceptionHandler(exceptionHandler) {
-    if (process.on)
+    if (process.domain)
+      process.domain.on('error', exceptionHandler);
+    else if (process.on)
       process.on('uncaughtException', exceptionHandler);
     else if (typeof(window) != 'undefined')
       window.onerror = exceptionHandler;
   },
 
   unregisterUncaughtExceptionHandler: function unregisterUncaughtExceptionHandler(exceptionHandler) {
-    if (process.removeListener)
+    if (process.domain)
+      process.domain.removeListener('error', exceptionHandler);
+    else if (process.removeListener)
       process.removeListener('uncaughtException', exceptionHandler);
     else if (typeof(window) != 'undefined')
      window.onerror = void(0);


### PR DESCRIPTION
Refer https://github.com/angular/protractor/issues/876#issuecomment-57892972. 
Prefer using the domain error handler instead of the top level Cucumber uses the top level uncaught error handler to catch exceptions
caught by tests.  Refer commit
https://github.com/cucumber/cucumber-js/commit/9091129df4866cf705fb4ea7fb488f81e7cb96c2
and issue #51.  A good approach would be to wrap the test code
executions in try/catch blocks and use that exception instead of the
`uncaughtException` handler.  Another approach is to use the error
handler of a nodejs domain instead of the top level global
uncaughtException handler.  In this commit, I'm using the domain level
error handler approach.
