### PR TITLE
Allow unknown CLI options

### DIFF
--- a/src/cli/argv_parser.js
+++ b/src/cli/argv_parser.js
@@ -40,6 +40,7 @@ export default class ArgvParser {
     program
       .usage('[options] [<DIR|FILE[:LINE]>...]')
       .version(version, '-v, --version')
+      .allowUnknownOption()
       .option('-b, --backtrace', 'show full backtrace for errors')
       .option(
         '--compiler <EXTENSION:MODULE>',


### PR DESCRIPTION
Commander by default throws an error when unexpected command-line option is present which is a problem when you try to pass additional arguments to the tests without specifying a 'command' but 'options' only, i.e. when using a profile.

For example the following works fine with `test/foo` and additional `--debug`:

    node node_modules/cucumber/bin/cucumber.js test/foo --require test/foo --debug

However the following throws an error `error: unknown option '--debug'` because `test/foo` directory is in profile definition:

    node node_modules/cucumber/bin/cucumber.js --profile foo --debug

The PR is to prevent Commander throwing exceptions when unexpected option is present and pass it verbatim to the tests.