### PR TITLE
Catch parameter transform errors

### DIFF
--- a/features/custom_parameter.feature
+++ b/features/custom_parameter.feature
@@ -9,61 +9,84 @@ Feature: Custom Parameter
       """
       Feature: a feature
         Scenario: a scenario
-          Given a passing step
+          Given a generic step
       """
 
   Scenario: custom parameter
-    Given a file named "features/step_definitions/passing_steps.js" with:
+    Given a file named "features/step_definitions/parameterized_steps.js" with:
       """
       import assert from 'assert'
       import {defineSupportCode} from 'cucumber'
       defineSupportCode(({Given, defineParameterType}) => {
         defineParameterType({
-          regexp: /passing|failing|undefined|pending/,
+          regexp: /generic|specific/,
           transformer: s => s.toUpperCase(),
           typeName: 'status'
         })
         Given('a {status} step', function(status) {
-          assert.equal(status, 'PASSING')
+          assert.equal(status, 'GENERIC')
         })
       })
       """
     When I run cucumber.js
-    Then the step "a passing step" has status "passed"
+    Then the step "a generic step" has status "passed"
 
   Scenario: custom parameter without transformer
-    Given a file named "features/step_definitions/passing_steps.js" with:
+    Given a file named "features/step_definitions/parameterized_steps.js" with:
       """
       import assert from 'assert'
       import {defineSupportCode} from 'cucumber'
       defineSupportCode(({Given, defineParameterType}) => {
         defineParameterType({
-          regexp: /passing|failing|undefined|pending/,
+          regexp: /generic|specific/,
           typeName: 'status'
         })
         Given('a {status} step', function(status) {
-          assert.equal(status, 'passing')
+          assert.equal(status, 'generic')
         })
       })
       """
     When I run cucumber.js
-    Then the step "a passing step" has status "passed"
+    Then the step "a generic step" has status "passed"
 
   Scenario: custom parameter (legacy API)
-    Given a file named "features/step_definitions/passing_steps.js" with:
+    Given a file named "features/step_definitions/parameterized_steps.js" with:
       """
       import assert from 'assert'
       import {defineSupportCode} from 'cucumber'
       defineSupportCode(({Given, addTransform}) => {
         addTransform({
-          captureGroupRegexps: /passing|failing|undefined|pending/,
+          captureGroupRegexps: /generic|specific/,
           transformer: s => s.toUpperCase(),
           typeName: 'status'
         })
         Given('a {status} step', function(status) {
-          assert.equal(status, 'PASSING')
+          assert.equal(status, 'GENERIC')
         })
       })
       """
     When I run cucumber.js
-    Then the step "a passing step" has status "passed"
+    Then the step "a generic step" has status "passed"
+
+  Scenario: custom transform throwing exception
+    Given a file named "features/step_definitions/parameterized_steps.js" with:
+      """
+      import assert from 'assert'
+      import {defineSupportCode} from 'cucumber'
+      defineSupportCode(({Given, defineParameterType}) => {
+        defineParameterType({
+          regexp: /generic|specific/,
+          transformer: s => { throw new Error(`the parameter transform of [${s}] failed`) },
+          typeName: 'status'
+        })
+        Given('a {status} step', function(status) {
+          throw new Error('should never get here')
+        })
+      })
+      """
+    When I run cucumber.js
+    Then it fails
+    And the step "a generic step" failed with:
+      """
+      the parameter transform of [generic] failed
+      """

--- a/src/runtime/step_runner.js
+++ b/src/runtime/step_runner.js
@@ -8,22 +8,27 @@ const {beginTiming, endTiming} = Time
 
 async function run({attachmentManager, defaultTimeout, scenarioResult, step, stepDefinition, parameterTypeRegistry, world}) {
   beginTiming()
-  const parameters = stepDefinition.getInvocationParameters({scenarioResult, step, parameterTypeRegistry})
-  const timeoutInMilliseconds = stepDefinition.options.timeout || defaultTimeout
-
   let error, result
-  const validCodeLengths = stepDefinition.getValidCodeLengths(parameters)
-  if (_.includes(validCodeLengths, stepDefinition.code.length)) {
-    const data = await UserCodeRunner.run({
-      argsArray: parameters,
-      fn: stepDefinition.code,
-      thisArg: world,
-      timeoutInMilliseconds
-    })
-    error = data.error
-    result = data.result
-  } else {
-    error = stepDefinition.getInvalidCodeLengthMessage(parameters)
+
+  try {
+    const parameters = stepDefinition.getInvocationParameters({scenarioResult, step, parameterTypeRegistry})
+    const timeoutInMilliseconds = stepDefinition.options.timeout || defaultTimeout
+
+    const validCodeLengths = stepDefinition.getValidCodeLengths(parameters)
+    if (_.includes(validCodeLengths, stepDefinition.code.length)) {
+      const data = await UserCodeRunner.run({
+        argsArray: parameters,
+        fn: stepDefinition.code,
+        thisArg: world,
+        timeoutInMilliseconds
+      })
+      error = data.error
+      result = data.result
+    } else {
+      error = stepDefinition.getInvalidCodeLengthMessage(parameters)
+    }
+  } catch(err) {
+    error = err
   }
 
   const attachments = attachmentManager.getAll()

--- a/src/runtime/step_runner.js
+++ b/src/runtime/step_runner.js
@@ -16,7 +16,7 @@ async function run({attachmentManager, defaultTimeout, scenarioResult, step, ste
     error = err
   }
 
-  if(!error) {
+  if (!error) {
     const timeoutInMilliseconds = stepDefinition.options.timeout || defaultTimeout
 
     const validCodeLengths = stepDefinition.getValidCodeLengths(parameters)

--- a/src/runtime/step_runner.js
+++ b/src/runtime/step_runner.js
@@ -8,10 +8,15 @@ const {beginTiming, endTiming} = Time
 
 async function run({attachmentManager, defaultTimeout, scenarioResult, step, stepDefinition, parameterTypeRegistry, world}) {
   beginTiming()
-  let error, result
+  let error, result, parameters
 
   try {
-    const parameters = stepDefinition.getInvocationParameters({scenarioResult, step, parameterTypeRegistry})
+    parameters = stepDefinition.getInvocationParameters({scenarioResult, step, parameterTypeRegistry})
+  } catch(err) {
+    error = err
+  }
+
+  if(!error) {
     const timeoutInMilliseconds = stepDefinition.options.timeout || defaultTimeout
 
     const validCodeLengths = stepDefinition.getValidCodeLengths(parameters)
@@ -27,8 +32,6 @@ async function run({attachmentManager, defaultTimeout, scenarioResult, step, ste
     } else {
       error = stepDefinition.getInvalidCodeLengthMessage(parameters)
     }
-  } catch(err) {
-    error = err
   }
 
   const attachments = attachmentManager.getAll()


### PR DESCRIPTION
This is a fix for #765. It depends on #764 and is branched off from the `cucumber-expressions-2.0.0` branch.