### PR TITLE
ParameterType transformer runs in World

### DIFF
--- a/docs/support_files/api_reference.md
+++ b/docs/support_files/api_reference.md
@@ -8,13 +8,13 @@ The function passed to `defineSupportCode` is called with an object as the first
 
 #### `defineParameterType({name, preferForRegexpMatch, regexp, transformer, useForSnippets})`
 
-Add a new transform to convert a capture group into something else.
+Define a new parameter type and optionally convert an output parameter into something else.
 
 * `name`: string used to refer to this type in cucumber expressions
 * `regexp`: A regular expression (or array of regular expressions) that match the parameter
 * `transformer`: An optional function which transforms the captured argument from a string into what is passed to the step definition.
   If no transform function is specified, the captured argument is left as a string.
-  The function can be synchronous or return a `Promise` of the transformed value.
+  The function can be synchronous or return a `Promise` of the transformed value. The value of `this` is the current world, so the function can delegate to world functions. World delegation does not work with arrow functions.
 * `useForSnippets`: Defaults to `true`. That means this parameter type will be used to generate snippets for undefined steps. If the `regexp` frequently matches text you don't intend to be used as arguments, disable its use for snippets with `false`.
 * `preferForRegexpMatch`: Defaults to `false`. Set to true if you use regular expressions and you want this parameter type's `regexp` to take precedence over others during a match.
 

--- a/features/parameter_types.feature
+++ b/features/parameter_types.feature
@@ -23,6 +23,29 @@ Feature: Parameter types
       })
       """
 
+  Scenario: delegate transform to world
+    Given a file named "features/support/transforms.js" with:
+      """
+      import {setWorldConstructor, defineParameterType} from 'cucumber'
+
+      defineParameterType({
+        regexp: /particular/,
+        transformer(s) {
+          return this.upcase(s)
+        },
+        name: 'param'
+      })
+
+      class MyWorld {
+        upcase(s) {
+          return s.toUpperCase()
+        }
+      }
+      setWorldConstructor(MyWorld)
+      """
+    When I run cucumber.js
+    Then the step "a particular step" has status "passed"
+
   Scenario: sync transform (success)
     Given a file named "features/support/transforms.js" with:
       """

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "cli-table": "^0.3.1",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
-    "cucumber-expressions": "^4.0.4",
+    "cucumber-expressions": "^5.0.0",
     "cucumber-tag-expressions": "^1.0.0",
     "duration": "^0.2.0",
     "escape-string-regexp": "^1.0.5",

--- a/src/models/step_definition.js
+++ b/src/models/step_definition.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import { CucumberExpression, RegularExpression } from 'cucumber-expressions'
 import DataTable from './data_table'
 import { buildStepArgumentIterator } from '../step_arguments'
@@ -33,12 +32,11 @@ export default class StepDefinition {
     )
   }
 
-  getInvocationParameters({ step, parameterTypeRegistry }) {
+  getInvocationParameters({ step, parameterTypeRegistry, world }) {
     const cucumberExpression = this.getCucumberExpression(parameterTypeRegistry)
-    const stepNameParameters = _.map(
-      cucumberExpression.match(step.text),
-      'value'
-    )
+    const stepNameParameters = cucumberExpression
+      .match(step.text)
+      .map(arg => arg.getValue(world))
     const iterator = buildStepArgumentIterator({
       dataTable: arg => new DataTable(arg),
       docString: arg => arg.content

--- a/src/runtime/step_runner.js
+++ b/src/runtime/step_runner.js
@@ -22,7 +22,8 @@ async function run({
       stepDefinition.getInvocationParameters({
         hookParameter,
         parameterTypeRegistry,
-        step
+        step,
+        world
       })
     )
   } catch (err) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1244,9 +1244,9 @@ crypto-browserify@^3.0.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
 
-cucumber-expressions@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/cucumber-expressions/-/cucumber-expressions-4.0.4.tgz#64d7ae485b941261b0582b0f8f02037f0818bf14"
+cucumber-expressions@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cucumber-expressions/-/cucumber-expressions-5.0.0.tgz#69332ccd38b8a06c57a7ecc38dfd7f75efc98f65"
   dependencies:
     becke-ch--regex--s0-0-v1--base--pl--lib "^1.2.0"
 


### PR DESCRIPTION
## Summary

Allow `transformer` functions to delegate to World

## Motivation and Context

Because sometimes we need stuff from the world to transform a string to a "rich" object

## How Has This Been Tested?

Unit tests in cucumber-expressions, new scenario in this PR

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
