### PR TITLE
World export fixed in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,7 @@ function World() {
   };
 }
 
-module.exports = function() {
-  this.World = World;
-};
+exports.World = World;
 ```
 
 If you need to perform operations before/after every scenario, use [hooks](#hooks).


### PR DESCRIPTION
World export in current documentation is broken. With export like,
```
module.exports = function() {
 this.World = World;
};
```
users get error like
```
var world = new World();
                  ^
TypeError: World is not a function
```
