### PR TITLE
Ambiguous/duplicated step definitions should be an error

### DIFF
--- a/features/legacy/core.feature
+++ b/features/legacy/core.feature
@@ -63,7 +63,7 @@ Feature: Core feature elements execution
     Then the feature should have run successfully      
 
   Scenario: Steps accepting parameters
-    Given a step definition matching /^I call a step with "(.*)"$/ recording its parameters
+    Given a step definition matching /^I call a step with "([^"]*)"$/ recording its parameters
     And a step definition matching /^I call a step with "(.*)", "(.*)" and "(.*)"$/ recording its parameters
     And a step definition matching /^the (\d+)(?:st|nd|rd) received parameter should be "(.*)"$/ checking a recorded parameter
     When I run the following feature:

--- a/features/legacy/core.feature
+++ b/features/legacy/core.feature
@@ -3,6 +3,9 @@ Feature: Core feature elements execution
   As a developer
   I want Cucumber to run core feature elements
 
+  Background:
+    Given no existing steps
+
   Scenario: Simple flat steps
     Given a step definition matching /^a step passes$/
     When I run the following feature:

--- a/features/step_definitions/cucumber_js_mappings.rb
+++ b/features/step_definitions/cucumber_js_mappings.rb
@@ -362,7 +362,7 @@ EOF
     params_string = params.join(", ")
     indented_code = indent_code(code).rstrip
     append_support_code <<-EOF
-this.defineStep(/#{step_name}/, function (#{params_string}) {
+this.defineStep(/^#{step_name}$/, function (#{params_string}) {
   fs.writeFileSync("#{step_file(step_name)}", "");
 #{indented_code}
 });

--- a/features/step_definitions/legacy/cucumber_steps.js
+++ b/features/step_definitions/legacy/cucumber_steps.js
@@ -12,6 +12,11 @@ var stepDefinitions = function() {
   var _recordedStepParameters;
   var _stepCallCount;
 
+  Given(/^no existing steps$/, function(callback) {
+    _stepDefs = [];
+    callback();
+  });
+
   // Creates a Given, When or Then step definition that does nothing and pass all the time.
   //
   // Matching groups:

--- a/lib/cucumber/support_code/library.js
+++ b/lib/cucumber/support_code/library.js
@@ -50,14 +50,23 @@ function Library(supportCodeDefinition) {
     },
 
     lookupStepDefinitionByName: function lookupStepDefinitionByName(name) {
-      var matchingStepDefinition;
+      var matchingStepDefinition = [];
 
       stepDefinitions.syncForEach(function (stepDefinition) {
         if (stepDefinition.matchesStepName(name)) {
-          matchingStepDefinition = stepDefinition;
+          matchingStepDefinition.push(stepDefinition);
         }
       });
-      return matchingStepDefinition;
+
+      if (matchingStepDefinition.length > 1) {
+        var exprs = [];
+        matchingStepDefinition.forEach(function(stepDefinition) {
+          exprs.push(stepDefinition.getPatternRegexp().toString());
+        });
+        throw new Error('ambiguous step definition, matches ' + exprs.join(', '));
+      }
+
+      return matchingStepDefinition[0];
     },
 
     isStepDefinitionNameDefined: function isStepDefinitionNameDefined(name) {

--- a/spec/cucumber/support_code/library_spec.js
+++ b/spec/cucumber/support_code/library_spec.js
@@ -127,9 +127,9 @@ describe("Cucumber.SupportCode.Library", function () {
 
     beforeEach(function () {
       stepDefinitions = [
-        createSpyWithStubs("First step definition",  {matchesStepName:false}),
-        createSpyWithStubs("Second step definition", {matchesStepName:false}),
-        createSpyWithStubs("Third step definition",  {matchesStepName:false})
+        createSpyWithStubs("First step definition",  {matchesStepName:false, getPatternRegexp: /first expression/}),
+        createSpyWithStubs("Second step definition", {matchesStepName:false, getPatternRegexp: /second expression/}),
+        createSpyWithStubs("Third step definition",  {matchesStepName:false, getPatternRegexp: /third expression/})
       ];
       spyOnStub(stepDefinitionCollection, 'syncForEach').andCallFake(function (cb) { stepDefinitions.forEach(cb); });
       library = Cucumber.SupportCode.Library(rawSupportCode);
@@ -153,6 +153,22 @@ describe("Cucumber.SupportCode.Library", function () {
         var matchingStepDefinition = stepDefinitions[1];
         matchingStepDefinition.matchesStepName.andReturn(true);
         expect(library.lookupStepDefinitionByName(stepName)).toBe(matchingStepDefinition);
+      });
+
+      it("throws when step definition is ambiguous", function() {
+          stepDefinitions.forEach(function(stepDefinition) {
+            stepDefinition.matchesStepName.andReturn(true);
+            stepDefinition.getPatternRegexp.andReturn(/ambiguous expression/);
+          });
+        expect(function() {
+          library.lookupStepDefinitionByName(stepName);
+        }).toThrow('ambiguous step definition, matches /ambiguous expression/, /ambiguous expression/, /ambiguous expression/');
+      });
+
+      it("does not throw when there is no matching step definition", function() {
+        expect(function() {
+          library.lookupStepDefinitionByName(stepName);
+        }).not.toThrow();
       });
     });
 


### PR DESCRIPTION
Closes #176 

If two step definitions match the same step, an error is thrown showing the regular expression used by each of the matching step definitions.

It was necessary to fix an ambiguous step definition within the legacy core features, and to clear down step definitions created by each core scenario.