### PR TITLE
Trim paths from @rerun files

### DIFF
--- a/features/rerun_formatter.feature
+++ b/features/rerun_formatter.feature
@@ -85,3 +85,21 @@ Feature: Rerun Formatter
       | A - ambiguous |
       | B - pending   |
       | C - undefined |
+
+  Scenario: rerun file with trailing new line
+    Given a file named "@rerun.txt" with:
+      """
+      features/c.feature:2
+
+      """
+    When I run cucumber.js with `-f json @rerun.txt`
+    Then the exit status should be 0
+    And the json output has the scenarios with names
+      | NAME          |
+      | C - passing   |
+
+  Scenario: empty rerun file
+    Given an empty file named "@rerun.txt"
+    When I run cucumber.js with `-f json @rerun.txt`
+    Then the exit status should be 0
+    And the json output has no scenarios

--- a/features/step_definitions/file_steps.js
+++ b/features/step_definitions/file_steps.js
@@ -12,6 +12,11 @@ var cliSteps = function cliSteps() {
     fsExtra.outputFile(absoluteFilePath, fileContent, callback);
   });
 
+  this.Given(/^an empty file named "(.*)"$/, function(filePath, callback) {
+    var absoluteFilePath = path.join(this.tmpDir, filePath);
+    fsExtra.outputFile(absoluteFilePath, '', callback);
+  });
+
   this.Given(/^a directory named "(.*)"$/, function(filePath, callback) {
     var absoluteFilePath = path.join(this.tmpDir, filePath);
     fsExtra.mkdirp(absoluteFilePath, callback);

--- a/features/step_definitions/json_output_steps.js
+++ b/features/step_definitions/json_output_steps.js
@@ -198,6 +198,19 @@ var jsonOutputSteps = function jsonOutputSteps() {
     });
     assert.deepEqual(expectedNames, actualNames);
   });
+  
+  this.Then(/^the json output has no scenarios$/, function () {
+    var features = JSON.parse(this.lastRun.stdout);
+    var hasScenario = false;
+    features.forEach(function(feature) {
+      feature.elements.forEach(function(element){
+        if (element.type === 'scenario') {
+          hasScenario = true;
+        }
+      });
+    });
+    assert.equal(false, hasScenario);
+  });
 
   this.Then(/^the json output's first scenario has the description "([^"]*)"$/, function (description) {
     var features = JSON.parse(this.lastRun.stdout);

--- a/lib/cucumber/cli/configuration.js
+++ b/lib/cucumber/cli/configuration.js
@@ -11,7 +11,8 @@ function Configuration(options, args) {
       var filename = path.basename(arg);
       if (filename[0] === '@') {
         var content = fs.readFileSync(arg, 'utf8');
-        unexpandedFeaturePaths = unexpandedFeaturePaths.concat(content.split('\n'));
+        var paths = _.chain(content).split('\n').map(_.trim).compact().value();
+        unexpandedFeaturePaths = unexpandedFeaturePaths.concat(paths);
       } else {
         unexpandedFeaturePaths.push(arg);
       }


### PR DESCRIPTION
Fixes #657. This prevents all the tests from running when there is a trailing newline in the rerun file.
