### PR TITLE
Use cross-platform symbols

### DIFF
--- a/features/multiple_formatters.feature
+++ b/features/multiple_formatters.feature
@@ -31,7 +31,7 @@ Feature: Multiple Formatters
       Feature: some feature
 
         Scenario: I've declared one step which passes
-        ✓ Given This step is passing
+        ✔ Given This step is passing
 
       1 scenario (1 passed)
       1 step (1 passed)

--- a/features/pretty_formatter.feature
+++ b/features/pretty_formatter.feature
@@ -50,7 +50,7 @@ Feature: Pretty Formatter
       Feature: some feature
 
         Scenario: I've declared one step which passes
-        ✓ Given This step is passing
+        ✔ Given This step is passing
 
       1 scenario (1 passed)
       1 step (1 passed)
@@ -130,12 +130,12 @@ Feature: Pretty Formatter
       Feature: some feature
 
         Scenario: some scenario
-        ✓ Given a basic step
-        ✓ And a step with a doc string
+        ✔ Given a basic step
+        ✔ And a step with a doc string
             \"\"\"
             my doc string
             \"\"\"
-        ✓ And a basic step
+        ✔ And a basic step
 
       1 scenario (1 passed)
       3 steps (3 passed)
@@ -164,7 +164,7 @@ Feature: Pretty Formatter
       Feature: some feature
 
         Scenario: some scenario
-        ✓ Given a table:
+        ✔ Given a table:
             | foo\nbar               | bar | baz      |
             | foo\nbar\n\nbaz\n\\boo | bar | baz\nfoo |
 

--- a/features/profiles.feature
+++ b/features/profiles.feature
@@ -69,7 +69,7 @@ Feature: default command line arguments
       Feature: some feature
 
         Scenario: some scenario
-        ✓ Given a passing step
+        ✔ Given a passing step
 
       1 scenario (1 passed)
       1 step (1 passed)

--- a/features/rerun_formatter.feature
+++ b/features/rerun_formatter.feature
@@ -47,7 +47,7 @@ Feature: Rerun Formatter
       Feature: A
 
         Scenario: 1
-        ✓ Given a passing step
+        ✔ Given a passing step
 
       1 scenario (1 passed)
       1 step (1 passed)
@@ -64,7 +64,7 @@ Feature: Rerun Formatter
       Feature: A
 
         Scenario: 1
-        ✓ Given a passing step
+        ✔ Given a passing step
 
         Scenario: 2
         ✖ Given a failing step
@@ -75,7 +75,7 @@ Feature: Rerun Formatter
       Feature: B
 
         Scenario: 4
-        ✓ Given a passing step
+        ✔ Given a passing step
 
         Scenario: 5
         ✖ Given a failing step

--- a/features/target_specific_scenarios_by_line.feature
+++ b/features/target_specific_scenarios_by_line.feature
@@ -37,7 +37,7 @@ Feature: Target specific scenarios
       Feature: some feature
 
         Scenario: first scenario
-        ✓ When a step is passing
+        ✔ When a step is passing
 
       1 scenario (1 passed)
       1 step (1 passed)
@@ -52,7 +52,7 @@ Feature: Target specific scenarios
       Feature: some feature
 
         Scenario: third scenario
-        ✓ When a step is passing
+        ✔ When a step is passing
 
         Scenario: third scenario
         ? When a step is pending
@@ -78,7 +78,7 @@ Feature: Target specific scenarios
       Feature: some feature
 
         Scenario: third scenario
-        ✓ When a step is passing
+        ✔ When a step is passing
 
       1 scenario (1 passed)
       1 step (1 passed)
@@ -93,10 +93,10 @@ Feature: Target specific scenarios
       Feature: some feature
 
         Scenario: first scenario
-        ✓ When a step is passing
+        ✔ When a step is passing
 
         Scenario: second scenario
-        ✓ When a step is passing
+        ✔ When a step is passing
 
       2 scenarios (2 passed)
       2 steps (2 passed)

--- a/features/target_specific_scenarios_by_tag.feature
+++ b/features/target_specific_scenarios_by_tag.feature
@@ -43,7 +43,7 @@ Feature: Target specific scenarios
 
         @a
         Scenario: first scenario
-        ✓ When a step is passing
+        ✔ When a step is passing
 
       1 scenario (1 passed)
       1 step (1 passed)
@@ -59,7 +59,7 @@ Feature: Target specific scenarios
 
         @a
         Scenario: first scenario
