### PR TITLE
Spike functional API

### DIFF
--- a/features/stateless_stepdefs.feature
+++ b/features/stateless_stepdefs.feature
@@ -1,0 +1,37 @@
+Feature: Stateless step definitions
+
+  Scenario: simple
+    Given a file named "features/a.feature" with:
+      """
+      Feature: some feature
+        Scenario:
+          Given my number is 21
+          When my number is multiplied by 2
+          Then my number should be 42
+      """
+    And a file named "features/step_definitions/cucumber_steps.js" with:
+      """
+      import assert from 'assert'
+      import {initialize, fnGiven as Given, fnWhen as When, fnThen as Then} from 'cucumber'
+
+      const multiply =
+        async (multiplicand, multiplier) => multiplicand * multiplier
+
+      initialize(() => ({myNumber: null}))
+
+      Given(/^my number is (\d+)$/, (ctx, myNewNumber) =>
+        Object.assign({}, ctx, {myNumber: myNewNumber})
+      )
+
+      When(/^my number is multiplied by (\d+)$/, (ctx, multiplier) =>
+        Object.assign({}, ctx, {
+          myNumber: multiply(ctx.myNumber, multiplier)
+        })
+      )
+
+      Then(/^my number should be (\d+)$/, (ctx, expectedNumber) => {
+        assert.equal(ctx.myNumber, expectedNumber)
+      })
+      """
+    When I run cucumber-js
+    Then it passes

--- a/src/index.js
+++ b/src/index.js
@@ -39,3 +39,31 @@ export const setWorldConstructor = proxySupportCode('setWorldConstructor')
 export const Given = defineStep
 export const When = defineStep
 export const Then = defineStep
+
+// functional API
+
+const defineFnStep = (...args) => {
+  const fn = args.pop()
+
+  const wrapped = (..._args) => Promise.resolve(fn(this.ctx, ..._args))
+  const params = []
+  for (let i = 0; i < fn.length - 1; i = i + 1)
+    params.push(`p${i}`)
+  const def = new Function(...params, wrapped)
+
+  defineStep(...args, def)
+}
+
+export const initialize = (fn) => {
+  setWorldConstructor(class FnWorld {
+    async initialize() {
+      this.ctx = await Promise.resolve(fn())
+    }
+  })
+
+  Before(async function () { await this.initialize() })
+}
+
+export const fnGiven = defineFnStep
+export const fnWhen = defineFnStep
+export const fnThen = defineFnStep


### PR DESCRIPTION
This is a spike of a possible functional API for stepdefs (and hooks) (potential solution for #745). I didn't bother figuring out how to expose the helpers on a submodule (`cucumber/fn`), but that would be nicer than the `fn`-prefixed helpers.

The way I dealt with the number or arguments in stepdefs is quite ugly but was good enough to demonstrate the functional interface.

Thoughts?