### PR TITLE
Proper handling of tagged hook options

### DIFF
--- a/lib/cucumber/tag_group_parser.js
+++ b/lib/cucumber/tag_group_parser.js
@@ -1,4 +1,8 @@
 function TagGroupParser(tagGroupString) {
+  if (typeof tagGroupString === 'object') {
+    tagGroupString = tagGroupString.tags.join(',');
+  }
+
   var self = {
     parse: function parse() {
       var splitTags = tagGroupString.split(TagGroupParser.TAG_SEPARATOR);

--- a/lib/cucumber/tag_group_parser.js
+++ b/lib/cucumber/tag_group_parser.js
@@ -1,16 +1,17 @@
-function TagGroupParser(tagGroupString) {
-  if (typeof tagGroupString === 'object') {
-    tagGroupString = tagGroupString.tags.join(',');
+function TagGroupParser(tagGroupConfig) {
+  var tagGroupString = tagGroupConfig;
+
+  if (typeof tagGroupConfig === 'object' && tagGroupConfig !== null) {
+    tagGroupString = tagGroupConfig.tags.join(',');
   }
 
-  var self = {
+  return {
     parse: function parse() {
-      var splitTags = tagGroupString.split(TagGroupParser.TAG_SEPARATOR);
-      var trimmedTags = splitTags.map(function (tag) { return tag.trim(); });
-      return trimmedTags;
+      return tagGroupString
+        .split(TagGroupParser.TAG_SEPARATOR)
+        .map(function (tag) { return tag.trim(); });
     }
   };
-  return self;
 }
 
 TagGroupParser.getTagGroupsFromStrings = function getTagGroupsFromStrings(tagGroupStrings) {


### PR DESCRIPTION
Hey guys,

I tried following the [tagged hooks](https://github.com/MrSenko/cucumber-js#tagged-hooks) example from the documentation but I got:
```
/Users/krasimir/Work/TrialReach/projects/gargantua/node_modules/cucumber/lib/cucumber/tag_group_parser.js:4
      var splitTags = tagGroupString.split(TagGroupParser.TAG_SEPARATOR);
```
It looks like in `lib/cucumber/tag_group_parser.js` `tagGroupString` is actually not a string anymore. It comes as an object in the shape of:
```
{ tags: [ '@regression' ] }
```
So I added a simple check to transform that object into a string.