### PR TITLE
Custom separator support for rerun formatter

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -84,6 +84,13 @@ Valid interfaces are 'callback', 'generator', 'promise', or 'synchronous'.
 Override the snippet syntaxes with `--format-options '{"snippetSyntax": "<FILE>"}'`.
 See [here](/docs/custom_snippet_syntaxes.md) for documentation about building a custom snippet syntax.
 
+## Rerun separator
+
+The separator used by the rerun formatter can be overwritten by specifying `--format-options '{"rerun": {"separator": "<separator>"}}'`.
+This is useful when one needs to rerun failed tests locally by copying a line from a CI log while using a space character as a separator.
+The default separator is a newline character.
+Note that the rerun file parser can only work with the default separator for now.
+
 ## Profiles
 
 In order to store and reuse commonly used CLI options, you can add a `cucumber.js` file to your project root directory. The file should export an object where the key is the profile name and the value is a string of CLI options. The profile can be applied with `-p <NAME>` or `--profile <NAME>`. This will prepend the profile's CLI options to the ones provided by the command line. Multiple profiles can be specified at a time. If no profile is specified and a profile named `default` exists, it will be applied.

--- a/src/formatter/rerun_formatter.js
+++ b/src/formatter/rerun_formatter.js
@@ -2,6 +2,8 @@ import _ from 'lodash'
 import Formatter from './'
 import Status from '../status'
 
+const DEFAULT_SEPARATOR = '\n'
+
 export default class RerunFormatter extends Formatter {
   constructor(options) {
     super(options)
@@ -9,6 +11,7 @@ export default class RerunFormatter extends Formatter {
       .on('test-case-finished', ::this.storeFailedTestCases)
       .on('test-run-finished', ::this.logFailedTestCases)
     this.mapping = {}
+    this.separator = options.separator || DEFAULT_SEPARATOR
   }
 
   storeFailedTestCases({ sourceLocation: { line, uri }, result: { status } }) {
@@ -23,7 +26,7 @@ export default class RerunFormatter extends Formatter {
   logFailedTestCases() {
     const text = _.chain(this.mapping)
       .map((lines, uri) => uri + ':' + lines.join(':'))
-      .join('\n')
+      .join(this.separator)
       .value()
     this.log(text)
   }

--- a/src/formatter/rerun_formatter.js
+++ b/src/formatter/rerun_formatter.js
@@ -11,7 +11,7 @@ export default class RerunFormatter extends Formatter {
       .on('test-case-finished', ::this.storeFailedTestCases)
       .on('test-run-finished', ::this.logFailedTestCases)
     this.mapping = {}
-    this.separator = options.separator || DEFAULT_SEPARATOR
+    this.separator = _.get(options, 'rerun.separator', DEFAULT_SEPARATOR)
   }
 
   storeFailedTestCases({ sourceLocation: { line, uri }, result: { status } }) {

--- a/src/formatter/rerun_formatter_spec.js
+++ b/src/formatter/rerun_formatter_spec.js
@@ -93,15 +93,17 @@ describe('RerunFormatter', function() {
 
   _.each(
     [
-      { separator: null, label: 'default' },
-      { separator: '\n', label: 'newline' },
-      { separator: ' ', label: 'space' }
+      { separator: { opt: undefined, expected: '\n' }, label: 'default' },
+      { separator: { opt: '\n', expected: '\n' }, label: 'newline' },
+      { separator: { opt: ' ', expected: ' ' }, label: 'space' }
     ],
     ({ separator, label }) => {
       describe('using ' + label + ' separator', function() {
         describe('with two failing scenarios in different files', function() {
           beforeEach(function() {
-            prepareFormatter.apply(this, [{ rerun: { separator } }])
+            prepareFormatter.apply(this, [
+              { rerun: { separator: separator.opt } }
+            ])
 
             this.eventBroadcaster.emit('test-case-finished', {
               sourceLocation: { uri: this.feature1Path, line: 1 },
@@ -116,7 +118,9 @@ describe('RerunFormatter', function() {
 
           it('outputs the references needed to run the scenarios again', function() {
             expect(this.output).to.eql(
-              `${this.feature1Path}:1` + separator + `${this.feature2Path}:2`
+              `${this.feature1Path}:1` +
+                separator.expected +
+                `${this.feature2Path}:2`
             )
           })
         })


### PR DESCRIPTION
Allows to change the separator in the rerun formatter, eg. `--format-options '{ separator: " " }'`. This way you can get the list of failing tests in a single line that could be handy sometimes.