### PR TITLE
Minor improvements - features accessor, Collection.sort(), 'npm test' on Windows

### DIFF
--- a/lib/cucumber/ast/feature.js
+++ b/lib/cucumber/ast/feature.js
@@ -69,6 +69,14 @@ function Feature(keyword, name, description, uri, line) {
       });
     },
 
+    getFeatures: function getFeatures() {
+      return featureElements;
+    },
+
+    setFeatures: function setFeatures(_featureElements) {
+      featureElements = _featureElements;
+    },
+
     getLastFeatureElement: function getLastFeatureElement() {
       return featureElements.getLast();
     },

--- a/lib/cucumber/ast/feature.js
+++ b/lib/cucumber/ast/feature.js
@@ -69,12 +69,8 @@ function Feature(keyword, name, description, uri, line) {
       });
     },
 
-    getFeatures: function getFeatures() {
+    getFeatureElements: function getFeatureElements() {
       return featureElements;
-    },
-
-    setFeatures: function setFeatures(_featureElements) {
-      featureElements = _featureElements;
     },
 
     getLastFeatureElement: function getLastFeatureElement() {

--- a/lib/cucumber/type/collection.js
+++ b/lib/cucumber/type/collection.js
@@ -74,6 +74,15 @@ function Collection() {
       return newCollection;
     },
 
+    sort: function sort(comparator) {
+      var sortedItems = items.sort(comparator);
+      var sortedCollection = new Collection();
+      sortedItems.forEach(function (item) {
+        sortedCollection.add(item);
+      });
+      return sortedCollection;
+    },
+
     length: function length() {
       return items.length;
     }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "exorcist": "^0.1.6"
   },
   "scripts": {
-    "test": "jshint bundler.js bin lib spec && jasmine-node spec && bin/cucumber.js -f progress -i"
+    "test": "jshint bundler.js bin lib spec && jasmine-node spec && node bin/cucumber.js -f progress -i"
   },
   "bin": {
     "cucumber.js": "./bin/cucumber.js",

--- a/spec/cucumber/ast/feature_spec.js
+++ b/spec/cucumber/ast/feature_spec.js
@@ -75,7 +75,7 @@ describe("Cucumber.Ast.Feature", function () {
       });
     });
 
-    describe("when no background was previousyly added", function () {
+    describe("when no background was previously added", function () {
       it("returns nothing", function () {
         expect(feature.getBackground()).toBeUndefined();
       });
@@ -227,6 +227,12 @@ describe("Cucumber.Ast.Feature", function () {
       it("inserts the scenario into the scenario collection", function () {
         expect(feature.insertFeatureElement).toHaveBeenCalledWith(scenarioOutlineIndex + index, scenario);
       });
+    });
+  });
+
+  describe("getFeatureElements()", function() {
+    it("gets the feature elements collection", function () {
+      expect(feature.getFeatureElements().getLast()).toBe(lastScenario);
     });
   });
 

--- a/spec/cucumber/type/collection_spec.js
+++ b/spec/cucumber/type/collection_spec.js
@@ -5,7 +5,7 @@ describe("Cucumber.Type.Collection", function () {
   var collection, itemArray;
 
   beforeEach(function () {
-    itemArray = [1, 2, 3];
+    itemArray = [3, 1, 2];
     spyOn(itemArray, 'push');
     spyOn(itemArray, 'unshift');
     spyOn(itemArray, 'splice');
@@ -74,9 +74,9 @@ describe("Cucumber.Type.Collection", function () {
 
   describe("getAtIndex()", function () {
     it("gets the item at a specific index in the item array", function () {
-      expect(collection.getAtIndex(0)).toEqual(1);
-      expect(collection.getAtIndex(1)).toEqual(2);
-      expect(collection.getAtIndex(2)).toEqual(3);
+      expect(collection.getAtIndex(0)).toEqual(3);
+      expect(collection.getAtIndex(1)).toEqual(1);
+      expect(collection.getAtIndex(2)).toEqual(2);
     });
   });
 
@@ -158,6 +158,18 @@ describe("Cucumber.Type.Collection", function () {
       collection.syncForEach(userFunction);
       expect(itemArray.slice).toHaveBeenCalledWith(0);
       expect(itemsCopy.forEach).toHaveBeenCalledWith(userFunction);
+    });
+  });
+
+  describe("sort()", function () {
+    it("sorts the array", function () {
+      var sorted = collection.sort(function(a, b) {
+        return a > b;
+      });
+
+      expect(sorted.shift()).toEqual(1);
+      expect(sorted.shift()).toEqual(2);
+      expect(sorted.shift()).toEqual(3);
     });
   });
 });


### PR DESCRIPTION
This PR is just a small set of changes that we needed to write an internal tool that we based on Cucumber:

* Feature.getFeatureElements()
* Collection.sort()
* 'npm test' will now function on Windows