### PR TITLE
chore: Force lf line endings for js files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf


### PR DESCRIPTION
Force lf line endings for all js files. This is useful for windows users that configured their line-endings as `auto`.