### PR TITLE
normalize OS-specific path separators when performing assertions on cucumber output

### DIFF
--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -162,7 +162,8 @@ var cliSteps = function cliSteps() {
       .replace(/\r\n|\r/g, "\n")
       .replace(/^\s+/g, "")
       .replace(/\s+$/g, "")
-      .replace(/[ \t]+\n/g, "\n");
+      .replace(/[ \t]+\n/g, "\n")
+      .replace(/\\/g, "/");
   }
 
   function getAdditionalErrorText(lastRun) {


### PR DESCRIPTION
this pull request fixes #353