### PR TITLE
WIP: feat(support-code): Import support code from `'cucumber'` directly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import SupportCodeFns from './support_code_fns'
+import * as helpers from './support_code_library/helpers'
 
 export {default as Cli} from './cli'
 export {default as FeatureParser} from './cli/feature_parser'
@@ -20,3 +21,20 @@ export {default as UsageJsonFormatter} from './formatter/usage_json_formatter'
 export const defineSupportCode = SupportCodeFns.add
 export const getSupportCodeFns = SupportCodeFns.get
 export const clearSupportCodeFns = SupportCodeFns.reset
+
+const cwd = process.cwd()
+const step = helpers.defineStepFactory(cwd)
+const hook = helpers.defineHookFactory(cwd)
+export const defineStep = (pattern, options, code) => {
+  SupportCodeFns.addStepDefinition(step(pattern, options, code))
+}
+export const given = defineStep
+export const when = defineStep
+export const then = defineStep
+export const before = (options, code) => {
+  SupportCodeFns.addBeforeHook(hook(options, code))
+}
+export const after = (options, code) => {
+  SupportCodeFns.addAfterHook(hook(options, code))
+}
+

--- a/src/support_code_fns.js
+++ b/src/support_code_fns.js
@@ -1,4 +1,7 @@
 let fns = []
+const beforeHooks = []
+const afterHooks = []
+const stepDefinitions = []
 
 export default {
   add(fn) {
@@ -11,5 +14,29 @@ export default {
 
   reset() {
     fns = []
+  },
+
+  addStepDefinition(stepDefinition) {
+    stepDefinitions.push(stepDefinition)
+  },
+
+  addBeforeHook(hookDefinition) {
+    beforeHooks.push(hookDefinition)
+  },
+
+  addAfterHook(hookDefinition) {
+    afterHooks.push(hookDefinition)
+  },
+
+  getStepDefinitions() {
+    return stepDefinitions
+  },
+
+  getAfterHooks() {
+    return afterHooks
+  },
+
+  getBeforeHooks() {
+    return beforeHooks
   }
 }

--- a/src/support_code_library/builder.js
+++ b/src/support_code_library/builder.js
@@ -3,14 +3,15 @@ import arity from 'util-arity'
 import isGenerator from 'is-generator'
 import path from 'path'
 import TransformLookupBuilder from './parameter_type_registry_builder'
+import SupportCodeFns from '../support_code_fns'
 import * as helpers from './helpers'
 function build({cwd, fns}) {
   const options = {
-    afterHookDefinitions: [],
-    beforeHookDefinitions: [],
+    afterHookDefinitions: [].concat(SupportCodeFns.getAfterHooks()),
+    beforeHookDefinitions: [].concat(SupportCodeFns.getBeforeHooks()),
     defaultTimeout: 5000,
     listeners: [],
-    stepDefinitions: [],
+    stepDefinitions: [].concat(SupportCodeFns.getStepDefinitions()),
     parameterTypeRegistry: TransformLookupBuilder.build(),
     World({attach, parameters}) {
       this.attach = attach
@@ -21,9 +22,9 @@ function build({cwd, fns}) {
   const fnArgument = {
     addTransform: helpers.addTransform(options.parameterTypeRegistry),
     defineParameterType: helpers.defineParameterType(options.parameterTypeRegistry),
-    After: helpers.defineHook(cwd, options.afterHookDefinitions),
-    Before: helpers.defineHook(cwd, options.beforeHookDefinitions),
-    defineStep: helpers.defineStep(cwd, options.stepDefinitions),
+    After: helpers.defineHookAndAddToCollection(cwd, options.afterHookDefinitions),
+    Before: helpers.defineHookAndAddToCollection(cwd, options.beforeHookDefinitions),
+    defineStep: helpers.defineStepAndAddToCollection(cwd, options.stepDefinitions),
     registerHandler: helpers.registerHandler(cwd, options.listeners),
     registerListener(listener) {
       options.listeners.push(listener)

--- a/src/support_code_library/helpers_spec.js
+++ b/src/support_code_library/helpers_spec.js
@@ -1,9 +1,9 @@
-import {defineHook, defineStep, registerHandler} from './helpers'
+import {defineHookAndAddToCollection, defineStepAndAddToCollection, registerHandler} from './helpers'
 
 describe('helpers', function () {
   describe('defineHook', function() {
     beforeEach(function() {
-      this.defineHook = defineHook('', [])
+      this.defineHook = defineHookAndAddToCollection('', [])
     })
 
     it('throws on invalid options/fn type', function() {
@@ -33,7 +33,7 @@ describe('helpers', function () {
 
   describe('defineStep', function() {
     beforeEach(function() {
-      this.defineStep = defineStep('', [])
+      this.defineStep = defineStepAndAddToCollection('', [])
     })
 
     it('throws on invalid pattern type', function() {


### PR DESCRIPTION
Make it possible to do this:

```javascript
const {given, when, then} = require('cucumber');
```

This is a work in progress.

I've hacked in the functionality without (hopefully) breaking the `const { defineSupportCode } = require('cucumber');` construct. However i think this solution gets a bit messy.
1. It can get complicated for an end user if you have multiple ways of doing things.
2. It gets complicated in the code, especially in the `support_code_fns.js` and `helpers.js`. 

If we drop the support for `defineSupportCode` we can cleanup the code further and simplify a lot of things INHO. For example, we can simplify the `support_code_libary/helpers.js`, `support_code_library/builder.js` and `support_code_fns.js`. 

Do you agree on this approach? It would mean rewriting the examples and test feature files.

Not: i haven't been able to run the features locally because of #826 

Fixes #770 