### PR TITLE
Convert step duration from ms to ns for JSON Formatter

### DIFF
--- a/src/formatter/json_formatter.js
+++ b/src/formatter/json_formatter.js
@@ -105,7 +105,8 @@ export default class JsonFormatter extends Formatter {
     }
 
     if (status === Status.PASSED || status === Status.FAILED) {
-      currentStep.result.duration = stepResult.duration
+      // Convert ms to ns
+      currentStep.result.duration = stepResult.duration * 1e6
     }
 
     if (_.size(stepResult.attachments) > 0) {

--- a/src/formatter/json_formatter_spec.js
+++ b/src/formatter/json_formatter_spec.js
@@ -131,7 +131,7 @@ describe('JsonFormatter', function () {
               name: 'A Step Name',
               result: {
                 status: 'passed',
-                duration: 1
+                duration: 1000000
               }
             }])
           })
@@ -150,7 +150,7 @@ describe('JsonFormatter', function () {
             expect(features[0].elements[0].steps[0].result).to.eql({
               status: 'failed',
               error_message: 'failure stack',
-              duration: 1
+              duration: 1000000
             })
           })
         })


### PR DESCRIPTION
Unless I miss something, the duration should not be in milliseconds in the JSON reporter but in nanoseconds. I checked and the Gherkin JSON report format uses nanoseconds. See:
- https://github.com/cucumber/gherkin2/blob/master/lib/gherkin/formatter/json_formatter.rb#L69

It could help on our side as our CI Cucumber reporter expect nanoseconds and not milliseconds.