### PR TITLE
fix usage helpers

### DIFF
--- a/src/formatter/helpers/usage_helpers/index.js
+++ b/src/formatter/helpers/usage_helpers/index.js
@@ -25,7 +25,7 @@ function buildMapping({ stepDefinitions, eventDataCollector }) {
     const stepLineToPickledStepMap = getStepLineToPickledStepMap(pickle)
     testCase.steps.forEach(testStep => {
       const { actionLocation, sourceLocation, result: { duration } } = testStep
-      if (sourceLocation) {
+      if (actionLocation && sourceLocation) {
         const location = formatLocation(actionLocation)
         const match = {
           line: sourceLocation.line,

--- a/src/formatter/helpers/usage_helpers/index_spec.js
+++ b/src/formatter/helpers/usage_helpers/index_spec.js
@@ -1,0 +1,73 @@
+import { getUsage } from './'
+import EventEmitter from 'events'
+import Gherkin from 'gherkin'
+import EventDataCollector from '../event_data_collector'
+
+describe('Usage Helpers', function() {
+  describe('getUsage', function() {
+    beforeEach(function() {
+      this.eventBroadcaster = new EventEmitter()
+      this.eventDataCollector = new EventDataCollector(this.eventBroadcaster)
+      this.stepDefinitions = []
+      this.getResult = () =>
+        getUsage({
+          eventDataCollector: this.eventDataCollector,
+          stepDefinitions: this.stepDefinitions
+        })
+    })
+
+    describe('no step definitions', function() {
+      describe('without steps', function() {
+        beforeEach(function() {
+          this.eventBroadcaster.emit('test-run-finished')
+        })
+
+        it('returns an empty array', function() {
+          expect(this.getResult()).to.eql([])
+        })
+      })
+
+      describe('with a step', function() {
+        beforeEach(function() {
+          const events = Gherkin.generateEvents(
+            'Feature: a\nScenario: b\nWhen abc\nThen ab',
+            'a.feature'
+          )
+          events.forEach(event => {
+            this.eventBroadcaster.emit(event.type, event)
+            if (event.type === 'pickle') {
+              this.eventBroadcaster.emit('pickle-accepted', {
+                type: 'pickle-accepted',
+                pickle: event.pickle,
+                uri: event.uri
+              })
+            }
+          })
+          const testCase = { sourceLocation: { uri: 'a.feature', line: 2 } }
+          this.eventBroadcaster.emit('test-case-prepared', {
+            ...testCase,
+            steps: [
+              { sourceLocation: { uri: 'a.feature', line: 3 } },
+              { sourceLocation: { uri: 'a.feature', line: 4 } }
+            ]
+          })
+          this.eventBroadcaster.emit('test-step-finished', {
+            index: 0,
+            testCase,
+            result: {}
+          })
+          this.eventBroadcaster.emit('test-step-finished', {
+            index: 1,
+            testCase,
+            result: {}
+          })
+          this.eventBroadcaster.emit('test-run-finished')
+        })
+
+        it('returns an empty array', function() {
+          expect(this.getResult()).to.eql([])
+        })
+      })
+    })
+  })
+})

--- a/src/formatter/usage_formatter_spec.js
+++ b/src/formatter/usage_formatter_spec.js
@@ -23,12 +23,56 @@ describe('UsageFormatter', function() {
     })
 
     describe('no step definitions', function() {
-      beforeEach(function() {
-        this.eventBroadcaster.emit('test-run-finished')
+      describe('without steps', function() {
+        beforeEach(function() {
+          this.eventBroadcaster.emit('test-run-finished')
+        })
+
+        it('outputs "No step definitions"', function() {
+          expect(this.output).to.eql('No step definitions')
+        })
       })
 
-      it('outputs "No step definitions"', function() {
-        expect(this.output).to.eql('No step definitions')
+      describe('with a step', function() {
+        beforeEach(function() {
+          const events = Gherkin.generateEvents(
+            'Feature: a\nScenario: b\nWhen abc\nThen ab',
+            'a.feature'
+          )
+          events.forEach(event => {
+            this.eventBroadcaster.emit(event.type, event)
+            if (event.type === 'pickle') {
+              this.eventBroadcaster.emit('pickle-accepted', {
+                type: 'pickle-accepted',
+                pickle: event.pickle,
+                uri: event.uri
+              })
+            }
+          })
+          const testCase = { sourceLocation: { uri: 'a.feature', line: 2 } }
+          this.eventBroadcaster.emit('test-case-prepared', {
+            ...testCase,
+            steps: [
+              { sourceLocation: { uri: 'a.feature', line: 3 } },
+              { sourceLocation: { uri: 'a.feature', line: 4 } }
+            ]
+          })
+          this.eventBroadcaster.emit('test-step-finished', {
+            index: 0,
+            testCase,
+            result: {}
+          })
+          this.eventBroadcaster.emit('test-step-finished', {
+            index: 1,
+            testCase,
+            result: {}
+          })
+          this.eventBroadcaster.emit('test-run-finished')
+        })
+
+        it('outputs "No step definitions"', function() {
+          expect(this.output).to.eql('No step definitions')
+        })
       })
     })
 

--- a/src/formatter/usage_formatter_spec.js
+++ b/src/formatter/usage_formatter_spec.js
@@ -23,56 +23,12 @@ describe('UsageFormatter', function() {
     })
 
     describe('no step definitions', function() {
-      describe('without steps', function() {
-        beforeEach(function() {
-          this.eventBroadcaster.emit('test-run-finished')
-        })
-
-        it('outputs "No step definitions"', function() {
-          expect(this.output).to.eql('No step definitions')
-        })
+      beforeEach(function() {
+        this.eventBroadcaster.emit('test-run-finished')
       })
 
-      describe('with a step', function() {
-        beforeEach(function() {
-          const events = Gherkin.generateEvents(
-            'Feature: a\nScenario: b\nWhen abc\nThen ab',
-            'a.feature'
-          )
-          events.forEach(event => {
-            this.eventBroadcaster.emit(event.type, event)
-            if (event.type === 'pickle') {
-              this.eventBroadcaster.emit('pickle-accepted', {
-                type: 'pickle-accepted',
-                pickle: event.pickle,
-                uri: event.uri
-              })
-            }
-          })
-          const testCase = { sourceLocation: { uri: 'a.feature', line: 2 } }
-          this.eventBroadcaster.emit('test-case-prepared', {
-            ...testCase,
-            steps: [
-              { sourceLocation: { uri: 'a.feature', line: 3 } },
-              { sourceLocation: { uri: 'a.feature', line: 4 } }
-            ]
-          })
-          this.eventBroadcaster.emit('test-step-finished', {
-            index: 0,
-            testCase,
-            result: {}
-          })
-          this.eventBroadcaster.emit('test-step-finished', {
-            index: 1,
-            testCase,
-            result: {}
-          })
-          this.eventBroadcaster.emit('test-run-finished')
-        })
-
-        it('outputs "No step definitions"', function() {
-          expect(this.output).to.eql('No step definitions')
-        })
+      it('outputs "No step definitions"', function() {
+        expect(this.output).to.eql('No step definitions')
       })
     })
 


### PR DESCRIPTION
Currently was running into this error if there was an undefined step:

```
TypeError: Cannot read property 'uri' of undefined
    at formatLocation (/Users/charlesrudolph/projects/cucumber-js/src/formatter/helpers/location_helpers.js:2:13)
    at /Users/charlesrudolph/projects/cucumber-js/src/formatter/helpers/usage_helpers/index.js:29:26
    at Array.forEach (native)
    at /Users/charlesrudolph/projects/cucumber-js/src/formatter/helpers/usage_helpers/index.js:26:20
    at /Users/charlesrudolph/projects/cucumber-js/node_modules/lodash/lodash.js:4944:15
    at baseForOwn (/Users/charlesrudolph/projects/cucumber-js/node_modules/lodash/lodash.js:3001:24)
    at /Users/charlesrudolph/projects/cucumber-js/node_modules/lodash/lodash.js:4913:18
    at Function.forEach (/Users/charlesrudolph/projects/cucumber-js/node_modules/lodash/lodash.js:9359:14)
    at buildMapping (/Users/charlesrudolph/projects/cucumber-js/src/formatter/helpers/usage_helpers/index.js:21:5)
    at getUsage (/Users/charlesrudolph/projects/cucumber-js/src/formatter/helpers/usage_helpers/index.js:76:19)
    at UsageFormatter.logUsage (/Users/charlesrudolph/projects/cucumber-js/src/formatter/usage_formatter.js:13:19)
    at emitOne (events.js:101:20)
    at EventEmitter.emit (events.js:188:7)
    at Runtime.<anonymous> (/Users/charlesrudolph/projects/cucumber-js/src/runtime/index.js:71:27)
    at Generator.next (<anonymous>)
    at Generator.tryCatcher (/Users/charlesrudolph/projects/cucumber-js/node_modules/bluebird/js/release/util.js:16:23)
```