### PR TITLE
Scenario Outline name rename: pluralize word

### DIFF
--- a/features/before_after_all_hook_timeouts.feature
+++ b/features/before_after_all_hook_timeouts.feature
@@ -41,7 +41,7 @@ Feature: before / after all hook timeouts
       | BeforeAll |
       | AfterAll  |
 
-  Scenario Outline: slow handler can increase their timeout
+  Scenario Outline: slow handlers can increase their timeout
     Given a file named "features/supports/handlers.js" with:
       """
       import {defineSupportCode} from 'cucumber'


### PR DESCRIPTION
This is tiny change on top of #899: pluralize a word in the Scenario Outline to make it fit the grammar of the sentence.