### PR TITLE
Removes color when no tty exists and cli params are included

### DIFF
--- a/lib/cucumber/listener/pretty_formatter.js
+++ b/lib/cucumber/listener/pretty_formatter.js
@@ -84,7 +84,7 @@ function PrettyFormatter(options) {
 
   self.logStepResult = function logStepResult(step, stepResult) {
     var source = self.applyColor(stepResult, step.getKeyword() + (step.getName() || ''));
-    source = self._pad(source, self._getCurrentMaxStepLength() + 10);
+    source = self._pad(source, self._getCurrentMaxStepLength() + (color.hasColor() ? 10 : 1));
 
     if (step.hasUri()) {
       source += color.format('comment', '# ' + step.getUri().replace(process.cwd(),'').slice(1) + ':' + step.getLine());

--- a/lib/cucumber/listener/pretty_formatter.js
+++ b/lib/cucumber/listener/pretty_formatter.js
@@ -84,7 +84,7 @@ function PrettyFormatter(options) {
 
   self.logStepResult = function logStepResult(step, stepResult) {
     var source = self.applyColor(stepResult, step.getKeyword() + (step.getName() || ''));
-    source = self._pad(source, self._getCurrentMaxStepLength() + (color.hasColor() ? 10 : 1));
+    source = self._pad(source, self._getCurrentMaxStepLength() + (color.supportsColor ? 10 : 1));
 
     if (step.hasUri()) {
       source += color.format('comment', '# ' + step.getUri().replace(process.cwd(),'').slice(1) + ':' + step.getLine());

--- a/lib/cucumber/util/colors.js
+++ b/lib/cucumber/util/colors.js
@@ -31,7 +31,46 @@ var ConsoleColor = {
     'tag'           : ['cyan']
   },
 
+  hasColor: function () {
+    var argv = process.argv;
+    if (argv.indexOf('--no-color') !== -1 ||
+      argv.indexOf('--color=false') !== -1) {
+      return false;
+    }
+
+    if (argv.indexOf('--color') !== -1 ||
+      argv.indexOf('--color=true') !== -1 ||
+      argv.indexOf('--color=always') !== -1) {
+      return true;
+    }
+
+    if (process.stdout && !process.stdout.isTTY) {
+      return false;
+    }
+
+    if (process.platform === 'win32') {
+      return true;
+    }
+
+    if ('COLORTERM' in process.env) {
+      return true;
+    }
+
+    if (process.env.TERM === 'dumb') {
+      return false;
+    }
+
+    if (/^screen|^xterm|^vt100|color|ansi|cygwin|linux/i.test(process.env.TERM)) {
+      return true;
+    }
+
+    return false;
+  },
+
   color: function (colors, text) {
+    if (!this.hasColor()) {
+      return text;
+    }
     var code = '';
     if (Object.prototype.toString.call(colors).slice(8,-1) !== 'Array')
       colors = [colors];

--- a/lib/cucumber/util/colors.js
+++ b/lib/cucumber/util/colors.js
@@ -1,3 +1,5 @@
+var supportsColor = require('supports-color');
+
 var ConsoleColor = {
   ANSICodes: {
     'reset'         : '\033[0m',
@@ -31,44 +33,10 @@ var ConsoleColor = {
     'tag'           : ['cyan']
   },
 
-  hasColor: function () {
-    var argv = process.argv;
-    if (argv.indexOf('--no-color') !== -1 ||
-      argv.indexOf('--color=false') !== -1) {
-      return false;
-    }
-
-    if (argv.indexOf('--color') !== -1 ||
-      argv.indexOf('--color=true') !== -1 ||
-      argv.indexOf('--color=always') !== -1) {
-      return true;
-    }
-
-    if (process.stdout && !process.stdout.isTTY) {
-      return false;
-    }
-
-    if (process.platform === 'win32') {
-      return true;
-    }
-
-    if ('COLORTERM' in process.env) {
-      return true;
-    }
-
-    if (process.env.TERM === 'dumb') {
-      return false;
-    }
-
-    if (/^screen|^xterm|^vt100|color|ansi|cygwin|linux/i.test(process.env.TERM)) {
-      return true;
-    }
-
-    return false;
-  },
+  supportsColor: supportsColor,
 
   color: function (colors, text) {
-    if (!this.hasColor()) {
+    if (!this.supportsColor) {
       return text;
     }
     var code = '';

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "gherkin": "2.12.2",
     "nopt": "3.0.1",
     "pogo": "0.9.4",
+    "supports-color": "1.3.1",
     "underscore": "1.7.0",
     "underscore.string": "2.3.3",
     "walkdir": "0.0.7"


### PR DESCRIPTION
Previous when cucumber was piped / used in a tty-less environment the
colour codes ended up being printed, this makes the output unreadable,
mostly the "pretty" formatter.

This does some auto detection based on tty and terminal capabilities and
disables colors when they are unable to be printed.

Also included are cli parameters which can be used to force the colors
on / off.

These are:

```sh
--no-color
--color=false
--color=true
--color=always
--color
```