### PR TITLE
added test scenario for missing background step definition

### DIFF
--- a/features/step_definition_snippets.feature
+++ b/features/step_definition_snippets.feature
@@ -87,3 +87,17 @@ Feature: step definition snippets
       """
       /^a step with a (.*)$/
       """
+
+  Scenario: background step
+    Given a file named "features/background.feature" with:
+      """
+      Feature: a feature
+        Background:
+          Given  a step with "quotes"
+        Scenario: a scenario
+      """
+    When I run cucumber-js
+    Then it suggests a "Given" step definition snippet with 1 parameter for:
+      """
+      /^a step with "([^"]*)"$/
+      """

--- a/lib/cucumber/listener/summary_formatter.js
+++ b/lib/cucumber/listener/summary_formatter.js
@@ -148,9 +148,13 @@ function SummaryFormatter(options) {
     var scenario = step.getScenario();
     var colorFn = colors[stepResult.getStatus()];
 
-    var scenarioLocation = path.relative(process.cwd(), scenario.getUri()) + ':' + scenario.getLine();
-    var scenarioLine = 'Scenario: ' + colors.bold(scenario.getName()) + ' - ' + colors.location(scenarioLocation);
-    lines.push(prefix + scenarioLine);
+    if(scenario) {
+      var scenarioLocation = path.relative(process.cwd(), scenario.getUri()) + ':' + scenario.getLine();
+      var scenarioLine = 'Scenario: ' + colors.bold(scenario.getName()) + ' - ' + colors.location(scenarioLocation);
+      lines.push(prefix + scenarioLine);
+    } else {
+      lines.push(prefix + 'Background:');
+    }
 
     var stepLine = 'Step: ' + colors.bold(step.getKeyword() + (step.getName() || ''));
     if (step.hasUri()) {


### PR DESCRIPTION
As mentioned in #554, here is my update with the additional scenario to check for a missing step definition in the background section of a feature file.  I have also included my dodgy fix, but will not be in any way offended if it's not used! :)