### PR TITLE
stack_trace_filter no longer blows up when given an error object without a stack trace

### DIFF
--- a/lib/cucumber/runtime/stack_trace_filter.js
+++ b/lib/cucumber/runtime/stack_trace_filter.js
@@ -12,7 +12,7 @@ function isFrameInCucumber(frame) {
 
 function filter() {
   currentFilter = chain.filter.attach(function (error, frames) {
-    if (isFrameInCucumber(frames[0])) {
+    if (frames[0] && isFrameInCucumber(frames[0])) {
       return frames;
     }
     return frames.filter(_.negate(isFrameInCucumber));

--- a/lib/cucumber/runtime/stack_trace_filter.js
+++ b/lib/cucumber/runtime/stack_trace_filter.js
@@ -12,7 +12,7 @@ function isFrameInCucumber(frame) {
 
 function filter() {
   currentFilter = chain.filter.attach(function (error, frames) {
-    if (frames[0] && isFrameInCucumber(frames[0])) {
+    if (frames.length > 0 && isFrameInCucumber(frames[0])) {
       return frames;
     }
     return frames.filter(_.negate(isFrameInCucumber));


### PR DESCRIPTION
When an asynchronous test step returns a promise rejected with an `Error` (`AssertionError` in the case of Chai), such as:

```javascript
return expect(browser.getTitle()).to.eventually.equal('my website')
```

Cucumber produces the following error output:
```
/Users/jan/project/node_modules/cucumber/lib/cucumber/runtime/stack_trace_filter.js:9
  var fileName = frame.getFileName() || '';
                      ^
TypeError: node_modules/protractor-cucumber-framework/lib/resultsCapturer.js:60 Cannot read property 'getFileName' of undefined
    at isFrameInCucumber (/Users/jan/project/node_modules/cucumber/lib/cucumber/runtime/stack_trace_filter.js:9:23)
    at Array.<anonymous> (/Users/jan/project/node_modules/cucumber/lib/cucumber/runtime/stack_trace_filter.js:15:9)
    at TraceModifier._modify (/Users/jan/project/node_modules/cucumber/node_modules/stack-chain/stack-chain.js:44:32)
    at Function.prepareStackTrace (/Users/jan/project/node_modules/cucumber/node_modules/stack-chain/stack-chain.js:119:25)
    at /Users/jan/project/node_modules/protractor-cucumber-framework/lib/resultsCapturer.js:73:37
    at Object.run (/Users/jan/project/node_modules/cucumber/lib/cucumber/util/run.js:34:19)
    at Object.hear (/Users/jan/project/node_modules/cucumber/lib/cucumber/listener.js:15:23)
    at /Users/jan/project/node_modules/cucumber/lib/cucumber/runtime/event_broadcaster.js:28:18
    at iterate (/Users/jan/project/node_modules/cucumber/lib/cucumber/util/async_for_each.js:7:7)
    at nextTickCallbackWith0Args (node.js:420:9)
```

This is caused by an assumption made in the `stack_trace_filterer` that an instance of an `Error` will always have a stack trace associated with it.

This pull request adds a check to verify that the stack trace is not empty.