### PR TITLE
Update docs/nodejs_example.md

### DIFF
--- a/docs/nodejs_example.md
+++ b/docs/nodejs_example.md
@@ -60,13 +60,13 @@
         return this.driver.get('https://github.com/cucumber/cucumber-js/tree/master');
       });
 
-      When('I click on {stringInDoubleQuotes}', function (text) {
+      When('I click on {string}', function (text) {
         return this.driver.findElement({linkText: text}).then(function(element) {
           return element.click();
         });
       });
 
-      Then('I should see {stringInDoubleQuotes}', function (text) {
+      Then('I should see {string}', function (text) {
         var xpath = "//*[contains(text(),'" + text + "')]";
         var condition = seleniumWebdriver.until.elementLocated({xpath: xpath});
         return this.driver.wait(condition, 5000);


### PR DESCRIPTION
The cucumber-expression '_stringInDoubleQuotes_' has become simply '_string_' [Reference](https://github.com/cucumber/cucumber-js/blob/master/CHANGELOG.md#breaking-changes)

Updating NodeJS example to reflect this change.