### PR TITLE
Add io.js to grid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ node_js:
   - "0.11"
   - "0.10"
   - "0.8"
+  - "iojs"
 
 matrix:
   allow_failures:

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "main": "./lib/cucumber",
   "engines": {
-    "node": "0.8 || 0.10 || 0.11"
+    "node": "0.8 || 0.10 || 0.11 || >= 1.0.0"
   },
   "dependencies": {
     "browserify": "5.11.1",


### PR DESCRIPTION
Via #307 

Since io.js follows semver, an install of cucumber-js would complain due to the version of io not matching the range of node specified in engines.

This should resolve the issue.