### PR TITLE
All multiple `:`s to appear in --compiler statement

### DIFF
--- a/src/cli/configuration_builder.js
+++ b/src/cli/configuration_builder.js
@@ -103,9 +103,9 @@ export default class ConfigurationBuilder {
   async expandSupportCodePaths(supportCodePaths) {
     const extensions = ['js']
     this.options.compiler.forEach((compiler) => {
-      const parts = compiler.split(':')
-      extensions.push(parts[0])
-      require(parts[1])
+      const [,extension, module] = compiler.match(/^([^:]+):(.+)$/)
+      extensions.push(extension)
+      require(module)
     })
     return await this.pathExpander.expandPathsWithExtensions(supportCodePaths, extensions)
   }


### PR DESCRIPTION
Need to specify an absolute path to a babel-register wrapper on windows. Multiple `:`s breaks everything, tries to require('C'), which obviously doesn't work :) 