### PR TITLE
add DataTable#map() - variables in a vertical tbl

### DIFF
--- a/docs/support_files/data_table_interface.md
+++ b/docs/support_files/data_table_interface.md
@@ -8,5 +8,7 @@ When steps have a data table, they are passed an object with methods that can be
 - without column headers
   - `raw`: returns the table as a 2-D array
   - `rowsHash`: returns an object where each row corresponds to an entry (first column is the key, second column is the value)
-
+  - `typedRowsHash`: returns an object where each row corresponds to an entry (first column is the key, second column is data-type, last is the value)
+     For supported DataTypes - look for `const types` at /src/models/step_arguments/data_table.js.
+  
 See this [feature](/features/data_tables.feature) for examples

--- a/docs/support_files/data_table_interface.md
+++ b/docs/support_files/data_table_interface.md
@@ -9,6 +9,6 @@ When steps have a data table, they are passed an object with methods that can be
   - `raw`: returns the table as a 2-D array
   - `rowsHash`: returns an object where each row corresponds to an entry (first column is the key, second column is the value)
   - `typedRowsHash`: returns an object where each row corresponds to an entry (first column is the key, second column is data-type, last is the value)
-     For supported DataTypes - look for `const types` at /src/models/step_arguments/data_table.js.
+     For supported DataTypes - look for `const types` at [src/models/step_arguments/data_table.js](../../src/models/step_arguments/data_table.js).
   
 See this [feature](/features/data_tables.feature) for examples

--- a/features/data_tables.feature
+++ b/features/data_tables.feature
@@ -110,7 +110,7 @@ Feature: Data Tables
             'OK': true,
             'Best For': ['bdd','ci','cd'],
             'Typed Since': new Date('2017-02-05'),
-            'compound': {name:'joe'}
+            'compound': {name:'Joe'}
           }
           assert.deepEqual(table.typedRowsHash(), expected)
         })

--- a/features/data_tables.feature
+++ b/features/data_tables.feature
@@ -84,6 +84,41 @@ Feature: Data Tables
     When I run cucumber.js
     Then it passes
 
+  Scenario: typedRowsHash
+    Given a file named "features/passing_steps.feature" with:
+      """
+      Feature: a feature
+        Scenario: a scenario
+          Given a table step
+            | Cucumber   | String | Cucumis sativus |
+            | Stars      | Number | 5               |
+            | OK         | Y/N    | Y               |
+            | Typed Since| Date   | 2017-02-05      |
+            | Best For   | list   | bdd,ci,cd       |
+            | compound   | JSON   | {"name":"Joe"}  |
+      """
+    Given a file named "features/step_definitions/passing_steps.js" with:
+      """
+      import {defineSupportCode} from 'cucumber'
+      import assert from 'assert'
+
+      defineSupportCode(({Given}) => {
+        Given(/^a table step$/, function(table) {
+          const expected = {
+            'Cucumber': 'Cucumis sativus',
+            'Stars': 5,
+            'OK: true,
+            'Best For': ['bdd','ci','cd']
+            'Typed Since': new Date('2017-02-05')
+            'compound': {name:'joe'}
+          }
+          assert.deepEqual(table.rowsHash(), expected)
+        })
+      })
+      """
+    When I run cucumber.js
+    Then it passes
+
   Scenario: hashes
     Given a file named "features/passing_steps.feature" with:
       """

--- a/features/data_tables.feature
+++ b/features/data_tables.feature
@@ -112,7 +112,7 @@ Feature: Data Tables
             'Typed Since': new Date('2017-02-05'),
             'compound': {name:'joe'}
           }
-          assert.deepEqual(table.rowsHash(), expected)
+          assert.deepEqual(table.typedRowsHash(), expected)
         })
       })
       """

--- a/features/data_tables.feature
+++ b/features/data_tables.feature
@@ -107,7 +107,7 @@ Feature: Data Tables
           const expected = {
             'Cucumber': 'Cucumis sativus',
             'Stars': 5,
-            'OK: true,
+            'OK': true,
             'Best For': ['bdd','ci','cd']
             'Typed Since': new Date('2017-02-05')
             'compound': {name:'joe'}

--- a/features/data_tables.feature
+++ b/features/data_tables.feature
@@ -108,8 +108,8 @@ Feature: Data Tables
             'Cucumber': 'Cucumis sativus',
             'Stars': 5,
             'OK': true,
-            'Best For': ['bdd','ci','cd']
-            'Typed Since': new Date('2017-02-05')
+            'Best For': ['bdd','ci','cd'],
+            'Typed Since': new Date('2017-02-05'),
             'compound': {name:'joe'}
           }
           assert.deepEqual(table.rowsHash(), expected)

