### PR TITLE
Resolve unhandled rejection in BeforeFeatures hook #797

### DIFF
--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -285,7 +285,7 @@ Feature: Environment Hooks
       module.exports = hooks;
       """
     When I run cucumber.js with `-f json`
-    Then the exit status should be 1
+    Then the exit status should be non-zero
     And the error output contains the text: 
       """
       features/support/hooks.js:2 Something bad

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -270,11 +270,15 @@ Feature: Environment Hooks
       """
     And a file named "features/support/hooks.js" with:
       """
-      var Promise = require('bluebird');
-      
       var hooks = function () {
         this.registerHandler('BeforeFeatures', function(){
-            return Promise.reject(new Error('Something bad'));
+          return {
+            then: function(resolve, reject){
+              setTimeout(function(){
+                reject(new Error('Something bad'))
+              });
+            }
+          };
         });
       };
 

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -284,7 +284,7 @@ Feature: Environment Hooks
     """
       features/support/hooks.js:2 Something bad
     """
-    And it does not outputs a valid JSON
+    And it does not output a valid JSON
 
   Scenario: Hooks still execute after a failure
     Given a file named "features/a.feature" with:

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -270,6 +270,8 @@ Feature: Environment Hooks
       """
     And a file named "features/support/hooks.js" with:
       """
+      var Promise = require('bluebird');
+      
       var hooks = function () {
         this.registerHandler('BeforeFeatures', function(){
             return Promise.reject(new Error('Something bad'));
@@ -281,17 +283,17 @@ Feature: Environment Hooks
     When I run cucumber.js with `-f json`
     Then the exit status should be 1
     And the error output contains the text: 
-    """
+      """
       features/support/hooks.js:2 Something bad
-    """
+      """
     And the output does not contain the text:
-    """
+      """
       is passing
-    """
+      """
     And the error output does not contain the text:
-    """
+      """
       is passing
-    """
+      """
     
 
   Scenario: Hooks still execute after a failure

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -264,7 +264,7 @@ Feature: Environment Hooks
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       var cucumberSteps = function() {
-        this.Given(/^This step is passing$/, function(callback) { callback(); });
+        this.Given(/^This step is passing$/, function(callback) { console.log('is passing'); callback(); });
       };
       module.exports = cucumberSteps;
       """
@@ -284,7 +284,15 @@ Feature: Environment Hooks
     """
       features/support/hooks.js:2 Something bad
     """
-    And it does not output a valid JSON
+    And the output does not contain the text:
+    """
+      is passing
+    """
+    And the error output does not contain the text:
+    """
+      is passing
+    """
+    
 
   Scenario: Hooks still execute after a failure
     Given a file named "features/a.feature" with:

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -63,16 +63,21 @@ var cliSteps = function cliSteps() {
                       getAdditionalErrorText(this.lastRun));
   });
 
-  this.Then(/^the (error )?output contains the text:$/, function(error, expectedOutput) {
+  this.Then(/^the (error )?output (does not)? ?contains? the text:$/, function(error, shouldFind, expectedOutput) {
+    var expectedToFind = !(shouldFind);
     var actualOutput = error ? this.lastRun.stderr : this.lastRun.stdout;
 
     actualOutput = normalizeText(actualOutput);
     expectedOutput = normalizeText(expectedOutput);
 
-    if (actualOutput.indexOf(expectedOutput) === -1)
-      throw new Error('Expected output to contain the following:\n' + expectedOutput + '\n' +
-                      'Got:\n' + actualOutput + '\n' +
-                      getAdditionalErrorText(this.lastRun));
+      if ((actualOutput.indexOf(expectedOutput) !== -1) !== expectedToFind) {
+          var errorPhrase = (expectedToFind) ? 'Expected output to contain the following:' : 'Expected output not to contain the following:';
+
+          throw new Error(errorPhrase + '\n' + expectedOutput + '\n' +
+              'Got:\n' + actualOutput + '\n' +
+              getAdditionalErrorText(this.lastRun));
+      }
+
   });
 
   this.Then(/^I see the version of Cucumber$/, function() {

--- a/features/step_definitions/json_output_steps.js
+++ b/features/step_definitions/json_output_steps.js
@@ -204,19 +204,6 @@ var jsonOutputSteps = function jsonOutputSteps() {
     assert.equal(features[0].elements[0].description.trim(), description);
   });
   
-  this.Then(/^it (does not)? ?outputs? a valid JSON$/, function(expected){
-    var expectedValid = (expected != 'does not');
-    var isValid = true;
-    try {
-        JSON.parse(this.lastRun.stdout);
-    } catch (e) {
-      isValid = false;
-    }
-      
-    
-    assert.equal(expectedValid, isValid);
-  });
-
 };
 
 module.exports = jsonOutputSteps;

--- a/features/step_definitions/json_output_steps.js
+++ b/features/step_definitions/json_output_steps.js
@@ -203,7 +203,7 @@ var jsonOutputSteps = function jsonOutputSteps() {
     var features = JSON.parse(this.lastRun.stdout);
     assert.equal(features[0].elements[0].description.trim(), description);
   });
-  
+
 };
 
 module.exports = jsonOutputSteps;

--- a/features/step_definitions/json_output_steps.js
+++ b/features/step_definitions/json_output_steps.js
@@ -203,6 +203,19 @@ var jsonOutputSteps = function jsonOutputSteps() {
     var features = JSON.parse(this.lastRun.stdout);
     assert.equal(features[0].elements[0].description.trim(), description);
   });
+  
+  this.Then(/^it (does not)? ?outputs? a valid JSON$/, function(expected){
+    var expectedValid = (expected != 'does not');
+    var isValid = true;
+    try {
+        JSON.parse(this.lastRun.stdout);
+    } catch (e) {
+      isValid = false;
+    }
+      
+    
+    assert.equal(expectedValid, isValid);
+  });
 
 };
 

--- a/lib/cucumber/runtime/event_broadcaster.js
+++ b/lib/cucumber/runtime/event_broadcaster.js
@@ -27,7 +27,7 @@ function EventBroadcaster(listeners, listenerDefaultTimeout) {
       Cucumber.Util.asyncForEach(listeners, function (listener, callback) {
         listener.hear(event, listenerDefaultTimeout, function(error) {
           if (error) {
-            throw error;
+            process.nextTick(function(){throw error;}) //prevents swallow by unhandled rejection
           }
           callback();
         });


### PR DESCRIPTION
This PR resolves https://github.com/cucumber/cucumber-js/issues/792.
Currently returning a rejected promise from the BeforeFeatures hook will cause the run to:
- Exit with code=0 (expected=1).
- Throw a node unhandled rejection error.