### PR TITLE
Add Zombie.js to list of Prerequesites

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It runs on both Node.js and *modern* web browsers.
 
 * [Node.js](https://nodejs.org) or [io.js](https://iojs.org)
 * [NPM](https://www.npmjs.com)
+* [Zombie.js](http://zombie.js.org/)
 
 Cucumber.js is tested on:
 


### PR DESCRIPTION
There is no mention of zombie.js until the point it's used in world, and no link to it.