--- a/src/models/step_arguments/data_table.js
+++ b/src/models/step_arguments/data_table.js
@@ -8,7 +8,6 @@ const date = (v) => new Date(v)
 
 const types = {
   'string':  asIs,
-  'str':     asIs,
   '':        asIs,
   'int':     parseInt,
   'integer': parseInt,

--- a/src/models/step_arguments/data_table.js
+++ b/src/models/step_arguments/data_table.js
@@ -1,5 +1,24 @@
 import _ from 'lodash'
 
+const truths = ["true", "TRUE", "True", "yes", "y", "1"];
+const trueFalse = v => !!~truths.indexOf(v);
+const asIs = v => v;
+
+const types = {
+  "string":  asIs,
+  "str":     asIs,
+  "number":  Number,
+  "int":     parseInt,
+  "integer": parseInt,
+  "double":  parseFloat,
+  "float":   parseFloat,
+  "bool":    trueFalse,
+  "boolean": trueFalse,
+  "y/n":     trueFalse,
+  "bit":     trueFalse,
+  "date":    Date
+};
+
 export default class DataTable {
   constructor(gherkinData) {
     this.rawTable = gherkinData.rows.map((row) => row.cells.map((cell) => cell.value))
@@ -29,5 +48,16 @@ export default class DataTable {
       throw new Error('rowsHash can only be called on a data table where all rows have exactly two columns')
     }
     return _.fromPairs(rows)
+  }
+
+  map() {
+    return this.rawTable.reduce( (h,r) => {
+          if (r.length == 1 ) r = r.concat(['bool', true])
+          if (r.length == 2 ) r = [r[0], "string", r[1]]
+          h[r[0] ] = (types[r[1].toLowerCase()] || asIs)(r[2])
+          return h
+      }, 
+      {}
+    )
   }
 }

--- a/src/models/step_arguments/data_table.js
+++ b/src/models/step_arguments/data_table.js
@@ -61,13 +61,13 @@ export default class DataTable {
       const pad = '             '.split('').join('                     ')
       const colPadder = () => {
         let colLen = 0
-        return v => {
+        return (v) => {
           colLen = Math.max(colLen, v.length)
           return {toString: () => (v + pad).substr(0, colLen)}
         }
       }
       const cols = [colPadder(), colPadder(), colPadder()]
-      return row => {
+      return (row) => {
         return cols.map( (padder, i) => padder( row[i] ) )
       }
     })()

--- a/src/models/step_arguments/data_table.js
+++ b/src/models/step_arguments/data_table.js
@@ -4,17 +4,17 @@ import Table from 'cli-table'
 const truths = ['true', 'yes', 'y', '1']
 const falses = ['false', 'no', 'n', '0']
 const trueFalse = (v) => {
-    const lower = v.toLowerCase()
-    if (~truths.indexOf(lower)) return true
-    if (~falses.indexOf(lower)) return false
-    throw new Error([
-      '\'' + v + '\' is not a legal boolean value.',
-      'Boolean values are case insensitive and may accept any of the following forms:',
-      ' - true/false',
-      ' - yes/no',
-      ' - y/n',
-      ' - 1/0'
-    ].join('\n'))
+  const lower = v.toLowerCase()
+  if (~truths.indexOf(lower)) return true
+  if (~falses.indexOf(lower)) return false
+  throw new Error([
+    '\'' + v + '\' is not a legal boolean value.',
+    'Boolean values are case insensitive and may accept any of the following forms:',
+    ' - true/false',
+    ' - yes/no',
+    ' - y/n',
+    ' - 1/0'
+  ].join('\n'))
 }
 const asIs = _.identity
 const list = (v) => v.split(',')

--- a/src/models/step_arguments/data_table.js
+++ b/src/models/step_arguments/data_table.js
@@ -1,10 +1,10 @@
 import _ from 'lodash'
 
 const truths = ['true', 'TRUE', 'True', 'yes', 'YES', 'Yes', 'y', 'Y', '1']
-const trueFalse = v => !!~truths.indexOf(v)
-const asIs = v => v
-const list = v => v.split(",")
-const date = v => new Date(v)
+const trueFalse = (v) => !!~truths.indexOf(v)
+const asIs = (v) => v
+const list = (v) => v.split(',')
+const date = (v) => new Date(v)
 
 const types = {
   'string':  asIs,
@@ -24,7 +24,7 @@ const types = {
   'array':   list,
   'list':    list,
   'json':    JSON.parse
-};
+}
 
 export default class DataTable {
   constructor(gherkinData) {
@@ -63,14 +63,14 @@ export default class DataTable {
     if (!everyRowHasThreeColumns) {
       throw new Error('typedRowsHash can only be called on a data table where all rows have exactly 3 columns')
     }
-    const unrecognizedTypes = rows.filter((row) => typeof types[row[1].toLowerCase()] != 'function')
+    const unrecognizedTypes = rows.filter((row) => typeof types[row[1].toLowerCase()] !== 'function')
     if (unrecognizedTypes.length) {
       throw new Error('typedRowsHash does not support type(s): [' + unrecognizedTypes + ']')
     }
     return this.rawTable.reduce( (h, r) => {
-          h[ r[0] ] = (types[r[1].toLowerCase()] || asIs)(r[2])
-          return h
-      }, 
+      h[ r[0] ] = (types[r[1].toLowerCase()] || asIs)(r[2])
+        return h
+      },
       {}
     )
   }

--- a/src/models/step_arguments/data_table.js
+++ b/src/models/step_arguments/data_table.js
@@ -76,7 +76,7 @@ export default class DataTable {
         chars: [
           'bottom', 'bottom-left', 'bottom-mid', 'bottom-right',
           'top', 'top-left', 'top-mid', 'top-right',
-          'left-mid', 'mid', 'mid-mid', 'right-mid',
+          'left-mid', 'mid', 'mid-mid', 'right-mid'
         ].reduce( (r,f) => {r[f] = ''; return r}, {left: '\t|', 'middle': '|', 'right' : '|'} )
       })
       rows.forEach( (row) => tbl.push(row) )

--- a/src/models/step_arguments/data_table.js
+++ b/src/models/step_arguments/data_table.js
@@ -1,8 +1,21 @@
 import _ from 'lodash'
 
-const truths = ['true', 'TRUE', 'True', 'yes', 'YES', 'Yes', 'y', 'Y', '1']
-const trueFalse = (v) => !!~truths.indexOf(v)
-const asIs = (v) => v
+const truths = ['true', 'yes', 'y', '1']
+const falses = ['false', 'no', 'n', '0']
+const trueFalse = (v) => {
+    const lower = v.toLowerCase()
+    if (~truths.indexOf(lower)) return true;
+    if (~falses.indexOf(lower)) return false;
+    throw new Error([
+      "'" + v + "' is not a legal boolean value.",
+      "Boolean values are case insensitive and may accept any of the following forms:",
+      " - true/false",
+      " - yes/no",
+      " - y/n",
+      " - 1/0"
+    ].join("\n"))
+}
+const asIs = _.identity
 const list = (v) => v.split(',')
 const date = (v) => new Date(v)
 

--- a/src/models/step_arguments/data_table.js
+++ b/src/models/step_arguments/data_table.js
@@ -57,14 +57,32 @@ export default class DataTable {
   }
 
   typedRowsHash() {
+    const erroredRowFormat = ( () => {
+        const pad = "             ".split("").join("                     ")
+        const colPadder = () => {
+          let colLen = 0
+          return v => {
+            colLen = Math.max(colLen, v.length)
+            return { toString: () => (v + pad).substr(0, colLen) }
+          }
+        }
+        const cols = [ colPadder(), colPadder(), colPadder() ]
+        return row => {
+            return cols.map( (pad, i) => pad( row[i] ) )
+        }
+    })()
     const rows = this.raw()
     const everyRowHasThreeColumns = _.every(rows, (row) => row.length === 3)
     if (!everyRowHasThreeColumns) {
-      throw new Error('typedRowsHash can only be called on a data table where all rows have exactly 3 columns')
+      throw new Error('typedRowsHash can only be used on a data table where all rows have exactly 3 columns')
     }
     const unrecognizedTypes = rows.filter((row) => typeof types[row[1].toLowerCase()] !== 'function')
     if (unrecognizedTypes.length) {
-      throw new Error('typedRowsHash does not support type(s): [' + unrecognizedTypes + ']')
+      throw new Error('typedRowsHash does not support type(s) in rows: \n\t| ' +
+        unrecognizedTypes.map(erroredRowFormat)
+          .map(row => row.join(" | ") )
+          .join(' |\n\t| ') + " |"
+      )
     }
     return this.rawTable.reduce( (h, r) => {
       h[ r[0] ] = (types[r[1].toLowerCase()] || asIs)(r[2])

--- a/src/models/step_arguments/data_table.js
+++ b/src/models/step_arguments/data_table.js
@@ -1,19 +1,20 @@
 import _ from 'lodash'
+import Table from 'cli-table'
 
 const truths = ['true', 'yes', 'y', '1']
 const falses = ['false', 'no', 'n', '0']
 const trueFalse = (v) => {
     const lower = v.toLowerCase()
-    if (~truths.indexOf(lower)) return true;
-    if (~falses.indexOf(lower)) return false;
+    if (~truths.indexOf(lower)) return true
+    if (~falses.indexOf(lower)) return false
     throw new Error([
-      "'" + v + "' is not a legal boolean value.",
-      "Boolean values are case insensitive and may accept any of the following forms:",
-      " - true/false",
-      " - yes/no",
-      " - y/n",
-      " - 1/0"
-    ].join("\n"))
+      '\'' + v + '\' is not a legal boolean value.',
+      'Boolean values are case insensitive and may accept any of the following forms:',
+      ' - true/false',
+      ' - yes/no',
+      ' - y/n',
+      ' - 1/0'
+    ].join('\n'))
 }
 const asIs = _.identity
 const list = (v) => v.split(',')

--- a/src/models/step_arguments/data_table.js
+++ b/src/models/step_arguments/data_table.js
@@ -19,10 +19,10 @@ const types = {
   'boolean': trueFalse,
   'y/n':     trueFalse,
   'bit':     trueFalse,
-  'date':    date,
+  date,
   'datetime':date,
   'array':   list,
-  'list':    list,
+  list,
   'json':    JSON.parse
 }
 
@@ -69,9 +69,7 @@ export default class DataTable {
     }
     return this.rawTable.reduce( (h, r) => {
       h[ r[0] ] = (types[r[1].toLowerCase()] || asIs)(r[2])
-        return h
-      },
-      {}
-    )
+      return h
+    }, {})
   }
 }

