### PR TITLE
Replaced process.exit in run.js with a process.exitCode

### DIFF
--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -23,7 +23,7 @@ export default async function run() {
 
   const exitCode = success ? 0 : 1
   function exitNow() {
-    process.exit(exitCode)
+    process.exitCode = exitCode
   }
 
   // If stdout.write() returned false, kernel buffer is not empty yet


### PR DESCRIPTION
Partially addresses #889 

I took a look at the code involved in adding a CLI flag for this and found it pretty confusing.  Anybody who wanted to add that work on top of this, however, would be welcome to.

I left the `process.exit` in the `exitWithError` function alone because it wasn't relevant to the problem I was experiencing; although I think a `throw` would be more appropriate there, I'm not familiar enough with VError to know if we'd be losing something to throw the error instead of consoling it.