### PR TITLE
Updated .codeclimate.yml to allow analysis to finish on server

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,8 +1,13 @@
 engines:
   eslint:
     enabled: true
-
 ratings:
   paths:
   - bin/**
   - lib/**
+exclude_paths:
+- features/**/*
+- spec/**/*
+- example/**/*
+- release/**/*
+- scripts/**/*


### PR DESCRIPTION
The .codeclimate.yml checked in doesn't exclude any paths -- this is fine, however, it looks like the analysis is getting killed due to an upper memory limit on codeclimate.com. By excluding some paths I was able to get the analysis to complete successfully. Feel free to remove some of the excludes to see what the minimum exclusions are required.