### PR TITLE
Update walkdir module to 0.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "stack-chain": "^1.3.1",
     "underscore": "1.7.0",
     "underscore.string": "2.3.3",
-    "walkdir": "0.0.7"
+    "walkdir": "0.0.10"
   },
   "devDependencies": {
     "connect": "3.2.0",


### PR DESCRIPTION
There's a bug in walkdir <0.0.10 in Windows (ntfs). Step definitions and features in different files have the same inode attribute. It causes that some features and some step definitions don't load, when tests run.