### PR TITLE
update dependency: pogo

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "cucumber-html": "0.2.3",
     "gherkin": "2.12.2",
     "nopt": "3.0.1",
-    "pogo": "0.9.4",
+    "pogo": "^0.10.0",
     "stack-chain": "^1.3.1",
     "underscore": "1.7.0",
     "underscore.string": "2.3.3",


### PR DESCRIPTION
@jbpros 

the latest version of pogo removed its peer dependency of bluebird which npm was warning about no longer being automatically fulfilled in npm3.

Note: many other dependencies are also out of date