### PR TITLE
Allow absolute formatter output paths. Fixes #900.

### DIFF
--- a/features/formatter_paths.feature
+++ b/features/formatter_paths.feature
@@ -1,4 +1,4 @@
-Feature: Multiple Formatters
+Feature: Formatter Paths
 
   Background:
     Given a file named "features/a.feature" with:
@@ -16,19 +16,29 @@ Feature: Multiple Formatters
       })
       """
 
-  Scenario: Ability to specify multiple formatters
-    When I run cucumber.js with `-f progress -f summary:summary.txt`
-    Then it outputs the text:
+  Scenario: Relative path
+    When I run cucumber.js with `-f summary:summary.txt`
+    Then the file "summary.txt" has the text:
       """
-      .
+      1 scenario (1 passed)
+      1 step (1 passed)
+      <duration-stat>
+      """
 
+  Scenario: Absolute path
+    Given "{{{tmpDir}}}" is an absolute path
+    When I run cucumber.js with `-f summary:{{{tmpDir}}}/summary.txt`
+    Then the file "{{{tmpDir}}}/summary.txt" has the text:
+      """
       1 scenario (1 passed)
       1 step (1 passed)
       <duration-stat>
       """
-    And the file "summary.txt" has the text:
+
+  Scenario: Invalid path
+    When I run cucumber.js with `-f summary:invalid/summary.txt`
+    Then it fails
+    And the error output contains the text:
       """
-      1 scenario (1 passed)
-      1 step (1 passed)
-      <duration-stat>
+      ENOENT
       """

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -4,11 +4,13 @@ import { defineSupportCode } from '../../'
 import { expect } from 'chai'
 import { normalizeText } from '../support/helpers'
 import stringArgv from 'string-argv'
+import Mustache from 'mustache'
 
 defineSupportCode(function({ When, Then }) {
   When(/^I run cucumber.js(?: with `(|.+)`)?$/, { timeout: 10000 }, function(
     args
   ) {
+    args = Mustache.render(args || '', this)
     args = stringArgv(args || '')
     return this.run(this.localExecutablePath, args)
   })

--- a/features/step_definitions/file_steps.js
+++ b/features/step_definitions/file_steps.js
@@ -7,6 +7,7 @@ import { promisify } from 'bluebird'
 import fs from 'mz/fs'
 import fsExtra from 'fs-extra'
 import path from 'path'
+import Mustache from 'mustache'
 
 defineSupportCode(function({ Given, Then }) {
   Given(/^a file named "(.*)" with:$/, function(filePath, fileContent) {
@@ -27,8 +28,14 @@ defineSupportCode(function({ Given, Then }) {
     return promisify(fsExtra.mkdirp)(absoluteFilePath)
   })
 
+  Given(/^"([^"]*)" is an absolute path$/, function(filePath) {
+    filePath = Mustache.render(filePath, this)
+    expect(path.isAbsolute(filePath)).to.be.true
+  })
+
   Then(/^the file "([^"]*)" has the text:$/, async function(filePath, text) {
-    const absoluteFilePath = path.join(this.tmpDir, filePath)
+    filePath = Mustache.render(filePath, this)
+    const absoluteFilePath = path.resolve(this.tmpDir, filePath)
     const content = await fs.readFile(absoluteFilePath, 'utf8')
     const actualContent = normalizeText(content)
     const expectedContent = normalizeText(text)

--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "eslint-plugin-prettier": "^2.1.2",
     "fs-extra": "^3.0.1",
     "mocha": "^3.1.2",
+    "mustache": "^2.3.0",
     "nyc": "^11.0.2",
     "prettier": "^1.5.2",
     "regenerator-runtime": "^0.10.0",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -35,7 +35,7 @@ export default class Cli {
     await Promise.map(formats, async ({ type, outputTo }) => {
       let stream = this.stdout
       if (outputTo) {
-        let fd = await fs.open(path.join(this.cwd, outputTo), 'w')
+        let fd = await fs.open(path.resolve(this.cwd, outputTo), 'w')
         stream = fs.createWriteStream(null, { fd })
         streamsToClose.push(stream)
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2767,6 +2767,10 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+mustache@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.0.tgz#4028f7778b17708a489930a6e52ac3bca0da41d0"
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"


### PR DESCRIPTION
I needed this fix to get protractor support for cucumber 3.

  - Moved the invalid path scenario that was in `multiple_formattters.feature` to a new `formatter_paths.feature` so all the path related scenarios were together.
  - Added mustache to get the temp dir into the feature. ~~Added a new `replaceContextVariables` helper so that I could get the actual temp dir into the feature itself. It felt kind of hacky, but I didn't know of another way besides duplicating step definitions to deal with absolute paths explicitly.~~