### PR TITLE
Update to docs around CustomWorld({attach})

### DIFF
--- a/docs/nodejs_example.md
+++ b/docs/nodejs_example.md
@@ -28,7 +28,7 @@
     var seleniumWebdriver = require('selenium-webdriver');
     var {defineSupportCode} = require('cucumber');
 
-    function CustomWorld({attach}) {
+    function CustomWorld() {
       this.driver = new seleniumWebdriver.Builder()
         .forBrowser('chrome')
         .build();
@@ -46,16 +46,6 @@
     defineSupportCode(function({After}) {
       After(function() {
         return this.driver.quit();
-      });
-    
-      After(function (scenarioResult) {
-        var world = this;
-        if (scenarioResult.isFailed()) {
-          return world.driver.takeScreenshot().then(function(screenShot) {
-            // screenShot is a base-64 encoded PNG
-            world.attach(screenShot, 'image/png');
-          });
-        }
       });
     });
     ```

--- a/docs/nodejs_example.md
+++ b/docs/nodejs_example.md
@@ -28,7 +28,7 @@
     var seleniumWebdriver = require('selenium-webdriver');
     var {defineSupportCode} = require('cucumber');
 
-    function CustomWorld() {
+    function CustomWorld({attach}) {
       this.driver = new seleniumWebdriver.Builder()
         .forBrowser('chrome')
         .build();
@@ -46,6 +46,16 @@
     defineSupportCode(function({After}) {
       After(function() {
         return this.driver.quit();
+      });
+    
+      After(function (scenarioResult) {
+        var world = this;
+        if (scenarioResult.isFailed()) {
+          return world.driver.takeScreenshot().then(function(screenShot) {
+            // screenShot is a base-64 encoded PNG
+            world.attach(screenShot, 'image/png');
+          });
+        }
       });
     });
     ```

--- a/docs/support_files/attachments.md
+++ b/docs/support_files/attachments.md
@@ -90,3 +90,5 @@ defineSupportCode(function({After}) {
   });
 });
 ```
+
+**Note:** If you are using a custom instance of World ensure that you are explicitly passing in the attach function (see [world.md](https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/world.md)).

--- a/docs/support_files/world.md
+++ b/docs/support_files/world.md
@@ -37,6 +37,7 @@ If you want to be able to attach screenshots to the results file you will need t
 
 ```javascript
 function CustomWorld({attach}) {...}
+this.attach = attach;
 ```
 
 **Note:** The World constructor was made strictly synchronous in *[v0.8.0](https://github.com/cucumber/cucumber-js/releases/tag/v0.8.0)*.

--- a/docs/support_files/world.md
+++ b/docs/support_files/world.md
@@ -33,4 +33,10 @@ defineSupportCode(function({setWorldConstructor}) {
 });
 ```
 
+If you want to be able to attach screenshots to the results file you will need to pass in {attach} explicity to your CustomWorld.
+
+```javascript
+function CustomWorld({attach}) {...}
+```
+
 **Note:** The World constructor was made strictly synchronous in *[v0.8.0](https://github.com/cucumber/cucumber-js/releases/tag/v0.8.0)*.

--- a/docs/support_files/world.md
+++ b/docs/support_files/world.md
@@ -37,7 +37,7 @@ If you want to be able to attach screenshots to the results file you will need t
 
 ```javascript
 function CustomWorld({attach}) {...}
-this.attach = attach;
+  this.attach = attach;
 ```
 
 **Note:** The World constructor was made strictly synchronous in *[v0.8.0](https://github.com/cucumber/cucumber-js/releases/tag/v0.8.0)*.


### PR DESCRIPTION
I spent quite a while trying to figure out why I couldn't get the example code for attaching a screenshot to the results file to work, and finally found I needed to pass {attach} to the custom world I had set up.

Hopefully the comments I have added to these two files will help others get things working more quickly.