### PR TITLE
Correct tagged hook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ Hooks can be conditionally selected for execution based on the tags of the scena
 // features/support/hooks.js (this path is just a suggestion)
 
 var myHooks = function () {
-  this.Before({tags: ["@foo", "@bar,@baz"]}, function (scenario) {
-    // This hook will be executed before scenarios tagged with @foo and either
+  this.Before("@foo", "@bar,@baz", function (scenario) {
+    // This hook will be executed before scenarios tagged with @foo AND either
     // @bar or @baz.
 
     // ...


### PR DESCRIPTION
The way it is currently implemented we should pass a variable amount of string parameters rather than an object with `tags` array .

This updates the documentation accordingly.