### PR TITLE
pass the step definition options to function wrapper

### DIFF
--- a/features/step_wrapper_with_options.feature
+++ b/features/step_wrapper_with_options.feature
@@ -15,9 +15,7 @@ Feature: Step Wrapper with Options
       import {defineSupportCode} from 'cucumber'
 
       defineSupportCode(({Then, When}) => {
-        When(/^I run a step with options$/, {wrapperOptions: {retry: 2}}, function () {
-        })
-
+        When(/^I run a step with options$/, {wrapperOptions: {retry: 2}}, function () {})
       })
       """
     And a file named "features/support/setup.js" with:
@@ -27,7 +25,7 @@ Feature: Step Wrapper with Options
       defineSupportCode(({setDefinitionFunctionWrapper}) => {
         setDefinitionFunctionWrapper(function (fn, options = {}) {
           if (options.retry) {
-            console.log("I can see that you want to retry the step at most", options.retry, "times");
+            console.log("Max retries: ", options.retry);
           }
           return fn;
         })
@@ -38,5 +36,5 @@ Feature: Step Wrapper with Options
     When I run cucumber-js
     Then the output contains the text:
       """
-      I can see that you want to retry the step at most 2 times
+      Max retries: 2
       """

--- a/features/step_wrapper_with_options.feature
+++ b/features/step_wrapper_with_options.feature
@@ -15,7 +15,7 @@ Feature: Step Wrapper with Options
       import {defineSupportCode} from 'cucumber'
 
       defineSupportCode(({Then, When}) => {
-        When(/^I run a step with options$/, {retry: 2}, function () {
+        When(/^I run a step with options$/, {wrapperOptions: {retry: 2}}, function () {
         })
 
       })

--- a/features/step_wrapper_with_options.feature
+++ b/features/step_wrapper_with_options.feature
@@ -1,0 +1,42 @@
+Feature: Step Wrapper with Options
+  In order to be able to write more complex step definition wrappers
+  As a developer
+  I want Cucumber to provide the "options" object to the wrapping function
+
+  Background:
+    Given a file named "features/a.feature" with:
+      """
+      Feature: Step with an option
+        Scenario: Steps
+          When I run a step with options
+      """
+    And a file named "features/step_definitions/cucumber_steps.js" with:
+      """
+      import {defineSupportCode} from 'cucumber'
+
+      defineSupportCode(({Then, When}) => {
+        When(/^I run a step with options$/, {retry: 2}, function () {
+        })
+
+      })
+      """
+    And a file named "features/support/setup.js" with:
+      """
+      import {defineSupportCode} from 'cucumber'
+
+      defineSupportCode(({setDefinitionFunctionWrapper}) => {
+        setDefinitionFunctionWrapper(function (fn, options = {}) {
+          if (options.retry) {
+            console.log("I can see that you want to retry the step at most", options.retry, "times");
+          }
+          return fn;
+        })
+      })
+      """
+
+  Scenario: options passed to the step definitions wrapper
+    When I run cucumber-js
+    Then the output contains the text:
+      """
+      I can see that you want to retry the step at most 2 times
+      """

--- a/src/support_code_library/builder.js
+++ b/src/support_code_library/builder.js
@@ -56,9 +56,7 @@ function wrapDefinitions({cwd, definitionFunctionWrapper, definitions}) {
   if (definitionFunctionWrapper) {
     definitions.forEach((definition) => {
       const codeLength = definition.code.length
-      const wrappedFn = definitionFunctionWrapper(
-        definition.code, definition.options && definition.options.wrapperOptions
-      )
+      const wrappedFn = definitionFunctionWrapper(definition.code, definition.options.wrapperOptions)
       if (wrappedFn !== definition.code) {
         definition.code = arity(codeLength, wrappedFn)
       }

--- a/src/support_code_library/builder.js
+++ b/src/support_code_library/builder.js
@@ -56,7 +56,9 @@ function wrapDefinitions({cwd, definitionFunctionWrapper, definitions}) {
   if (definitionFunctionWrapper) {
     definitions.forEach((definition) => {
       const codeLength = definition.code.length
-      const wrappedFn = definitionFunctionWrapper(definition.code, definition.options)
+      const wrappedFn = definitionFunctionWrapper(
+        definition.code, definition.options && definition.options.wrapperOptions
+      )
       if (wrappedFn !== definition.code) {
         definition.code = arity(codeLength, wrappedFn)
       }

--- a/src/support_code_library/builder.js
+++ b/src/support_code_library/builder.js
@@ -56,7 +56,7 @@ function wrapDefinitions({cwd, definitionFunctionWrapper, definitions}) {
   if (definitionFunctionWrapper) {
     definitions.forEach((definition) => {
       const codeLength = definition.code.length
-      const wrappedFn = definitionFunctionWrapper(definition.code)
+      const wrappedFn = definitionFunctionWrapper(definition.code, definition.options)
       if (wrappedFn !== definition.code) {
         definition.code = arity(codeLength, wrappedFn)
       }


### PR DESCRIPTION
It would be helpful to have the options available in the wrapper.
Then I can do something like this:

```javascript
defineSupportCode(function ({setDefinitionFunctionWrapper}) {
    setDefinitionFunctionWrapper(function (fn, options) {
        let retryTest = isFinite(options.retry) ? parseInt(options.retry, 10) : 0
        let wrappedFunction = isAsync(fn) || config.sync === false
            ? wrapStepAsync(fn, retryTest) : wrapStepSync(fn, retryTest)
        return wrappedFunction
    })
})
```

I'm currently writing a "wdio-cucumber2-framework" (which is a wrapper around cucumber 2 to allow webdriverio runner run cucumber tests), and this is the cleanest way for me to implement retrying (this is how it was done in wdio-cucumber-framework as well , with the options)

Please let me know what you think, I hope you don't feel like this is too much of a feature creep. :-) 

Thanks!