### PR TITLE
cli: don't split formatter:output on Windows drive letters (#953)

### DIFF
--- a/src/cli/configuration_builder.js
+++ b/src/cli/configuration_builder.js
@@ -95,9 +95,15 @@ export default class ConfigurationBuilder {
   getFormats() {
     const mapping = { '': 'progress' }
     this.options.format.forEach(function(format) {
-      const parts = format.split(':')
-      const type = parts[0]
-      const outputTo = parts.slice(1).join(':')
+      let type = format
+      let outputTo = ''
+      const parts = format.split(/([^A-Z]):([^\\])/)
+
+      if (parts.length > 1) {
+        type = parts.slice(0, 2).join('')
+        outputTo = parts.slice(2).join('')
+      }
+
       mapping[outputTo] = type
     })
     return _.map(mapping, function(type, outputTo) {

--- a/src/cli/configuration_builder_spec.js
+++ b/src/cli/configuration_builder_spec.js
@@ -99,4 +99,53 @@ describe('Configuration', function() {
       expect(supportCodePaths).to.eql([this.supportCodePath])
     })
   })
+
+  describe('formatters', function() {
+    it('adds a default', async function() {
+      const formats = await getFormats(this.configurationOptions)
+      expect(formats).to.eql([{ outputTo: '', type: 'progress' }])
+    })
+
+    it('splits relative unix paths', async function() {
+      this.argv.push('-f', '../custom/formatter:../formatter/output.txt')
+      const formats = await getFormats(this.configurationOptions)
+
+      expect(formats).to.eql([
+        { outputTo: '', type: 'progress' },
+        { outputTo: '../formatter/output.txt', type: '../custom/formatter' }
+      ])
+    })
+
+    it('splits absolute unix paths', async function() {
+      this.argv.push('-f', '/custom/formatter:/formatter/output.txt')
+      const formats = await getFormats(this.configurationOptions)
+
+      expect(formats).to.eql([
+        { outputTo: '', type: 'progress' },
+        { outputTo: '/formatter/output.txt', type: '/custom/formatter' }
+      ])
+    })
+
+    it('splits absolute windows paths', async function() {
+      this.argv.push('-f', 'C:\\custom\\formatter:D:\\formatter\\output.txt')
+      const formats = await getFormats(this.configurationOptions)
+
+      expect(formats).to.eql([
+        { outputTo: '', type: 'progress' },
+        { outputTo: 'D:\\formatter\\output.txt', type: 'C:\\custom\\formatter' }
+      ])
+    })
+
+    it('does not split absolute windows paths without an output', async function() {
+      this.argv.push('-f', 'C:\\custom\\formatter')
+      const formats = await getFormats(this.configurationOptions)
+
+      expect(formats).to.eql([{ outputTo: '', type: 'C:\\custom\\formatter' }])
+    })
+
+    async function getFormats(options) {
+      const result = await ConfigurationBuilder.build(options)
+      return result.formats
+    }
+  })
 })


### PR DESCRIPTION
That regex feels hacky to me so if there is a way to do this with a single `split` without checking the number of split parts I'd be more than happy to use it. It's still splitting on a `:`, but not if it is preceded by a capital letter and followed by a `/` (at least that was my intention). I looked at [this old pr](https://github.com/cucumber/cucumber-js/pull/680/files#diff-125eabbcc2e8302c4674fbbcc2fa3439R106), but couldn't tell if that would work in this situation. Regex hurts my head. 