### PR TITLE
Add error diffs to pretty formatter

### DIFF
--- a/lib/cucumber/listener/pretty_formatter.js
+++ b/lib/cucumber/listener/pretty_formatter.js
@@ -105,7 +105,7 @@ function PrettyFormatter(options) {
 
     if (stepResult.isFailed()) {
       var failure            = stepResult.getFailureException();
-      var failureDescription = failure.stack || failure;
+      var failureDescription = stepResult.getFailureDescription() || failure.stack || failure;
       self.logIndented(failureDescription + '\n', 3);
     }
   };

--- a/lib/cucumber/runtime/failed_step_result.js
+++ b/lib/cucumber/runtime/failed_step_result.js
@@ -1,3 +1,5 @@
+var jsondiff = require('json-diff');
+
 function FailedStepResult(payload) {
   var Cucumber = require('../../cucumber');
 
@@ -7,6 +9,16 @@ function FailedStepResult(payload) {
 
   self.getFailureException = function getFailureException() {
     return payload.failureException;
+  };
+
+  self.getFailureDescription = function getFailureDescription() {
+    var exception = payload.failureException;
+    if (exception.showDiff && exception.actual && exception.expected) {
+      var delta = jsondiff.diffString(exception.expected, exception.actual)
+      return exception.name + ': ' + exception.message + '\n' + delta + '\n' + exception.stack;
+    } else {
+      return exception.stack || exception;
+    }
   };
 
   return self;

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "cucumber-html": "0.2.3",
     "duration": "^0.2.0",
     "gherkin": "2.12.2",
+    "json-diff": "^0.3.1",
     "nopt": "3.0.4",
     "stack-chain": "1.3.3",
     "underscore": "1.8.3",


### PR DESCRIPTION
Do not merge.

This is an experimental attempt at fixing #386. Something similar would be implemented in a more global fashion. The key idea being that we check for the three properties `showDiff`, `expected` and `actual` properties on error instances to return an augmented description of it. It should probably done in a new ErrorPresenter object, rather than on FailedStepResult.

Thoughts?

