### PR TITLE
Adding --init and nicer messages for missing features

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -3,6 +3,21 @@ Feature: Command line interface
   As a person who wants to run features
   I want to run Cucumber on the command line
 
+  Scenario: run with no features directory
+    When I run cucumber.js with `-f summary`
+    Then the error output contains the text:
+    """
+    No such file or directory - features. You can use `cucumber --init` to get started.
+    """
+
+  Scenario: run a nonexistant feature file
+    Given a directory named "features" 
+    When I run cucumber.js with `-f summary features/a.feature`
+    Then the error output contains the text:
+    """
+    No such file or directory - features/a.feature. You can use `cucumber --init` to get started.
+    """
+
   Scenario: run a single feature
     Given a file named "features/a.feature" with:
       """

--- a/lib/cucumber/cli.js
+++ b/lib/cucumber/cli.js
@@ -19,6 +19,7 @@ function Cli(argv) {
       .option('-d, --dry-run', 'invoke formatters without executing steps')
       .option('--fail-fast', 'abort the run on first failure')
       .option('-f, --format <TYPE[:PATH]>', 'specify the output format, optionally supply PATH to redirect formatter output (repeatable)', collect, ['pretty'])
+      .option('--init', 'Initializes folder structure and generates conventional files for a Cucumber project.')
       .option('--name <REGEXP>', 'only execute the scenarios with name matching the expression (repeatable)', collect, [])
       .option('--no-colors', 'disable colors in formatter output')
       .option('-p, --profile <NAME>', 'specify the profile to use (repeatable)', collect, [])
@@ -42,6 +43,10 @@ function Cli(argv) {
       var fullArgs = argv.slice(0, 2).concat(profileArgs).concat(argv.slice(2));
       program = getProgram();
       program.parse(fullArgs);
+    } 
+    if (program.init) { 
+      Cucumber.Cli.ProjectInitializer.createDefaultProject();
+      process.exit(0);
     }
     var configuration = Cucumber.Cli.Configuration(program.opts(), program.args);
     return configuration;
@@ -66,6 +71,7 @@ Cli.FeaturePathExpander = require('./cli/feature_path_expander');
 Cli.FeatureSourceLoader = require('./cli/feature_source_loader');
 Cli.PathExpander = require('./cli/path_expander');
 Cli.ProfilesLoader = require('./cli/profiles_loader');
+Cli.ProjectInitializer = require('./cli/project_initializer');
 Cli.SupportCodeLoader = require('./cli/support_code_loader');
 Cli.SupportCodePathExpander = require('./cli/support_code_path_expander');
 

--- a/lib/cucumber/cli.js
+++ b/lib/cucumber/cli.js
@@ -19,7 +19,7 @@ function Cli(argv) {
       .option('-d, --dry-run', 'invoke formatters without executing steps')
       .option('--fail-fast', 'abort the run on first failure')
       .option('-f, --format <TYPE[:PATH]>', 'specify the output format, optionally supply PATH to redirect formatter output (repeatable)', collect, ['pretty'])
-      .option('--init', 'Initializes folder structure and generates conventional files for a Cucumber project.')
+      .option('--init', 'Initializes folder structure for a conventional Cucumber project.')
       .option('--name <REGEXP>', 'only execute the scenarios with name matching the expression (repeatable)', collect, [])
       .option('--no-colors', 'disable colors in formatter output')
       .option('-p, --profile <NAME>', 'specify the profile to use (repeatable)', collect, [])

--- a/lib/cucumber/cli/configuration.js
+++ b/lib/cucumber/cli/configuration.js
@@ -18,8 +18,20 @@ function Configuration(options, args) {
     });
   }
 
-  var expandedFeaturePaths = Cucumber.Cli.FeaturePathExpander.expandPaths(unexpandedFeaturePaths);
-
+  var expandedFeaturePaths;
+  try {
+    expandedFeaturePaths = Cucumber.Cli.FeaturePathExpander.expandPaths(unexpandedFeaturePaths);
+  } catch (e) {
+      if (e.code === 'ENOENT' || e.code === 'ENOTDIR') {  
+        var errorMessage = 'No such file or directory - ';
+        errorMessage += path.relative(process.cwd(), e.path);
+        errorMessage += '. You can use `cucumber --init` to get started.';
+        console.error(errorMessage); 
+        process.exit(1);
+      } else {
+        throw e;
+      }
+  }
 
   function getCompilerExtensions() {
     return options.compiler.map(function(compiler) {

--- a/lib/cucumber/cli/project_initializer.js
+++ b/lib/cucumber/cli/project_initializer.js
@@ -1,0 +1,10 @@
+var ProjectInitializer = {
+  createDefaultProject: function createDefaultProject() { 
+    var fsExtra = require('fs-extra');
+    var path = require('path');
+    var cwd = process.cwd(); 
+    fsExtra.mkdirsSync(path.join(cwd, 'features', 'support'));
+    fsExtra.mkdirsSync(path.join(cwd, 'features', 'step_definitions'));
+  }
+};
+module.exports = ProjectInitializer;

--- a/spec/cucumber/cli/project_initializer_spec.js
+++ b/spec/cucumber/cli/project_initializer_spec.js
@@ -1,0 +1,24 @@
+require('../../support/spec_helper');
+
+describe('Cucumber.Cli.ProjectInitializer', function () {
+  describe('createDefaultProject()', function () {
+    var Cucumber = requireLib('cucumber');  
+    var fsExtra = require('fs-extra'); 
+    
+    beforeEach(function () {
+       spyOn(fsExtra, 'mkdirsSync');
+       process.cwd = createSpy("fake cwd").and.returnValue("/tmp");
+       process.exit = createSpy("fake exit").and.callFake(function() {});
+    });
+      
+    it("creates the features/support directory", function () {
+        Cucumber.Cli.ProjectInitializer.createDefaultProject();
+        expect(fsExtra.mkdirsSync).toHaveBeenCalledWith('/tmp/features/support');
+    });
+    
+    it("creates the features/step_definitions directory", function () {
+        Cucumber.Cli.ProjectInitializer.createDefaultProject();
+        expect(fsExtra.mkdirsSync).toHaveBeenCalledWith('/tmp/features/step_definitions'); 
+    }); 
+  });
+});


### PR DESCRIPTION
This PR adds behavior for missing features dir and missing feature file identical to cucumber-ruby. It also adds the --init cli option for new projects.