### PR TITLE
Change links in event_handlers.md docs to make navigation work

### DIFF
--- a/docs/support_files/event_handlers.md
+++ b/docs/support_files/event_handlers.md
@@ -4,20 +4,20 @@ You can register event handlers for the following events within the cucumber lif
 
 | Event          | Object                                            |
 |----------------|-----------------------------------------------------------|
-| BeforeFeatures | array of [Features](lib/cucumber/ast/feature.js)          |
-| BeforeFeature  | [Feature](lib/cucumber/ast/feature.js)                    |
-| BeforeScenario | [Scenario](lib/cucumber/ast/scenario.js)                  |
-| BeforeStep     | [Step](lib/cucumber/ast/step.js)                          |
-| StepResult     | [StepResult](lib/cucumber/runtime/step_result.js)         |
-| AfterStep      | [Step](lib/cucumber/ast/step.js)                          |
-| ScenarioResult | [ScenarioResult](lib/cucumber/runtime/scenario_result.js) |
-| AfterScenario  | [Scenario](lib/cucumber/ast/scenario.js)                  |
-| AfterFeature   | [Feature](lib/cucumber/ast/feature.js)                    |
-| FeaturesResult | [FeaturesResult](lib/cucumber/runtime/features_result.js) |
-| AfterFeatures  | array of [Features](lib/cucumber/ast/feature.js)          |
+| BeforeFeatures | array of [Features](/lib/cucumber/ast/feature.js)          |
+| BeforeFeature  | [Feature](/lib/cucumber/ast/feature.js)                    |
+| BeforeScenario | [Scenario](/lib/cucumber/ast/scenario.js)                  |
+| BeforeStep     | [Step](/lib/cucumber/ast/step.js)                          |
+| StepResult     | [StepResult](/lib/cucumber/runtime/step_result.js)         |
+| AfterStep      | [Step](/lib/cucumber/ast/step.js)                          |
+| ScenarioResult | [ScenarioResult](/lib/cucumber/runtime/scenario_result.js) |
+| AfterScenario  | [Scenario](/lib/cucumber/ast/scenario.js)                  |
+| AfterFeature   | [Feature](/lib/cucumber/ast/feature.js)                    |
+| FeaturesResult | [FeaturesResult](/lib/cucumber/runtime/features_result.js) |
+| AfterFeatures  | array of [Features](/lib/cucumber/ast/feature.js)          |
 
 Hooks also trigger `BeforeStep`, `StepResult`, and `AfterStep` events with the object
-[HookStep](lib/cucumber/ast/hook_step.js)
+[HookStep](/lib/cucumber/ast/hook_step.js)
 
 Handlers will be passed the associated object as the first argument.
 Handlers can be synchronous, return a promise, accept an additional callback argument, or use generators.


### PR DESCRIPTION
Hi,

Was trying to use the event handlers in cucumber but the links didn't work after the documentation refactor. Procrastinating made this pull request for you.

Hope it helps.

Oli