### PR TITLE
cli: extract option splitting and use it for --compiler (#746)

### DIFF
--- a/src/cli/option_splitter.js
+++ b/src/cli/option_splitter.js
@@ -1,0 +1,17 @@
+export default class OptionSplitter {
+  static split(option) {
+    const parts = option.split(/([^A-Z]):(?!\\)/)
+
+    return parts.reduce((memo, part, i) => {
+      if (partNeedsRecombined(i)) {
+        memo.push(parts.slice(i, i + 2).join(''))
+      }
+
+      return memo
+    }, [])
+  }
+}
+
+function partNeedsRecombined(i) {
+  return i % 2 === 0
+}

--- a/src/cli/option_splitter_spec.js
+++ b/src/cli/option_splitter_spec.js
@@ -1,0 +1,52 @@
+import OptionSplitter from './option_splitter'
+
+describe('OptionSplitter', function() {
+  const examples = [
+    {
+      description: "doesn't split when nothing to split on",
+      input: '../custom/formatter',
+      output: ['../custom/formatter']
+    },
+    {
+      description: 'splits relative unix paths',
+      input: '../custom/formatter:../formatter/output.txt',
+      output: ['../custom/formatter', '../formatter/output.txt']
+    },
+    {
+      description: 'splits absolute unix paths',
+      input: '/custom/formatter:/formatter/output.txt',
+      output: ['/custom/formatter', '/formatter/output.txt']
+    },
+    {
+      description: 'splits absolute windows paths',
+      input: 'C:\\custom\\formatter:C:\\formatter\\output.txt',
+      output: ['C:\\custom\\formatter', 'C:\\formatter\\output.txt']
+    },
+    {
+      description: 'does not split a single absolute windows paths',
+      input: 'C:\\custom\\formatter',
+      output: ['C:\\custom\\formatter']
+    },
+    {
+      description: 'splits extensions and modules',
+      input: 'ts:typescript',
+      output: ['ts', 'typescript']
+    },
+    {
+      description: 'splits extension and module with an absolute windows path',
+      input: 'ts:C:/typescript',
+      output: ['ts', 'C:/typescript']
+    },
+    {
+      description: 'splits more than 2 parts',
+      input: 'part1:part2:part3',
+      output: ['part1', 'part2', 'part3']
+    }
+  ]
+
+  examples.forEach(({ description, input, output }) => {
+    it(description, function() {
+      expect(OptionSplitter.split(input)).to.eql(output)
+    })
+  })
+})


### PR DESCRIPTION
Thought I'd take a crack at #746 while I was dealing with `:` splitting for the formatters. The compiler isn't as easy to unit test as the formatters was since the result of the split is used internally to the config builder plus it actually `require`s the module so you can't just send anything you want to it...like a windows absolute path. So I added an `OptionSplitter` utility that both the `--format` and `--compiler` can use. There are no new tests for `--compiler` because of the reason above, but the existing [feature](https://github.com/cucumber/cucumber-js/blob/master/features/compiler.feature) should ensure there are no regressions.

The splitting itself almost turned out to be simple with negative look aheads and look behinds until I found out that js regex doesn't support look behinds. That's why there's still a little bit of logic to smash those back together.