### PR TITLE
Fix broken spec when running under Windows

### DIFF
--- a/spec/cucumber/listener/summary_formatter_spec.js
+++ b/spec/cucumber/listener/summary_formatter_spec.js
@@ -280,7 +280,7 @@ describe("Cucumber.Listener.SummaryFormatter", function () {
 
     beforeEach(function () {
       name           = "some failed scenario";
-      relativeUri    = "path/to/some.feature";
+      relativeUri    = path.normalize("path/to/some.feature");
       uri            = path.join(process.cwd(), relativeUri);
       line           = "123";
       string         = relativeUri + ":" + line + " # Scenario: " + name;


### PR DESCRIPTION
I just cloned the repo locally and was running the specs where one test failed **due to wrong directory separators under Windows**:

```
Failures:

  1) Cucumber.Listener.SummaryFormatter storeFailedScenario() appends the scenario details to the failed scenario log buffer
   Message:
     Expected spy appendStringToFailedScenarioLogBuffer to have been called with [ 'path/to/some.feature:123 # Scenario: some failed scenario' ] but actual calls were [ 'path\to\some.feature:123 # Scenario: some failed scenario' ]
   Stacktrace:
     Error: Expected spy appendStringToFailedScenarioLogBuffer to have been called with [ 'path/to/some.feature:123 # Scenario: some failed scenario' ] but actual calls were [ 'path\to\some.feature:123 # Scenario: some failed scenario' ]
    at null.<anonymous> (.\cucumber-js\spec\cucumber\listener\summary_formatter_spec.js:308:70)

Finished in 1.397 seconds
1392 tests, 1594 assertions, 1 failure, 0 skipped
```
