### PR TITLE
disable script execution in example zombie code

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ module.exports = function () {
     // Express the regexp above with the code you wish you had.
     // `this` is set to a World instance.
     // i.e. you may use this.browser to execute the step:
-
+    this.browser.runScripts = false; // this disables executing javascript
     this.visit('https://github.com/cucumber/cucumber-js', callback);
 
     // The callback is passed to visit() so that when the job's finished, the next step can


### PR DESCRIPTION
Github pages crash zombie and cause node to error; disabling script execution in the sample code works around this.

<details><summary>crash dump</summary>
```
1) Scenario: Reading documentation - features/first.feature:6
   Step: Given I am on the Cucumber.js GitHub repository - features/first.feature:7
   Step Definition: features/step_definitions/first_steps.js:2
   Message:
     TypeError: n.initCustomEvent is not a function
         at Object.CustomEvent (https://assets-cdn.github.com/assets/compat-7db58f8b7b91111107fac755dd8b178fe7db0f209ced51fc339c446ad3f8da2b.js:1:2405)
         at i (https://assets-cdn.github.com/assets/frameworks-149d9338c2665172870825c78fa48fdcca4d431d067cbf5fda7120d9e39cc738.js:7:2169)
         at r (https://assets-cdn.github.com/assets/frameworks-149d9338c2665172870825c78fa48fdcca4d431d067cbf5fda7120d9e39cc738.js:7:2032)
         at https://assets-cdn.github.com/assets/frameworks-149d9338c2665172870825c78fa48fdcca4d431d067cbf5fda7120d9e39cc738.js:7:2961
         at i (https://assets-cdn.github.com/assets/frameworks-149d9338c2665172870825c78fa48fdcca4d431d067cbf5fda7120d9e39cc738.js:2:18582)
         at i (https://assets-cdn.github.com/assets/frameworks-149d9338c2665172870825c78fa48fdcca4d431d067cbf5fda7120d9e39cc738.js:2:18563)
         at https://assets-cdn.github.com/assets/frameworks-149d9338c2665172870825c78fa48fdcca4d431d067cbf5fda7120d9e39cc738.js:7:4939
         at https://assets-cdn.github.com/assets/frameworks-149d9338c2665172870825c78fa48fdcca4d431d067cbf5fda7120d9e39cc738.js:7:5126
         at Object.exports.runInContext (vm.js:44:17)
         at window._evaluate (/Users/ibroadfo/flowerpot/node_modules/zombie/lib/document.js:253:75)
         in https://github.com/cucumber/cucumber-js

1 scenario (1 failed)
3 steps (1 failed, 2 skipped)
0m02.427s
```
</details>