### PR TITLE
A new feature for switching environment of data table. 

### DIFF
--- a/features/scenario_outlines.feature
+++ b/features/scenario_outlines.feature
@@ -98,3 +98,24 @@ Feature: Scenario Outlines and Examples
     And the step "step b" passes
     And the step "step c" passes
     And the step "step d" passes
+
+  Scenario: Data table can switch environment by _env tag
+    Given the following feature:
+      """
+      Feature: testing scenarios
+        Scenario Outline: scenario outline 1
+          When step <id>
+
+        Examples:
+          |_env  | id |
+          |alpha | a  |
+          |beta  | b  |
+          |all   | c  |
+
+      """
+    And the step "step a" has a failing mapping
+    And the step "step b" has a failing mapping
+    And the step "step c" has a passing mapping
+    When Cucumber runs the feature
+    Then the step "step c" passes
+

--- a/lib/cucumber/ast/scenario_outline.js
+++ b/lib/cucumber/ast/scenario_outline.js
@@ -20,10 +20,20 @@ var ScenarioOutline = function (keyword, name, description, uri, line) {
 
   self.buildScenarios = function () {
     var scenarios = Cucumber.Type.Collection();
-
+    var ArgumentParser = Cucumber.Cli.ArgumentParser();
+    ArgumentParser.parse();
+    var allowedDataEnv = ArgumentParser.getOptionOrDefault('data_environment', 'all');
+    if (allowedDataEnv !== "all") {
+        allowedDataEnv = ['all', allowedDataEnv];
+    } else {
+        allowedDataEnv = ['all'];
+    }
     examplesCollection.syncForEach(function(examples) {
       var exampleHashes = examples.getDataTable().hashes();
       exampleHashes.forEach(function(exampleHash) {
+        if (exampleHash['_env'] && allowedDataEnv.indexOf(exampleHash['_env']) === -1) {
+            return "";
+        }
         scenarios.add(buildScenario(exampleHash));
       });
     });

--- a/lib/cucumber/cli/argument_parser.js
+++ b/lib/cucumber/cli/argument_parser.js
@@ -72,6 +72,8 @@ var ArgumentParser = function(argv) {
       definitions[ArgumentParser.COFFEE_SCRIPT_SNIPPETS_FLAG_NAME] = Boolean;
       definitions[ArgumentParser.SNIPPETS_FLAG_NAME]               = Boolean;
       definitions[ArgumentParser.STRICT_FLAG_NAME]                 = Boolean;
+      definitions[ArgumentParser.DATA_ENVIRONMENT_FLAG_NAME]       = String;
+
       return definitions;
     },
 
@@ -82,6 +84,8 @@ var ArgumentParser = function(argv) {
       definitions[ArgumentParser.HELP_FLAG_SHORT_NAME]      = [ArgumentParser.LONG_OPTION_PREFIX + ArgumentParser.HELP_FLAG_NAME];
       definitions[ArgumentParser.SNIPPETS_FLAG_SHORT_NAME]  = [ArgumentParser.LONG_OPTION_PREFIX + "no-" + ArgumentParser.SNIPPETS_FLAG_NAME];
       definitions[ArgumentParser.STRICT_FLAG_SHORT_NAME]    = [ArgumentParser.LONG_OPTION_PREFIX + ArgumentParser.STRICT_FLAG_NAME];
+      definitions[ArgumentParser.DATA_ENVIRONMENT_FLAG_SHORT_NAME]    = [ArgumentParser.LONG_OPTION_PREFIX + ArgumentParser.DATA_ENVIRONMENT_FLAG_NAME];
+
       return definitions;
     },
 
@@ -151,6 +155,10 @@ ArgumentParser.DEFAULT_COFFEE_SCRIPT_SNIPPETS_FLAG_VALUE = false;
 ArgumentParser.SNIPPETS_FLAG_NAME                        = "snippets";
 ArgumentParser.SNIPPETS_FLAG_SHORT_NAME                  = "i";
 ArgumentParser.DEFAULT_SNIPPETS_FLAG_VALUE               = true;
+ArgumentParser.DATA_ENVIRONMENT_FLAG_NAME                = "data_environment";
+ArgumentParser.DATA_ENVIRONMENT_FLAG_SHORT_NAME          = "data_env";
+ArgumentParser.DEFAULT_DATA_ENVIRONMENT_FLAG_VALUE       = "all";
+
 ArgumentParser.FeaturePathExpander     = require('./argument_parser/feature_path_expander');
 ArgumentParser.PathExpander            = require('./argument_parser/path_expander');
 ArgumentParser.SupportCodePathExpander = require('./argument_parser/support_code_path_expander');


### PR DESCRIPTION
We used cucumber to test our websites and met a problem about the data table of scenario outline features. 
Data table will test all data rows which we defined, but we need to skip some data rows when these testing are running in different environment, such as alpha, beta, production.


Here is the example of new feature.
<pre>
     Feature: testing scenarios
        Scenario Outline: scenario outline 1
          When step <id>

        Examples:
          |_env   | id |
          | alpha | a  |
          | beta  | b  |
          | all   | c  |
</pre>
If you executed command cucumber.js append with "-data_env beta", then cucumber will only execute two data rows, both of them are "beta" and "all". 
<pre>
jasmine-node spec && ./bin/cucumber.js -i features/xx.feature  -data_env beta
</pre>

