### PR TITLE
Use colors by default if the option was not explicitly set

### DIFF
--- a/lib/cucumber/util/colors.js
+++ b/lib/cucumber/util/colors.js
@@ -1,7 +1,10 @@
 var colors = require('colors/safe');
 
 function Colors (useColors) {
-  colors.enabled = useColors;
+  if (typeof useColors !== 'undefined') {
+    colors.enabled = useColors;
+  }
+
   return {
     ambiguous: colors.magenta,
     comment: colors.grey,

--- a/spec/cucumber/util/colors_spec.js
+++ b/spec/cucumber/util/colors_spec.js
@@ -1,0 +1,23 @@
+require('../../support/spec_helper');
+
+describe("Cucumber.Util.Colors", function () {
+  var Cucumber = requireLib('cucumber');
+  var colors = require('colors');
+  colors.enabled = true;
+
+  describe("failed()", function () {
+    var RED = "red".red;
+
+    it("enables colors by default", function () {
+      expect(Cucumber.Util.Colors().failed("red")).toBe(RED);
+    });
+
+    it("enables colors explicitly", function () {
+      expect(Cucumber.Util.Colors(true).failed("red")).toBe(RED);
+    });
+
+    it("disables colors explicitly", function () {
+      expect(Cucumber.Util.Colors(false).failed("red")).toBe("red");
+    });
+  });
+});


### PR DESCRIPTION
colors has support for defaulting enablement if not explicitly set [here](https://github.com/Marak/colors.js/blob/master/lib/colors.js#L41-L43). We were overriding that after we required it. So setting `--color=true` as described in #409 will no longer be needed.