### PR TITLE
native base64 encoding, fix for binary attachments

### DIFF
--- a/lib/cucumber/listener/json_formatter.js
+++ b/lib/cucumber/listener/json_formatter.js
@@ -1,7 +1,6 @@
 /* jshint -W106 */
 function JsonFormatter(options) {
   var Cucumber = require('../../cucumber');
-  var base64 = require('base-64');
 
   var self = Cucumber.Listener.Formatter(options);
 
@@ -91,8 +90,12 @@ function JsonFormatter(options) {
 
     if (stepResult.hasAttachments()) {
       currentStep.embeddings = stepResult.getAttachments().map(function (attachment) {
+        var data = attachment.getData();
+        if (!(data instanceof Buffer)) {
+          data = new Buffer(data);
+        }
         return {
-          data: base64.encode(attachment.getData()),
+          data: data.toString('base64'),
           mime_type: attachment.getMimeType(),
         };
       });

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "base-64": "^0.1.0",
     "callsite": "^1.0.0",
     "camel-case": "^1.2.0",
     "cli-table": "^0.3.1",

--- a/spec/cucumber/listener/json_formatter_spec.js
+++ b/spec/cucumber/listener/json_formatter_spec.js
@@ -3,6 +3,7 @@ require('../../support/spec_helper');
 
 describe("Cucumber.Listener.JsonFormatter", function () {
   var Cucumber = requireLib('cucumber');
+  var fs = require('fs');
   var jsonFormatter, options;
 
   beforeEach(function () {
@@ -281,7 +282,13 @@ describe("Cucumber.Listener.JsonFormatter", function () {
           beforeEach(function (){
             var attachment1 = createSpyWithStubs("first attachment", {getMimeType: "first mime type", getData: "first data"});
             var attachment2 = createSpyWithStubs("second attachment", {getMimeType: "second mime type", getData: "second data"});
-            var attachments = [attachment1, attachment2];
+            var favicon = fs.readFileSync('example/images/favicon.png');
+            var attachment3 = createSpyWithStubs("third attachment", {
+              getMimeType: "image/png",
+              getData: favicon
+            });
+            this.faviconBase64 = favicon.toString('base64');
+            var attachments = [attachment1, attachment2, attachment3];
             stepResult.hasAttachments.and.returnValue(true);
             stepResult.getAttachments.and.returnValue(attachments);
             jsonFormatter.handleStepResultEvent(event, callback);
@@ -298,7 +305,11 @@ describe("Cucumber.Listener.JsonFormatter", function () {
             var features = JSON.parse(json);
             expect(features[0].elements[0].steps[0].embeddings).toEqual([
               {data: 'Zmlyc3QgZGF0YQ==', mime_type: 'first mime type'},
-              {data: 'c2Vjb25kIGRhdGE=', mime_type: 'second mime type'}
+              {data: 'c2Vjb25kIGRhdGE=', mime_type: 'second mime type'},
+              {
+                data: this.faviconBase64,
+                mime_type: 'image/png'
+              }
             ]);
           });
         });


### PR DESCRIPTION
this removes the `base-64` dependency which doesn't support binary input (it throws an error if input is not ASCII), that makes json formatter fail if any attachment is binary (like screenshots are), replacing it node.js native base64 encoding.
as a side benefit, native encoding is probably (not measure) faster, and it's one less dependency to care about.