### PR TITLE
Type tag with 'scenario' as value added to scenario element

### DIFF
--- a/src/formatter/json_formatter.js
+++ b/src/formatter/json_formatter.js
@@ -123,7 +123,8 @@ export default class JsonFormatter extends Formatter {
       keyword: 'Scenario',
       line: pickle.locations[0].line,
       name: pickle.name,
-      tags: this.getTags(pickle)
+      tags: this.getTags(pickle),
+      type: 'scenario'
     }
   }
 

--- a/src/formatter/json_formatter_spec.js
+++ b/src/formatter/json_formatter_spec.js
@@ -85,6 +85,7 @@ describe('JsonFormatter', function() {
                 keyword: 'Scenario',
                 line: 4,
                 name: 'my scenario',
+                type: 'scenario',
                 steps: [
                   {
                     arguments: [],


### PR DESCRIPTION
Hello,
I want to use jenkins to generate report from json file generated by JsonFormatter. We're using https://github.com/jenkinsci/cucumber-reports-plugin to generate cucumber reports on jenkins, but to do that "type" tag for scenario is required to identify element as scenario. 