### PR TITLE
latest doesn't pull 2.0.0-rc.9

### DIFF
--- a/docs/nodejs_example.md
+++ b/docs/nodejs_example.md
@@ -2,7 +2,7 @@
 
 * Install [Chrome](https://www.google.com/chrome/)
 * Install [Node.js](https://nodejs.org) (6 or higher)
-* Run `npm install --save-dev cucumber@latest selenium-webdriver@3.0.1 chromedriver@2.25.1`
+* Run `npm install --save-dev cucumber@2.0.0-rc.9 selenium-webdriver@3.0.1 chromedriver@2.25.1`
 * Add the following files
 
     ```gherkin


### PR DESCRIPTION
So I had to hardcode 2.0.0-rc.9 in order to make it work. Otherwise the following error is returned:

/Users/diegozuluaga/tools/git/cucumber.js-test/features/support/world.js:12
defineSupportCode(function({setWorldConstructor}) {
^

TypeError: defineSupportCode is not a function