### PR TITLE
Fix documentation for some markdown parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@
 #### Breaking Changes
 
 * update support code library interface - instead of exporting a function and calling methods on `this`, require the `cucumber` module and call `defineSupportCode` which passes an object as the first argument whch exposes the methods. Overriding the world constructor has changed from overriding the World property to calling `setWorldConstructor`.
-    ```js
+
+    ```javascript
     // 1.3.1
     module.exports = function () {
       this.Given(/^a step$/, function() {});
@@ -114,7 +115,8 @@
 * Support Files
   * Attachments
     * The `attach` function used for adding attachments moved from the API scenario object to world. It is thus now available in step definitions without saving a reference to the scenario.
-        ```js
+
+        ```javascript
         // 1.3.0
         this.After(function(scenario, callback) {
           scenario.attach(new Buffer([137, 80, 78, 71]), 'image/png')
@@ -125,18 +127,22 @@
           this.attach(new Buffer([137, 80, 78, 71]), 'image/png');
         });
         ```
+
     * When attaching buffers or strings, the callback argument is ignored.
   * Hooks
     * Hooks now receive a [ScenarioResult](/src/models/scenario_result.js) instead of the Scenario
-        ```js
+
+        ```javascript
         // 1.3.0
         this.After(function(scenario) {});
 
         // 2.0.0
         this.After(function(scenarioResult) {});
         ```
+
     * The `tags` option for hook should now be a string instead of an array and uses [cucumber-tag-expressions](https://docs.cucumber.io/tag-expressions/)
-        ```js
+
+        ```javascript
         // 1.3.0
         this.Before({tags: ["@foo"]}, function (scenario) {})
         this.Before({tags: ["@foo,@bar"]}, function (scenario) {})
@@ -147,6 +153,7 @@
         this.Before({tags: "@foo and @bar"}, function (scenario) {})
         this.Before({tags: "@foo or @bar"}, function (scenario) {})
         ```
+
   * Step Definitions
     * String patterns were removed in favor [cucumber-expressions](https://docs.cucumber.io/cucumber-expressions/)
     * Regular Expressions

--- a/docs/support_files/api_reference.md
+++ b/docs/support_files/api_reference.md
@@ -15,7 +15,8 @@ Add a new transform to convert a capture group into something else.
 * `typeName`: string used to refer to this type in cucumber expressions
 
 The built in transforms are:
-```js
+
+```javascript
 // Float
 {
   captureGroupRegexps: ['-?\\d*\\.?\\d+'],
@@ -113,7 +114,8 @@ Set a function used to wrap step / hook definitions. When used, the result is wr
 #### `setWorldConstructor(constructor)`
 
 Set a custom world constructor, to override the default world constructor:
-```js
+
+```javascript
 function World({attach, parameters}) {
   attach = attach
   parameters = parameters

--- a/docs/support_files/attachments.md
+++ b/docs/support_files/attachments.md
@@ -4,7 +4,7 @@ Text, images and files can be added to the output of the JSON formatter with att
 The world constructor is passed an `attach` function,
 which the default world constructor assigns to `this.attach`.
 
-``` javascript
+```javascript
 var {defineSupportCode} = require('cucumber');
 
 defineSupportCode(function({After}) {
@@ -17,7 +17,7 @@ defineSupportCode(function({After}) {
 By default, text is saved with a MIME type of `text/plain`.  You can also specify
 a different MIME type:
 
-``` javascript
+```javascript
 var {defineSupportCode} = require('cucumber');
 
 defineSupportCode(function({After}) {
@@ -31,7 +31,7 @@ Images and other binary data can be attached using a [stream.Readable](https://n
 The data will be `base64` encoded in the output.
 You should wait for the stream to be read before continuing by providing a callback or waiting for the returned promise to resolve.
 
-``` javascript
+```javascript
 var {defineSupportCode} = require('cucumber');
 
 defineSupportCode(function({After}) {
@@ -59,7 +59,7 @@ defineSupportCode(function({After}) {
 Images and binary data can also be attached using a [Buffer](https://nodejs.org/api/buffer.html).
 The data will be `base64` encoded in the output.
 
-``` javascript
+```javascript
 var {defineSupportCode} = require('cucumber');
 
 defineSupportCode(function({After}) {
@@ -75,7 +75,7 @@ defineSupportCode(function({After}) {
 Here is an example of saving a screenshot using [Selenium WebDriver](https://www.npmjs.com/package/selenium-webdriver)
 when a scenario fails:
 
-``` javascript
+```javascript
 var {defineSupportCode} = require('cucumber');
 
 defineSupportCode(function({After}) {

--- a/docs/support_files/hooks.md
+++ b/docs/support_files/hooks.md
@@ -36,7 +36,7 @@ defineSupportCode(function({After, Before}) {
 
 Hooks can be conditionally selected for execution based on the tags of the scenario.
 
-``` javascript
+```javascript
 var {defineSupportCode} = require('cucumber');
 
 defineSupportCode(function({After, Before}) {

--- a/docs/support_files/timeouts.md
+++ b/docs/support_files/timeouts.md
@@ -3,7 +3,7 @@
 By default, asynchronous hooks and steps timeout after 5000 milliseconds.
 This can be modified globally with:
 
-```js
+```javascript
 var {defineSupportCode} = require('cucumber');
 
 defineSupportCode(function({setDefaultTimeout}) {
@@ -13,7 +13,7 @@ defineSupportCode(function({setDefaultTimeout}) {
 
 A specific hook's or step's timeout can be set with:
 
-```js
+```javascript
 var {defineSupportCode} = require('cucumber');
 
 defineSupportCode(function({Before, Given}) {
@@ -35,7 +35,7 @@ Disable timeouts by setting it to -1.
 If you use this, you need to implement your own timeout protection.
 Otherwise the test suite may end prematurely or hang indefinitely.
 
-```js
+```javascript
 var {defineSupportCode} = require('cucumber');
 var Promise = require('bluebird');
 

--- a/docs/support_files/world.md
+++ b/docs/support_files/world.md
@@ -2,7 +2,8 @@
 
 *World* is an isolated context for each scenario, exposed to the hooks and steps as `this`.
 The default world constructor is:
-```js
+
+```javascript
 function World({attach, parameters}) {
   attach = attach
   parameters = parameters
@@ -10,6 +11,7 @@ function World({attach, parameters}) {
 ```
 
 The default can be overridden with `setWorldConstructor`.
+
 ```javascript
 var {defineSupportCode} = require('cucumber');
 var seleniumWebdriver = require('selenium-webdriver');


### PR DESCRIPTION
[MacDown](http://macdown.uranusjr.com), my favorite local markdown reader for *OSX* doesn't handle well block of code if not precedeed by an empty line. This PR fix that and uniform `'''js` to `'''javascript`