-        ✓ When a step is passing
+        ✔ When a step is passing
 
       1 scenario (1 passed)
       1 step (1 passed)
@@ -75,7 +75,7 @@ Feature: Target specific scenarios
 
         @b @c
         Scenario: second scenario
-        ✓ When a step is passing
+        ✔ When a step is passing
 
         @b @c
         Scenario: second scenario
@@ -117,7 +117,7 @@ Feature: Target specific scenarios
 
         @b @c
         Scenario: second scenario
-        ✓ When a step is passing
+        ✔ When a step is passing
 
         @b @c
         Scenario: second scenario

--- a/lib/cucumber/listener/pretty_formatter.js
+++ b/lib/cucumber/listener/pretty_formatter.js
@@ -1,5 +1,6 @@
 function PrettyFormatter(options) {
   var Cucumber         = require('../../cucumber');
+  var figures          = require('figures');
 
   var colors           = Cucumber.Util.Colors(options.useColors);
   var self             = Cucumber.Listener.Formatter(options);
@@ -16,9 +17,9 @@ function PrettyFormatter(options) {
   };
 
   var characters = {};
-  characters[Cucumber.Status.AMBIGUOUS] = '✖';
-  characters[Cucumber.Status.FAILED] = '✖';
-  characters[Cucumber.Status.PASSED] = '✓';
+  characters[Cucumber.Status.AMBIGUOUS] = figures.warning;
+  characters[Cucumber.Status.FAILED] = figures.cross;
+  characters[Cucumber.Status.PASSED] = figures.tick;
   characters[Cucumber.Status.PENDING] = '?';
   characters[Cucumber.Status.SKIPPED] = '-';
   characters[Cucumber.Status.UNDEFINED] = '?';

--- a/lib/cucumber/listener/pretty_formatter.js
+++ b/lib/cucumber/listener/pretty_formatter.js
@@ -17,7 +17,7 @@ function PrettyFormatter(options) {
   };
 
   var characters = {};
-  characters[Cucumber.Status.AMBIGUOUS] = figures.warning;
+  characters[Cucumber.Status.AMBIGUOUS] = figures.cross;
   characters[Cucumber.Status.FAILED] = figures.cross;
   characters[Cucumber.Status.PASSED] = figures.tick;
   characters[Cucumber.Status.PENDING] = '?';

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "commander": "^2.9.0",
     "cucumber-html": "^0.2.3",
     "duration": "^0.2.0",
+    "figures": "1.7.0",
     "gherkin": "^4.0.0",
     "glob": "^7.0.0",
     "is-generator": "^1.0.2",

--- a/spec/cucumber/listener/pretty_formatter_spec.js
+++ b/spec/cucumber/listener/pretty_formatter_spec.js
@@ -230,7 +230,7 @@ describe("Cucumber.Listener.PrettyFormatter", function () {
 
       it('logs the keyword and name', function () {
         var expected =
-          '  ' + colors.green('✓ step-keyword step-name') + '\n';
+          '  ' + colors.green('✔ step-keyword step-name') + '\n';
         expect(logged).toEqual(expected);
       });
     });
@@ -296,7 +296,7 @@ describe("Cucumber.Listener.PrettyFormatter", function () {
 
       it('logs the keyword', function () {
         var expected =
-          '  ✓ step-keyword ' + '\n';
+          '  ✔ step-keyword ' + '\n';
         expect(colors.strip(logged)).toEqual(expected);
       });
     });
@@ -315,7 +315,7 @@ describe("Cucumber.Listener.PrettyFormatter", function () {
 
       it('logs the keyword and name and data table', function () {
         var expected =
-          '  ✓ step-keyword step-name' + '\n' +
+          '  ✔ step-keyword step-name' + '\n' +
           '      | cuk | cuke | cukejs   |' + '\n' +
           '      | c   | cuke | cuke.js  |' + '\n' +
           '      | cu  | cuke | cucumber |' + '\n';
@@ -333,7 +333,7 @@ describe("Cucumber.Listener.PrettyFormatter", function () {
 
       it('logs the keyword and name and doc string', function () {
         var expected =
-          '  ✓ step-keyword step-name' + '\n' +
+          '  ✔ step-keyword step-name' + '\n' +
           '      """' + '\n' +
           '      this is a multiline' + '\n' +
           '      doc string' + '\n' +


### PR DESCRIPTION
@charlierudolph 

Some Windows shells only support a limited character set. Using [figures](https://github.com/sindresorhus/figures) makes the new unicode output of Cucumber more compatible across all platforms. 