### PR TITLE
browserstack integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ A few example apps are available for you to browse:
 
 * [Rails app serving features in the browser](https://github.com/jbpros/cucumber-js-example)
 * [Express.js app running features in the cli](https://github.com/olivoil/NodeBDD)
+* [Running Cucumber tests on BrowserStack](https://github.com/browserstack/cucumber-js-browserstack)
 
 ## Contribute
 


### PR DESCRIPTION
Cucumber tests can be run on BrowserStack infrastructure out of the box.
Attached link for sample repo in the README.md 