--- a/src/models/step_arguments/data_table.js
+++ b/src/models/step_arguments/data_table.js
@@ -58,18 +58,18 @@ export default class DataTable {
 
   typedRowsHash() {
     const erroredRowFormat = ( () => {
-        const pad = "             ".split("").join("                     ")
-        const colPadder = () => {
-          let colLen = 0
-          return v => {
-            colLen = Math.max(colLen, v.length)
-            return { toString: () => (v + pad).substr(0, colLen) }
-          }
+      const pad = '             '.split('').join('                     ')
+      const colPadder = () => {
+        let colLen = 0
+        return v => {
+          colLen = Math.max(colLen, v.length)
+          return {toString: () => (v + pad).substr(0, colLen)}
         }
-        const cols = [ colPadder(), colPadder(), colPadder() ]
-        return row => {
-            return cols.map( (pad, i) => pad( row[i] ) )
-        }
+      }
+      const cols = [colPadder(), colPadder(), colPadder()]
+      return row => {
+        return cols.map( (padder, i) => padder( row[i] ) )
+      }
     })()
     const rows = this.raw()
     const everyRowHasThreeColumns = _.every(rows, (row) => row.length === 3)
@@ -80,8 +80,8 @@ export default class DataTable {
     if (unrecognizedTypes.length) {
       throw new Error('typedRowsHash does not support type(s) in rows: \n\t| ' +
         unrecognizedTypes.map(erroredRowFormat)
-          .map(row => row.join(" | ") )
-          .join(' |\n\t| ') + " |"
+          .map((row) => row.join(' | '))
+          .join(' |\n\t| ') + ' |'
       )
     }
     return this.rawTable.reduce( (h, r) => {

--- a/src/models/step_arguments/data_table.js
+++ b/src/models/step_arguments/data_table.js
@@ -72,15 +72,15 @@ export default class DataTable {
 
   typedRowsHash() {
     const formatTypes = (rows) => {
-        const tbl = new Table( {
-          chars: [
-            'bottom', 'bottom-left', 'bottom-mid', 'bottom-right', 
-            'top', 'top-left', 'top-mid', 'top-right',
-            'left-mid', 'mid', 'mid-mid', 'right-mid', 
-          ].reduce( (r,f) => {r[f] = ''; return r}, {left: '\t|', 'middle': '|', 'right' : '|'} )
-        })
-        rows.forEach( (row) => tbl.push(row) )
-        return tbl.toString().replace(/\u001b\[[0-9]{2}m/g,'')
+      const tbl = new Table( {
+        chars: [
+          'bottom', 'bottom-left', 'bottom-mid', 'bottom-right',
+          'top', 'top-left', 'top-mid', 'top-right',
+          'left-mid', 'mid', 'mid-mid', 'right-mid',
+        ].reduce( (r,f) => {r[f] = ''; return r}, {left: '\t|', 'middle': '|', 'right' : '|'} )
+      })
+      rows.forEach( (row) => tbl.push(row) )
+      return tbl.toString().replace(/\u001b\[[0-9]{2}m/g,'')
     }
     const rows = this.raw()
     const everyRowHasThreeColumns = _.every(rows, (row) => row.length === 3)

--- a/src/models/step_arguments/data_table.js
+++ b/src/models/step_arguments/data_table.js
@@ -1,22 +1,29 @@
 import _ from 'lodash'
 
-const truths = ["true", "TRUE", "True", "yes", "y", "1"];
-const trueFalse = v => !!~truths.indexOf(v);
-const asIs = v => v;
+const truths = ['true', 'TRUE', 'True', 'yes', 'YES', 'Yes', 'y', 'Y', '1']
+const trueFalse = v => !!~truths.indexOf(v)
+const asIs = v => v
+const list = v => v.split(",")
+const date = v => new Date(v)
 
 const types = {
-  "string":  asIs,
-  "str":     asIs,
-  "number":  Number,
-  "int":     parseInt,
-  "integer": parseInt,
-  "double":  parseFloat,
-  "float":   parseFloat,
-  "bool":    trueFalse,
-  "boolean": trueFalse,
-  "y/n":     trueFalse,
-  "bit":     trueFalse,
-  "date":    Date
+  'string':  asIs,
+  'str':     asIs,
+  '':        asIs,
+  'int':     parseInt,
+  'integer': parseInt,
+  'double':  parseInt,
+  'float':   parseFloat,
+  'number':  parseFloat,
+  'bool':    trueFalse,
+  'boolean': trueFalse,
+  'y/n':     trueFalse,
+  'bit':     trueFalse,
+  'date':    date,
+  'datetime':date,
+  'array':   list,
+  'list':    list,
+  'json':    JSON.parse
 };
 
 export default class DataTable {
@@ -50,11 +57,18 @@ export default class DataTable {
     return _.fromPairs(rows)
   }
 
-  map() {
-    return this.rawTable.reduce( (h,r) => {
-          if (r.length == 1 ) r = r.concat(['bool', true])
-          if (r.length == 2 ) r = [r[0], "string", r[1]]
-          h[r[0] ] = (types[r[1].toLowerCase()] || asIs)(r[2])
+  typedRowsHash() {
+    const rows = this.raw()
+    const everyRowHasThreeColumns = _.every(rows, (row) => row.length === 3)
+    if (!everyRowHasThreeColumns) {
+      throw new Error('typedRowsHash can only be called on a data table where all rows have exactly 3 columns')
+    }
+    const unrecognizedTypes = rows.filter((row) => typeof types[row[1].toLowerCase()] != 'function')
+    if (unrecognizedTypes.length) {
+      throw new Error('typedRowsHash does not support type(s): [' + unrecognizedTypes + ']')
+    }
+    return this.rawTable.reduce( (h, r) => {
+          h[ r[0] ] = (types[r[1].toLowerCase()] || asIs)(r[2])
           return h
       }, 
       {}

--- a/src/models/step_arguments/data_table_spec.js
+++ b/src/models/step_arguments/data_table_spec.js
@@ -108,22 +108,22 @@ describe('DataTable', function () {
         ]
       })
 
-      let err;
+      let err
       try {
         dataTable.typedRowsHash()
       } catch (e) {
-        err = e;
+        err = e
       }
 
-      expect(err).to.exist;
+      expect(err).to.exist
       expect( err.message ).to.equal([
-        "typedRowsHash does not support type(s) in rows: ",
-        "\t" + "| key2 | OUPS       | some value |",
-	      "\t" + "| key3 | AYAYAYAYAY | value      |"
-      ].join("\n"))
+        'typedRowsHash does not support type(s) in rows: ',
+        '\t' + '| key2 | OUPS       | some value |',
+        '\t' + '| key3 | AYAYAYAYAY | value      |'
+      ].join('\n'))
     })
 
-    const toTableRow = (rawRow) => ({cells : rawRow.map((value) => ({value}))});
+    const toTableRow = (rawRow) => ({cells : rawRow.map((value) => ({value}))})
 
     it('reads value as string when no type is given', function() {
       const dataTable = new DataTable({
@@ -224,24 +224,24 @@ describe('DataTable', function () {
           ['k13', 'bool',    'no'],
           ['k16', 'bool',    'maybe']
         ].map(toTableRow)
-      });
+      })
 
-      let err;
+      let err
       try {
         dataTable.typedRowsHash()
-      } catch(e) { 
+      } catch(e) {
         err = e
       }
 
-      expect(err).to.exist;
+      expect(err).to.exist
       expect( err.message ).to.equal([
-        "'maybe' is not a legal boolean value.",
-        "Boolean values are case insensitive and may accept any of the following forms:",
-        " - true/false",
-        " - yes/no",
-        " - y/n",
-        " - 1/0"
-      ].join("\n"))
+        ''maybe' is not a legal boolean value.',
+        'Boolean values are case insensitive and may accept any of the following forms:',
+        ' - true/false',
+        ' - yes/no',
+        ' - y/n',
+        ' - 1/0'
+      ].join('\n'))
     })
 
     it('accepts lists, lets user communicate with non-tech PO anyhow they like, type column is case insensitive', function() {
@@ -268,9 +268,9 @@ describe('DataTable', function () {
     it('accepts JSON, type column is case insensitive', function() {
       const dataTable = new DataTable({
         rows: [
-          ['k20', 'JSON', '["a",1,true]'],
-          ['k21', 'Json', '"a string"'],
-          ['k22', 'json', '{"answer":42}']
+          ['k20', 'JSON', '['a',1,true]'],
+          ['k21', 'Json', ''a string''],
+          ['k22', 'json', '{'answer':42}']
         ].map(toTableRow)
       })
       expect(dataTable.typedRowsHash()).to.deep.equal({

--- a/src/models/step_arguments/data_table_spec.js
+++ b/src/models/step_arguments/data_table_spec.js
@@ -114,7 +114,7 @@ describe('DataTable', function () {
         expect(err.message).to.match(/typedRowsHash does not support type\(s\) in rows/)
         const rows = err.message.split(/\n/).slice(1)
         expect(rows.length).to.eql(2) //formatted row per rejected row
-        expect(rows[0].length).to.eql(rows[1].length) //formatted
+        expect(rows[0].length).to.eql(rows[1].length) //formatted awsomely
         return
       }
       throw new Error('did not throw error for unrecognized type');

--- a/src/models/step_arguments/data_table_spec.js
+++ b/src/models/step_arguments/data_table_spec.js
@@ -117,7 +117,7 @@ describe('DataTable', function () {
         expect(rows[0].length).to.eql(rows[1].length) //formatted awsomely
         return
       }
-      throw new Error('did not throw error for unrecognized type');
+      throw new Error('did not throw error for unrecognized type')
     })
 
     it('reads value as string when no type is given', function() {
@@ -145,9 +145,9 @@ describe('DataTable', function () {
         k1 : 'value',
         k2 : 'value',
         k3 : 'value'
-      })        
+      })
     })
-    
+
     it('accept numbers, lets user\'s PO document a concrete type (although JS does not care), type column is case insensitive', function() {
       const dataTable = new DataTable({
         rows: [
@@ -183,13 +183,13 @@ describe('DataTable', function () {
         k92: 4.2,
         k00: 0.42,
         k01: 0.42,
-        k02: 0.42,
-      })        
-    })    
-    
+        k02: 0.42
+      })
+    })
+
     it('accepts boolean values, lets user use his non-tech PO\'s favorite jargone, type column is case insensitive', function() {
-       const dataTable = new DataTable({
-        rows: [
+      const dataTable = new DataTable({
+         rows: [
           ['k10', 'Bool'    , 'true'],
           ['k11', 'Boolean' , 'True'],
           ['k12', 'Y/N'     , 'Y'],
@@ -199,7 +199,7 @@ describe('DataTable', function () {
           ['k16', 'bool'    , 'n'],
           ['k17', 'bool'    , 'false']
         ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
-      })
+       })
       expect(dataTable.typedRowsHash()).to.deep.equal({
         k10: true,
         k11: true,
@@ -211,7 +211,7 @@ describe('DataTable', function () {
         k17: false
       })
     })
-    
+
     it('accepts lists, lets user communicate with non-tech PO anyhow they like, type column is case insensitive', function() {
       const dataTable = new DataTable({
         rows: [
@@ -246,8 +246,8 @@ describe('DataTable', function () {
         k21: 'a string',
         k22: {answer: 42}
       })
-    })    
-    
+    })
+
     it('handles dates correctly, lets user document concrete type (although JS does not care), column type is case insensitive', function () {
       const dataTable = new DataTable({
         rows: [

--- a/src/models/step_arguments/data_table_spec.js
+++ b/src/models/step_arguments/data_table_spec.js
@@ -54,13 +54,13 @@ describe('DataTable', function () {
               {value: 'string'},
               {value:  'value'}
             ]
-          } , {
+          }, {
             cells: [
               {value: 'key2'},
               {value: 'string'},
               {value: 'value'}
             ]
-          } , {
+          }, {
             cells: [
               {value: 'key3'},
               {value: 'value'}
@@ -86,19 +86,19 @@ describe('DataTable', function () {
               {value: 'string'},
               {value:  'value'}
             ]
-          } , {
+          }, {
             cells: [
               {value: 'key2'},
               {value: 'OUPS'}, //<--- 1st No such type
               {value: 'some value'}
             ]
-          } , {
+          }, {
             cells: [
               {value: 'key3'},
               {value: 'string'},
               {value: 'value'}
             ]
-          } , {
+          }, {
             cells: [
               {value: 'key3'},
               {value: 'AYAYAYAYAY'}, //<--- 2nd No such type
@@ -108,24 +108,29 @@ describe('DataTable', function () {
         ]
       })
 
+      let err;
       try {
         dataTable.typedRowsHash()
-      } catch (err) {
-        expect(err.message).to.match(/typedRowsHash does not support type\(s\) in rows/)
-        const rows = err.message.split(/\n/).slice(1)
-        expect(rows.length).to.eql(2) //formatted row per rejected row
-        expect(rows[0].length).to.eql(rows[1].length) //formatted awsomely
-        return
+      } catch (e) {
+        err = e;
       }
-      throw new Error('did not throw error for unrecognized type')
+
+      expect(err).to.exist;
+      expect( err.message ).to.equal([
+        "typedRowsHash does not support type(s) in rows: ",
+        "\t" + "| key2 | OUPS       | some value |",
+	      "\t" + "| key3 | AYAYAYAYAY | value      |"
+      ].join("\n"))
     })
+
+    const toTableRow = (rawRow) => ({cells : rawRow.map((value) => ({value}))});
 
     it('reads value as string when no type is given', function() {
       const dataTable = new DataTable({
         rows: [
-          ['k5' , ''        , 'some value'],
-          ['j5' , ''        , 'other value']
-        ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
+          ['k5', '', 'some value'],
+          ['j5', '', 'other value']
+        ].map(toTableRow)
       })
       expect(dataTable.typedRowsHash()).to.deep.equal({
         k5 : 'some value',
@@ -136,10 +141,10 @@ describe('DataTable', function () {
     it('accept strings, type column is case insensitive', function() {
       const dataTable = new DataTable({
         rows: [
-          ['k1' , 'string'  , 'value'],
-          ['k2' , 'String'  , 'value'],
-          ['k3' , 'STRING'  , 'value']
-        ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
+          ['k1', 'string', 'value'],
+          ['k2', 'String', 'value'],
+          ['k3', 'STRING', 'value']
+        ].map(toTableRow)
       })
       expect(dataTable.typedRowsHash()).to.deep.equal({
         k1 : 'value',
@@ -151,22 +156,22 @@ describe('DataTable', function () {
     it('accept numbers, lets user\'s PO document a concrete type (although JS does not care), type column is case insensitive', function() {
       const dataTable = new DataTable({
         rows: [
-          ['k60', 'int'     , '42'],
-          ['k61', 'Int'     , '42'],
-          ['k62', 'INT'     , '42'],
-          ['k70', 'Integer' , '42'],
-          ['k71', 'integer' , '42'],
-          ['k72', 'INTEGER' , '42'],
-          ['k80', 'double'  , '4.2'],
-          ['k81', 'Double'  , '4.2'],
-          ['k82', 'DOUBLE'  , '4.2'],
-          ['k90', 'float'   , '4.2'],
-          ['k91', 'Float'   , '4.2'],
-          ['k92', 'FLOAT'   , '4.2'],
-          ['k00', 'number'  , '0.42'],
-          ['k01', 'Number'  , '0.42'],
-          ['k02', 'NUMBER'  , '0.42']
-        ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
+          ['k60', 'int',      '42'],
+          ['k61', 'Int',      '42'],
+          ['k62', 'INT',      '42'],
+          ['k70', 'Integer',  '42'],
+          ['k71', 'integer',  '42'],
+          ['k72', 'INTEGER',  '42'],
+          ['k80', 'double',   '4.2'],
+          ['k81', 'Double',   '4.2'],
+          ['k82', 'DOUBLE',   '4.2'],
+          ['k90', 'float',    '4.2'],
+          ['k91', 'Float',    '4.2'],
+          ['k92', 'FLOAT',    '4.2'],
+          ['k00', 'number',   '0.42'],
+          ['k01', 'Number',   '0.42'],
+          ['k02', 'NUMBER',   '0.42']
+        ].map(toTableRow)
       })
       expect(dataTable.typedRowsHash()).to.deep.equal({
         k60: 42,
@@ -190,15 +195,15 @@ describe('DataTable', function () {
     it('accepts boolean values, lets user use his non-tech PO\'s favorite jargone, type column is case insensitive', function() {
       const dataTable = new DataTable({
         rows: [
-          ['k10', 'Bool'    , 'true'],
-          ['k11', 'Boolean' , 'True'],
-          ['k12', 'Y/N'     , 'Y'],
-          ['k13', 'y/n'     , 'y'],
-          ['k14', 'bit'     , '1'],
-          ['k15', 'BIT'     , 'TRUE'],
-          ['k16', 'bool'    , 'n'],
-          ['k17', 'bool'    , 'false']
-        ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
+          ['k10', 'Bool',    'true'],
+          ['k11', 'Boolean', 'True'],
+          ['k12', 'Y/N',     'Y'],
+          ['k13', 'y/n',     'y'],
+          ['k14', 'bit',     '1'],
+          ['k15', 'BIT',     'TRUE'],
+          ['k16', 'bool',    'n'],
+          ['k17', 'bool',    'false']
+        ].map(toTableRow)
       })
       expect(dataTable.typedRowsHash()).to.deep.equal({
         k10: true,
@@ -212,16 +217,43 @@ describe('DataTable', function () {
       })
     })
 
+    it('should reject boolean values that are not mapped to any of truths or a falses', function() {
+      const dataTable = new DataTable({
+        rows: [
+          ['k11', 'bool',    'yes'],
+          ['k13', 'bool',    'no'],
+          ['k16', 'bool',    'maybe']
+        ].map(toTableRow)
+      });
+
+      let err;
+      try {
+        dataTable.typedRowsHash()
+      } catch(e) { 
+        err = e
+      }
+
+      expect(err).to.exist;
+      expect( err.message ).to.equal([
+        "'maybe' is not a legal boolean value.",
+        "Boolean values are case insensitive and may accept any of the following forms:",
+        " - true/false",
+        " - yes/no",
+        " - y/n",
+        " - 1/0"
+      ].join("\n"))
+    })
+
     it('accepts lists, lets user communicate with non-tech PO anyhow they like, type column is case insensitive', function() {
       const dataTable = new DataTable({
         rows: [
-          ['k180', 'list'    , 'a,b,c'],
-          ['k181', 'List'    , 'a,b,c'],
-          ['k182', 'LIST'    , 'a,b,c'],
-          ['k190', 'array'   , '1,2,3'],
-          ['k191', 'Array'   , '1,2,3'],
-          ['k192', 'ARRAY'   , '1,2,3']
-        ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
+          ['k180', 'list',  'a,b,c'],
+          ['k181', 'List',  'a,b,c'],
+          ['k182', 'LIST',  'a,b,c'],
+          ['k190', 'array', '1,2,3'],
+          ['k191', 'Array', '1,2,3'],
+          ['k192', 'ARRAY', '1,2,3']
+        ].map(toTableRow)
       })
       expect(dataTable.typedRowsHash()).to.deep.equal({
         k180: ['a','b','c'],
@@ -236,10 +268,10 @@ describe('DataTable', function () {
     it('accepts JSON, type column is case insensitive', function() {
       const dataTable = new DataTable({
         rows: [
-          ['k20', 'JSON'    , '["a",1,true]'],
-          ['k21', 'Json'    , '"a string"'],
-          ['k22', 'json'    , '{"answer":42}']
-        ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
+          ['k20', 'JSON', '["a",1,true]'],
+          ['k21', 'Json', '"a string"'],
+          ['k22', 'json', '{"answer":42}']
+        ].map(toTableRow)
       })
       expect(dataTable.typedRowsHash()).to.deep.equal({
         k20: ['a',1,true],
@@ -257,7 +289,7 @@ describe('DataTable', function () {
               {value: 'Date'},
               {value:  '2017-02-03'}
             ]
-          } , {
+          }, {
             cells: [
               {value: 'key2'},
               {value: 'datetime'},

--- a/src/models/step_arguments/data_table_spec.js
+++ b/src/models/step_arguments/data_table_spec.js
@@ -43,33 +43,33 @@ describe('DataTable', function () {
       })
     })
   })
-  
+
   describe('typed hashes', function() {
     it('rejects tables where not all rows have 3 columns', function() {
-      const dataTable = new DataTable({ 
+      const dataTable = new DataTable({
         rows: [
           {
             cells: [
-              { value: 'key1'}, 
-              { value: 'string'},
-              { value:  'value'}
+              {value: 'key1'},
+              {value: 'string'},
+              {value:  'value'}
             ]
           } , {
             cells: [
-              { value: 'key2'}, 
-              { value: 'string'}, 
-              { value: 'value'}
+              {value: 'key2'}, 
+              {value: 'string'}, 
+              {value: 'value'}
             ]
           } , {
             cells: [
-              { value: 'key3'}, 
-              { value: 'value'}, 
+              {value: 'key3'}, 
+              {value: 'value'}, 
             ]
           }
         ]
-      });
+      })
       expect(() => {
-          dataTable.typedRowsHash()
+        dataTable.typedRowsHash()
       }).to.throw(Error)
     })
     
@@ -78,56 +78,56 @@ describe('DataTable', function () {
         rows: [
           {
             cells: [
-              { value: 'key1'}, 
-              { value: 'string'},
-              { value:  'value'}
+              {value: 'key1'},
+              {value: 'string'},
+              {value:  'value'}
             ]
           } , {
             cells: [
-              { value: 'key2'}, 
-              { value: 'OUPS'}, 
-              { value: 'value'}
+              {value: 'key2'},
+              {value: 'OUPS'},
+              {value: 'value'}
             ]
           } , {
             cells: [
-              { value: 'key3'}, 
-              { value: 'string'}, 
-              { value: 'value'}
+              {value: 'key3'},
+              {value: 'string'},
+              {value: 'value'}
             ]
           }
         ]
-      });
+      })
       expect(() => {
-          dataTable.typedRowsHash()
+        dataTable.typedRowsHash()
       }).to.throw(Error)
     })
-    
+
     it('accepts all supported types, case insensitive, no type given - is string', function() {
-      const dataTable = new DataTable({ 
+      const dataTable = new DataTable({
         rows: [
           ['k1' , 'string'  , 'value'],
           ['k2' , 'String'  , 'value'],
           ['k3' , 'str'     , 'value'],
           ['k4' , 'STR'     , 'value'],
           ['k5' , ''        , 'value'],
-          ['k6' , 'Int'     , '42'   ],
-          ['k7' , 'integer' , '42'   ],
-          ['k8' , 'double'  , '4.2'  ],
-          ['k9' , 'Float'   , '4.2'  ],
-          ['k9' , 'Number'  , '0.42' ],
-          ['k10', 'Bool'    , 'true' ],
-          ['k11', 'Boolean' , 'True' ],
-          ['k12', 'Y/N'     , 'Y'    ],
-          ['k13', 'y/n'     , 'y'    ],
-          ['k14', 'bit'     , '1'    ],
-          ['k15', 'BIT'     , 'TRUE' ],
-          ['k16', 'bool'    , 'n'    ],
+          ['k6' , 'Int'     , '42'],
+          ['k7' , 'integer' , '42'],
+          ['k8' , 'double'  , '4.2'],
+          ['k9' , 'Float'   , '4.2'],
+          ['k9' , 'Number'  , '0.42'],
+          ['k10', 'Bool'    , 'true'],
+          ['k11', 'Boolean' , 'True'],
+          ['k12', 'Y/N'     , 'Y'],
+          ['k13', 'y/n'     , 'y'],
+          ['k14', 'bit'     , '1'],
+          ['k15', 'BIT'     , 'TRUE'],
+          ['k16', 'bool'    , 'n'],
           ['k17', 'bool'    , 'false'],
           ['k18', 'list'    , 'a,b,c'],
           ['k19', 'Array'   , '1,2,3'],
-          ['k20', 'JSON'    , '["a",1,true]' ],
+          ['k20', 'JSON'    , '["a",1,true]'],
           ['k21', 'Json'    , '"a string"']
-        ].map( (rawRow) => ({ cells : rawRow.map(value => ({ value })) }) )
+        ].map( (rawRow) => ({cells : rawRow.map(value => ({ value }))}) )
       })
       expect(dataTable.typedRowsHash()).to.deep.equal( {
         k1 : 'value',
@@ -153,21 +153,21 @@ describe('DataTable', function () {
         k21: "a string"
       })
     })
-    
+
     it('handles dates correctly', function () {
       const dataTable = new DataTable({
         rows: [
           {
             cells: [
-              { value: 'key1'},
-              { value: 'Date'},
-              { value:  '2017-02-03'}
+              {value: 'key1'},
+              {value: 'Date'},
+              {value:  '2017-02-03'}
             ]
           } , {
             cells: [
-              { value: 'key2'},
-              { value: 'datetime'},
-              { value: '2017-02-03T12:50:10'}
+              {value: 'key2'},
+              {value: 'datetime'},
+              {value: '2017-02-03T12:50:10'}
             ]
           }
         ]

--- a/src/models/step_arguments/data_table_spec.js
+++ b/src/models/step_arguments/data_table_spec.js
@@ -68,9 +68,13 @@ describe('DataTable', function () {
           }
         ]
       })
-      expect(() => {
+      try {
         dataTable.typedRowsHash()
-      }).to.throw(Error)
+      } catch (err) {
+        expect(err.message).to.match(/typedRowsHash can only be used on a data table where all rows have exactly 3 columns/)
+        return
+      }
+      throw new Error('did not throw error for row that lacks columns')
     })
 
     it('rejects tables where not all types are recognized', function() {
@@ -85,8 +89,8 @@ describe('DataTable', function () {
           } , {
             cells: [
               {value: 'key2'},
-              {value: 'OUPS'},
-              {value: 'value'}
+              {value: 'OUPS'}, //<--- 1st No such type
+              {value: 'some value'}
             ]
           } , {
             cells: [
@@ -94,12 +98,26 @@ describe('DataTable', function () {
               {value: 'string'},
               {value: 'value'}
             ]
+          } , {
+            cells: [
+              {value: 'key3'},
+              {value: 'AYAYAYAYAY'}, //<--- 2nd No such type
+              {value: 'value'}
+            ]
           }
         ]
       })
-      expect(() => {
+
+      try {
         dataTable.typedRowsHash()
-      }).to.throw(Error)
+      } catch (err) {
+        expect(err.message).to.match(/typedRowsHash does not support type\(s\) in rows/)
+        const rows = err.message.split(/\n/).slice(1)
+        expect(rows.length).to.eql(2) //formatted row per rejected row
+        expect(rows[0].length).to.eql(rows[1].length) //formatted
+        return
+      }
+      throw new Error('did not throw error for unrecognized type');
     })
 
     it('reads value as string when no type is given', function() {

--- a/src/models/step_arguments/data_table_spec.js
+++ b/src/models/step_arguments/data_table_spec.js
@@ -189,7 +189,7 @@ describe('DataTable', function () {
 
     it('accepts boolean values, lets user use his non-tech PO\'s favorite jargone, type column is case insensitive', function() {
       const dataTable = new DataTable({
-         rows: [
+        rows: [
           ['k10', 'Bool'    , 'true'],
           ['k11', 'Boolean' , 'True'],
           ['k12', 'Y/N'     , 'Y'],
@@ -199,7 +199,7 @@ describe('DataTable', function () {
           ['k16', 'bool'    , 'n'],
           ['k17', 'bool'    , 'false']
         ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
-       })
+      })
       expect(dataTable.typedRowsHash()).to.deep.equal({
         k10: true,
         k11: true,

--- a/src/models/step_arguments/data_table_spec.js
+++ b/src/models/step_arguments/data_table_spec.js
@@ -268,9 +268,9 @@ describe('DataTable', function () {
     it('accepts JSON, type column is case insensitive', function() {
       const dataTable = new DataTable({
         rows: [
-          ['k20', 'JSON', '['a',1,true]'],
-          ['k21', 'Json', ''a string''],
-          ['k22', 'json', '{'answer':42}']
+          ['k20', 'JSON', '["a",1,true]'],
+          ['k21', 'Json', '"a string"'],
+          ['k22', 'json', '{"answer":42}']
         ].map(toTableRow)
       })
       expect(dataTable.typedRowsHash()).to.deep.equal({

--- a/src/models/step_arguments/data_table_spec.js
+++ b/src/models/step_arguments/data_table_spec.js
@@ -43,6 +43,141 @@ describe('DataTable', function () {
       })
     })
   })
+  
+  describe('typed hashes', function() {
+    it('rejects tables where not all rows have 3 columns', function() {
+      const dataTable = new DataTable({ 
+        rows: [
+          {
+            cells: [
+              { value: 'key1'}, 
+              { value: 'string'},
+              { value:  'value'}
+            ]
+          } , {
+            cells: [
+              { value: 'key2'}, 
+              { value: 'string'}, 
+              { value: 'value'}
+            ]
+          } , {
+            cells: [
+              { value: 'key3'}, 
+              { value: 'value'}, 
+            ]
+          }
+        ]
+      });
+      expect(() => {
+          dataTable.typedRowsHash()
+      }).to.throw(Error)
+    })
+    
+    it('rejects tables where not all types are recognized', function() {
+      const dataTable = new DataTable({ 
+        rows: [
+          {
+            cells: [
+              { value: 'key1'}, 
+              { value: 'string'},
+              { value:  'value'}
+            ]
+          } , {
+            cells: [
+              { value: 'key2'}, 
+              { value: 'OUPS'}, 
+              { value: 'value'}
+            ]
+          } , {
+            cells: [
+              { value: 'key3'}, 
+              { value: 'string'}, 
+              { value: 'value'}
+            ]
+          }
+        ]
+      });
+      expect(() => {
+          dataTable.typedRowsHash()
+      }).to.throw(Error)
+    })
+    
+    it('accepts all supported types, case insensitive, no type given - is string', function() {
+      const dataTable = new DataTable({ 
+        rows: [
+          ['k1' , 'string'  , 'value'],
+          ['k2' , 'String'  , 'value'],
+          ['k3' , 'str'     , 'value'],
+          ['k4' , 'STR'     , 'value'],
+          ['k5' , ''        , 'value'],
+          ['k6' , 'Int'     , '42'   ],
+          ['k7' , 'integer' , '42'   ],
+          ['k8' , 'double'  , '4.2'  ],
+          ['k9' , 'Float'   , '4.2'  ],
+          ['k9' , 'Number'  , '0.42' ],
+          ['k10', 'Bool'    , 'true' ],
+          ['k11', 'Boolean' , 'True' ],
+          ['k12', 'Y/N'     , 'Y'    ],
+          ['k13', 'y/n'     , 'y'    ],
+          ['k14', 'bit'     , '1'    ],
+          ['k15', 'BIT'     , 'TRUE' ],
+          ['k16', 'bool'    , 'n'    ],
+          ['k17', 'bool'    , 'false'],
+          ['k18', 'list'    , 'a,b,c'],
+          ['k19', 'Array'   , '1,2,3'],
+          ['k20', 'JSON'    , '["a",1,true]' ],
+          ['k21', 'Json'    , '"a string"']
+        ].map( (rawRow) => ({ cells : rawRow.map(value => ({ value })) }) )
+      })
+      expect(dataTable.typedRowsHash()).to.deep.equal( {
+        k1 : 'value',
+        k2 : 'value',
+        k3 : 'value',
+        k4 : 'value',
+        k5 : 'value',
+        k6 : 42,
+        k7 : 42,
+        k8 : 4,
+        k9 : 0.42,
+        k10: true,
+        k11: true,
+        k12: true,
+        k13: true,
+        k14: true,
+        k15: true,
+        k16: false,
+        k17: false,
+        k18: ['a','b','c'],
+        k19: ['1','2','3'],
+        k20: ['a',1,true],
+        k21: "a string"
+      })
+    })
+    
+    it('handles dates correctly', function () {
+      const dataTable = new DataTable({
+        rows: [
+          {
+            cells: [
+              { value: 'key1'},
+              { value: 'Date'},
+              { value:  '2017-02-03'}
+            ]
+          } , {
+            cells: [
+              { value: 'key2'},
+              { value: 'datetime'},
+              { value: '2017-02-03T12:50:10'}
+            ]
+          }
+        ]
+      })
+      expect(dataTable.typedRowsHash()).to.deep.equal( {
+        key1 : new Date('2017-02-03'),
+        key2 : new Date('2017-02-03T12:50:10')
+      })
+    })
+  })
 
   describe('table without headers', function () {
     beforeEach(function () {

--- a/src/models/step_arguments/data_table_spec.js
+++ b/src/models/step_arguments/data_table_spec.js
@@ -56,14 +56,14 @@ describe('DataTable', function () {
             ]
           } , {
             cells: [
-              {value: 'key2'}, 
-              {value: 'string'}, 
+              {value: 'key2'},
+              {value: 'string'},
               {value: 'value'}
             ]
           } , {
             cells: [
-              {value: 'key3'}, 
-              {value: 'value'}, 
+              {value: 'key3'},
+              {value: 'value'}
             ]
           }
         ]
@@ -72,9 +72,9 @@ describe('DataTable', function () {
         dataTable.typedRowsHash()
       }).to.throw(Error)
     })
-    
+
     it('rejects tables where not all types are recognized', function() {
-      const dataTable = new DataTable({ 
+      const dataTable = new DataTable({
         rows: [
           {
             cells: [
@@ -127,7 +127,7 @@ describe('DataTable', function () {
           ['k19', 'Array'   , '1,2,3'],
           ['k20', 'JSON'    , '["a",1,true]'],
           ['k21', 'Json'    , '"a string"']
-        ].map( (rawRow) => ({cells : rawRow.map(value => ({ value }))}) )
+        ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
       })
       expect(dataTable.typedRowsHash()).to.deep.equal( {
         k1 : 'value',
@@ -150,7 +150,7 @@ describe('DataTable', function () {
         k18: ['a','b','c'],
         k19: ['1','2','3'],
         k20: ['a',1,true],
-        k21: "a string"
+        k21: 'a string'
       })
     })
 

--- a/src/models/step_arguments/data_table_spec.js
+++ b/src/models/step_arguments/data_table_spec.js
@@ -102,19 +102,76 @@ describe('DataTable', function () {
       }).to.throw(Error)
     })
 
-    it('accepts all supported types, case insensitive, no type given - is string', function() {
+    it('reads value as string when no type is given', function() {
+      const dataTable = new DataTable({
+        rows: [
+          ['k5' , ''        , 'some value'],
+          ['j5' , ''        , 'other value']
+        ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
+      })
+      expect(dataTable.typedRowsHash()).to.deep.equal({
+        k5 : 'some value',
+        j5 : 'other value'
+      })
+    })
+
+    it('accept strings, type column is case insensitive', function() {
       const dataTable = new DataTable({
         rows: [
           ['k1' , 'string'  , 'value'],
           ['k2' , 'String'  , 'value'],
-          ['k3' , 'str'     , 'value'],
-          ['k4' , 'STR'     , 'value'],
-          ['k5' , ''        , 'value'],
-          ['k6' , 'Int'     , '42'],
-          ['k7' , 'integer' , '42'],
-          ['k8' , 'double'  , '4.2'],
-          ['k9' , 'Float'   , '4.2'],
-          ['k9' , 'Number'  , '0.42'],
+          ['k3' , 'STRING'  , 'value']
+        ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
+      })
+      expect(dataTable.typedRowsHash()).to.deep.equal({
+        k1 : 'value',
+        k2 : 'value',
+        k3 : 'value'
+      })        
+    })
+    
+    it('accept numbers, lets user\'s PO document a concrete type (although JS does not care), type column is case insensitive', function() {
+      const dataTable = new DataTable({
+        rows: [
+          ['k60', 'int'     , '42'],
+          ['k61', 'Int'     , '42'],
+          ['k62', 'INT'     , '42'],
+          ['k70', 'Integer' , '42'],
+          ['k71', 'integer' , '42'],
+          ['k72', 'INTEGER' , '42'],
+          ['k80', 'double'  , '4.2'],
+          ['k81', 'Double'  , '4.2'],
+          ['k82', 'DOUBLE'  , '4.2'],
+          ['k90', 'float'   , '4.2'],
+          ['k91', 'Float'   , '4.2'],
+          ['k92', 'FLOAT'   , '4.2'],
+          ['k00', 'number'  , '0.42'],
+          ['k01', 'Number'  , '0.42'],
+          ['k02', 'NUMBER'  , '0.42']
+        ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
+      })
+      expect(dataTable.typedRowsHash()).to.deep.equal({
+        k60: 42,
+        k61: 42,
+        k62: 42,
+        k70: 42,
+        k71: 42,
+        k72: 42,
+        k80: 4,
+        k81: 4,
+        k82: 4,
+        k90: 4.2,
+        k91: 4.2,
+        k92: 4.2,
+        k00: 0.42,
+        k01: 0.42,
+        k02: 0.42,
+      })        
+    })    
+    
+    it('accepts boolean values, lets user use his non-tech PO\'s favorite jargone, type column is case insensitive', function() {
+       const dataTable = new DataTable({
+        rows: [
           ['k10', 'Bool'    , 'true'],
           ['k11', 'Boolean' , 'True'],
           ['k12', 'Y/N'     , 'Y'],
@@ -122,23 +179,10 @@ describe('DataTable', function () {
           ['k14', 'bit'     , '1'],
           ['k15', 'BIT'     , 'TRUE'],
           ['k16', 'bool'    , 'n'],
-          ['k17', 'bool'    , 'false'],
-          ['k18', 'list'    , 'a,b,c'],
-          ['k19', 'Array'   , '1,2,3'],
-          ['k20', 'JSON'    , '["a",1,true]'],
-          ['k21', 'Json'    , '"a string"']
+          ['k17', 'bool'    , 'false']
         ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
       })
-      expect(dataTable.typedRowsHash()).to.deep.equal( {
-        k1 : 'value',
-        k2 : 'value',
-        k3 : 'value',
-        k4 : 'value',
-        k5 : 'value',
-        k6 : 42,
-        k7 : 42,
-        k8 : 4,
-        k9 : 0.42,
+      expect(dataTable.typedRowsHash()).to.deep.equal({
         k10: true,
         k11: true,
         k12: true,
@@ -146,15 +190,47 @@ describe('DataTable', function () {
         k14: true,
         k15: true,
         k16: false,
-        k17: false,
-        k18: ['a','b','c'],
-        k19: ['1','2','3'],
-        k20: ['a',1,true],
-        k21: 'a string'
+        k17: false
+      })
+    })
+    
+    it('accepts lists, lets user communicate with non-tech PO anyhow they like, type column is case insensitive', function() {
+      const dataTable = new DataTable({
+        rows: [
+          ['k180', 'list'    , 'a,b,c'],
+          ['k181', 'List'    , 'a,b,c'],
+          ['k182', 'LIST'    , 'a,b,c'],
+          ['k190', 'array'   , '1,2,3'],
+          ['k191', 'Array'   , '1,2,3'],
+          ['k192', 'ARRAY'   , '1,2,3']
+        ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
+      })
+      expect(dataTable.typedRowsHash()).to.deep.equal({
+        k180: ['a','b','c'],
+        k181: ['a','b','c'],
+        k182: ['a','b','c'],
+        k190: ['1','2','3'],
+        k191: ['1','2','3'],
+        k192: ['1','2','3']
       })
     })
 
-    it('handles dates correctly', function () {
+    it('accepts JSON, type column is case insensitive', function() {
+      const dataTable = new DataTable({
+        rows: [
+          ['k20', 'JSON'    , '["a",1,true]'],
+          ['k21', 'Json'    , '"a string"'],
+          ['k22', 'json'    , '{"answer":42}']
+        ].map( (rawRow) => ({cells : rawRow.map((value) => ({value}))}) )
+      })
+      expect(dataTable.typedRowsHash()).to.deep.equal({
+        k20: ['a',1,true],
+        k21: 'a string',
+        k22: {answer: 42}
+      })
+    })    
+    
+    it('handles dates correctly, lets user document concrete type (although JS does not care), column type is case insensitive', function () {
       const dataTable = new DataTable({
         rows: [
           {

--- a/src/models/step_arguments/data_table_spec.js
+++ b/src/models/step_arguments/data_table_spec.js
@@ -235,7 +235,7 @@ describe('DataTable', function () {
 
       expect(err).to.exist
       expect( err.message ).to.equal([
-        ''maybe' is not a legal boolean value.',
+        '\'maybe\' is not a legal boolean value.',
         'Boolean values are case insensitive and may accept any of the following forms:',
         ' - true/false',
         ' - yes/no',


### PR DESCRIPTION
I'm editing online, will checkout the created clone to complete work shortly:
I still need to add tests and docs, but generally - it lets you describe variables in a vertical table.
supported format -  `key / type / value`.

example:
```
   Given an escaped prisoner:
     | name     | String | Monster Joe |
     | escapes  | Int    | 7           |
     | address  | String | Balfur 413  |
     | district | String | Sohoy       |
     | city     | String | London      |
     | caught   | Bool   | No          |
     | lastSeen | Date   | 1976-06-07  |
```

In step definition:
```
Given(/an escaped prisoner/g, function(dt, next) {
  const props = dt.map(); /* --> returns
    { 
      name:      "Monster Joe",
      escapes:   7,
      address:   "Balfur 413",
      district:  "Sohoy",
      city:      "London",
      caught:    false,
      lastSeen:  new Date("1976-06-07")
    }
  */
  this.prisoner = new Prisoner(props);
  next()
})
```

Will also work on a wider type support (Array, JSON, ...).
