### PR TITLE
Functional api

### DIFF
--- a/functional-spike/functional.feature
+++ b/functional-spike/functional.feature
@@ -17,3 +17,7 @@ Feature: some feature
     When my number is divided by 2
     Then my number should be 11
     And my remainder should be 1
+
+  Scenario: parameter types
+    Given Joe is around
+    Then Joe should be around

--- a/functional-spike/functional.feature
+++ b/functional-spike/functional.feature
@@ -1,6 +1,19 @@
 Feature: some feature
 
-  Scenario:
+  Scenario: multiplication
     Given my number is 21
     When my number is multiplied by 2
     Then my number should be 42
+    And my number should not be 41
+
+  Scenario: multiplication 2
+    Given my number is 21
+    When my number is multiplied by 3
+    Then my number should be 63
+    And my number should not be 42
+
+  Scenario: modulo
+    Given my number is 21
+    When my number is divided by 2
+    Then my number should be 11
+    And my remainder should be 1

--- a/functional-spike/functional.feature
+++ b/functional-spike/functional.feature
@@ -1,0 +1,6 @@
+Feature: some feature
+
+  Scenario:
+    Given my number is 21
+    When my number is multiplied by 2
+    Then my number should be 42

--- a/functional-spike/parameter_types.js
+++ b/functional-spike/parameter_types.js
@@ -1,0 +1,10 @@
+const { defineParameterType } = require('../lib')
+
+defineParameterType({
+  name: 'actor',
+  regexp: /[A-Z][a-z]+/,
+  transformer: (state, name) => {
+    console.log('TRANSFORMER', state, name)
+    return state.actors[name]
+  },
+})

--- a/functional-spike/steps.js
+++ b/functional-spike/steps.js
@@ -1,0 +1,14 @@
+const assert = require('assert')
+const { Given, When, Then } = require('../dist/cucumber')
+
+Given(/^my number is (\d+)$/, (state, myNewNumber) => ({
+  myNumber: myNewNumber,
+}))
+
+When(/^my number is multiplied by (\d+)$/, (state, multiplier) => ({
+  myNumber: state.myNumber * multiplier,
+}))
+
+Then(/^my number should be (\d+)$/, (state, expectedNumber) =>
+  assert.equal(state.myNumber, expectedNumber)
+)

--- a/functional-spike/steps.js
+++ b/functional-spike/steps.js
@@ -24,7 +24,8 @@ After((state, res) => {
     )
 })
 
-Given(/^my number is (\d+)$/, (state, myNewNumber) => {
+Given(/^my number is (\d+)$/, function(state, myNewNumber) {
+  this.foo = 1
   return state.with({
     myNumber: myNewNumber,
   })
@@ -54,3 +55,9 @@ Then(/^my number should not be (\d+)$/, (state, unexpectedNumber) =>
 Then('my remainder should be {int}', (state, expectedRemainder) =>
   assert.equal(state.myRemainder, expectedRemainder)
 )
+
+Given('{word} is around', (state, actorName) =>
+  state.with({ actors: { actorName } })
+)
+
+Then('{actor} should be around', (state, actor) => assert.equal(actor, 'Joe'))

--- a/functional-spike/steps.js
+++ b/functional-spike/steps.js
@@ -1,6 +1,7 @@
 const assert = require('assert')
 const { After, Before, Given, When, Then } = require('../lib')
 
+// We're using our own State class here, but Immutable.js can be used too
 class State {
   constructor(props = {}) {
     Object.keys(props).forEach(key => {
@@ -24,7 +25,6 @@ After((state, res) => {
 })
 
 Given(/^my number is (\d+)$/, (state, myNewNumber) => {
-  console.log('THIS', this)
   return state.with({
     myNumber: myNewNumber,
   })

--- a/functional-spike/steps.js
+++ b/functional-spike/steps.js
@@ -1,14 +1,55 @@
 const assert = require('assert')
-const { Given, When, Then } = require('../dist/cucumber')
+const { After, Before, Given, When, Then } = require('../lib')
 
-Given(/^my number is (\d+)$/, (state, myNewNumber) => ({
-  myNumber: myNewNumber,
-}))
+class State {
+  constructor(props = {}) {
+    Object.keys(props).forEach(key => {
+      this[key] = props[key]
+    })
+  }
 
-When(/^my number is multiplied by (\d+)$/, (state, multiplier) => ({
-  myNumber: state.myNumber * multiplier,
-}))
+  with(props) {
+    return new State(Object.assign({}, this, props))
+  }
+}
+
+Before(() => new State())
+
+After((state, res) => {
+  if (res.result.status === 'failed')
+    console.log(
+      `--- FAILED SCENARIO LAST STATE (${res.sourceLocation.uri}:${res
+        .sourceLocation.line}) ---\n${JSON.stringify(state, null, 2)}`
+    )
+})
+
+Given(/^my number is (\d+)$/, (state, myNewNumber) =>
+  state.with({
+    myNumber: myNewNumber,
+  })
+)
+
+When(/^my number is multiplied by (\d+)$/, (state, multiplier) =>
+  state.with({
+    myNumber: state.myNumber * multiplier,
+  })
+)
+
+When('my number is divided by {int}', (state, divider) =>
+  state.with({
+    myNumber: Math.floor(state.myNumber / divider),
+    myRemainder: state.myNumber % divider,
+  })
+)
 
 Then(/^my number should be (\d+)$/, (state, expectedNumber) =>
   assert.equal(state.myNumber, expectedNumber)
+)
+
+Then(/^my number should not be (\d+)$/, (state, unexpectedNumber) =>
+  assert.notEqual(state.myNumber, unexpectedNumber)
+)
+
+Then('my remainder should be {int}', (state, expectedRemainder) =>
+  assert.equal(state.myRemainder, expectedRemainder)
 )

--- a/functional-spike/steps.js
+++ b/functional-spike/steps.js
@@ -23,11 +23,12 @@ After((state, res) => {
     )
 })
 
-Given(/^my number is (\d+)$/, (state, myNewNumber) =>
-  state.with({
+Given(/^my number is (\d+)$/, (state, myNewNumber) => {
+  console.log('THIS', this)
+  return state.with({
     myNumber: myNewNumber,
   })
-)
+})
 
 When(/^my number is multiplied by (\d+)$/, (state, multiplier) =>
   state.with({

--- a/src/cli/argv_parser.js
+++ b/src/cli/argv_parser.js
@@ -82,6 +82,7 @@ export default class ArgvParser {
         []
       )
       .option('--no-strict', 'succeed even if there are pending steps')
+      .option('--pure', 'use pure (stateless) step definition functions')
       .option(
         '-p, --profile <NAME>',
         'specify the profile to use (repeatable)',

--- a/src/cli/configuration_builder.js
+++ b/src/cli/configuration_builder.js
@@ -112,7 +112,10 @@ export default class ConfigurationBuilder {
   getFormatOptions() {
     const formatOptions = _.clone(this.options.formatOptions)
     formatOptions.cwd = this.cwd
-    _.defaults(formatOptions, { colorsEnabled: true })
+    _.defaults(formatOptions, {
+      colorsEnabled: true,
+      snippetInterface: this.options.pure ? 'pure' : 'callback',
+    })
     return formatOptions
   }
 

--- a/src/cli/configuration_builder.js
+++ b/src/cli/configuration_builder.js
@@ -58,6 +58,7 @@ export default class ConfigurationBuilder {
         failFast: !!this.options.failFast,
         filterStacktraces: !this.options.backtrace,
         strict: !!this.options.strict,
+        pure: !!this.options.pure,
         worldParameters: this.options.worldParameters,
       },
       shouldExitImmediately: !!this.options.exit,

--- a/src/cli/configuration_builder_spec.js
+++ b/src/cli/configuration_builder_spec.js
@@ -31,6 +31,7 @@ describe('Configuration', () => {
         formatOptions: {
           colorsEnabled: true,
           cwd: this.tmpDir,
+          snippetInterface: 'callback',
         },
         formats: [{ outputTo: '', type: 'progress' }],
         listI18nKeywordsFor: '',

--- a/src/cli/configuration_builder_spec.js
+++ b/src/cli/configuration_builder_spec.js
@@ -46,6 +46,7 @@ describe('Configuration', () => {
           dryRun: false,
           failFast: false,
           filterStacktraces: true,
+          pure: false,
           strict: true,
           worldParameters: {},
         },

--- a/src/formatter/builder.js
+++ b/src/formatter/builder.js
@@ -54,9 +54,6 @@ export default class FormatterBuilder {
     snippetSyntax,
     supportCodeLibrary,
   }) {
-    if (!snippetInterface) {
-      snippetInterface = 'callback'
-    }
     let Syntax = JavascriptSnippetSyntax
     if (snippetSyntax) {
       const fullSyntaxPath = path.resolve(cwd, snippetSyntax)

--- a/src/formatter/step_definition_snippet_builder/javascript_snippet_syntax.js
+++ b/src/formatter/step_definition_snippet_builder/javascript_snippet_syntax.js
@@ -6,11 +6,15 @@ export default class JavaScriptSnippetSyntax {
   }
 
   build({ comment, generatedExpressions, functionName, stepParameterNames }) {
-    let functionKeyword = 'function '
+    let functionKeyword
     if (this.snippetInterface === 'async-await') {
-      functionKeyword = 'async ' + functionKeyword
+      functionKeyword = 'async function '
     } else if (this.snippetInterface === 'generator') {
-      functionKeyword += '*'
+      functionKeyword = 'function *'
+    } else if (this.snippetInterface === 'pure') {
+      functionKeyword = ''
+    } else {
+      functionKeyword = 'function '
     }
 
     let implementation
@@ -26,13 +30,18 @@ export default class JavaScriptSnippetSyntax {
         const allParameterNames = generatedExpression.parameterNames.concat(
           stepParameterNames
         )
+        if (this.snippetInterface === 'pure') {
+          allParameterNames.unshift('state')
+        }
         if (this.snippetInterface === 'callback') {
           allParameterNames.push(CALLBACK_NAME)
         }
+        const functionEol =
+          this.snippetInterface === 'pure' ? ' => {\n' : ' {\n'
         return `${prefix + functionName}('${generatedExpression.source.replace(
           /'/g,
           "\\'"
-        )}', ${functionKeyword}(${allParameterNames.join(', ')}) {\n`
+        )}', ${functionKeyword}(${allParameterNames.join(', ')})${functionEol}`
       }
     )
 

--- a/src/formatter/step_definition_snippet_builder/javascript_snippet_syntax_spec.js
+++ b/src/formatter/step_definition_snippet_builder/javascript_snippet_syntax_spec.js
@@ -82,6 +82,32 @@ describe('JavascriptSnippetSyntax', () => {
       })
     })
 
+    describe('pure interface', () => {
+      beforeEach(function() {
+        this.syntax = new JavascriptSnippetSyntax('pure')
+      })
+
+      it('returns the proper snippet', function() {
+        const actual = this.syntax.build({
+          comment: 'comment',
+          functionName: 'functionName',
+          generatedExpressions: [
+            {
+              source: 'pattern',
+              parameterNames: ['arg1', 'arg2'],
+            },
+          ],
+          stepParameterNames: [],
+        })
+        const expected =
+          "functionName('pattern', (state, arg1, arg2) => {\n" +
+          '  // comment\n' +
+          "  return 'pending';\n" +
+          '});'
+        expect(actual).to.eql(expected)
+      })
+    })
+
     describe('synchronous interface', () => {
       beforeEach(function() {
         this.syntax = new JavascriptSnippetSyntax('synchronous')

--- a/src/runtime/index.js
+++ b/src/runtime/index.js
@@ -8,7 +8,7 @@ import UserCodeRunner from '../user_code_runner'
 import VError from 'verror'
 
 export default class Runtime {
-  // options - {dryRun, failFast, filterStacktraces, strict}
+  // options - {dryRun, failFast, filterStacktraces, strict, pure}
   constructor({ eventBroadcaster, options, supportCodeLibrary, testCases }) {
     this.eventBroadcaster = eventBroadcaster
     this.options = options || {}
@@ -49,6 +49,7 @@ export default class Runtime {
       skip,
       supportCodeLibrary: this.supportCodeLibrary,
       testCase,
+      pure: this.options.pure,
       worldParameters: this.options.worldParameters,
     })
     const testCaseResult = await testCaseRunner.run()

--- a/src/runtime/step_runner.js
+++ b/src/runtime/step_runner.js
@@ -12,6 +12,8 @@ async function run({
   parameterTypeRegistry,
   step,
   stepDefinition,
+  pure,
+  state,
   world,
 }) {
   beginTiming()
@@ -26,6 +28,7 @@ async function run({
         world,
       })
     )
+    if (pure) parameters.unshift(state)
   } catch (err) {
     error = err
   }
@@ -60,6 +63,7 @@ async function run({
     testStepResult.status = Status.FAILED
   } else {
     testStepResult.status = Status.PASSED
+    testStepResult.state = result
   }
 
   return testStepResult

--- a/src/runtime/step_runner.js
+++ b/src/runtime/step_runner.js
@@ -12,6 +12,7 @@ async function run({
   parameterTypeRegistry,
   step,
   stepDefinition,
+  state,
   world,
 }) {
   beginTiming()
@@ -36,6 +37,7 @@ async function run({
 
     const validCodeLengths = stepDefinition.getValidCodeLengths(parameters)
     if (_.includes(validCodeLengths, stepDefinition.code.length)) {
+      parameters.unshift(state)
       const data = await UserCodeRunner.run({
         argsArray: parameters,
         fn: stepDefinition.code,
@@ -60,6 +62,7 @@ async function run({
     testStepResult.status = Status.FAILED
   } else {
     testStepResult.status = Status.PASSED
+    testStepResult.state = result
   }
 
   return testStepResult

--- a/src/runtime/step_runner.js
+++ b/src/runtime/step_runner.js
@@ -12,7 +12,6 @@ async function run({
   parameterTypeRegistry,
   step,
   stepDefinition,
-  state,
   world,
 }) {
   beginTiming()
@@ -37,7 +36,6 @@ async function run({
 
     const validCodeLengths = stepDefinition.getValidCodeLengths(parameters)
     if (_.includes(validCodeLengths, stepDefinition.code.length)) {
-      parameters.unshift(state)
       const data = await UserCodeRunner.run({
         argsArray: parameters,
         fn: stepDefinition.code,
@@ -62,7 +60,6 @@ async function run({
     testStepResult.status = Status.FAILED
   } else {
     testStepResult.status = Status.PASSED
-    testStepResult.state = result
   }
 
   return testStepResult

--- a/src/runtime/test_case_runner.js
+++ b/src/runtime/test_case_runner.js
@@ -39,6 +39,7 @@ export default class TestCaseRunner {
       uri: this.testCase.uri,
       line: this.testCase.pickle.locations[0].line,
     }
+    this.state = null
   }
 
   emit(name, data) {
@@ -100,15 +101,18 @@ export default class TestCaseRunner {
     )
   }
 
-  invokeStep(step, stepDefinition, hookParameter) {
-    return StepRunner.run({
+  async invokeStep(step, stepDefinition, hookParameter) {
+    const testStepResult = await StepRunner.run({
       defaultTimeout: this.supportCodeLibrary.defaultTimeout,
       hookParameter,
       parameterTypeRegistry: this.supportCodeLibrary.parameterTypeRegistry,
       step,
       stepDefinition,
+      state: this.state,
       world: this.world,
     })
+    this.state = testStepResult.state
+    return testStepResult
   }
 
   isSkippingSteps() {

--- a/src/runtime/test_case_runner.js
+++ b/src/runtime/test_case_runner.js
@@ -111,7 +111,7 @@ export default class TestCaseRunner {
       state: this.state,
       world: this.world,
     })
-    this.state = testStepResult.state
+    this.state = testStepResult.state || this.state
     return testStepResult
   }
 

--- a/src/runtime/test_case_runner.js
+++ b/src/runtime/test_case_runner.js
@@ -39,7 +39,6 @@ export default class TestCaseRunner {
       uri: this.testCase.uri,
       line: this.testCase.pickle.locations[0].line,
     }
-    this.state = null
   }
 
   emit(name, data) {
@@ -101,18 +100,15 @@ export default class TestCaseRunner {
     )
   }
 
-  async invokeStep(step, stepDefinition, hookParameter) {
-    const testStepResult = await StepRunner.run({
+  invokeStep(step, stepDefinition, hookParameter) {
+    return StepRunner.run({
       defaultTimeout: this.supportCodeLibrary.defaultTimeout,
       hookParameter,
       parameterTypeRegistry: this.supportCodeLibrary.parameterTypeRegistry,
       step,
       stepDefinition,
-      state: this.state,
       world: this.world,
     })
-    this.state = testStepResult.state || this.state
-    return testStepResult
   }
 
   isSkippingSteps() {

--- a/src/runtime/test_case_runner.js
+++ b/src/runtime/test_case_runner.js
@@ -27,8 +27,8 @@ export default class TestCaseRunner {
     this.supportCodeLibrary = supportCodeLibrary
     this.pure = pure
     if (pure) {
-      // TODO: Disallow callbacks too
-      this.state = null
+      // There's no World instance in pure mode, so `this` is undefined in stepdefs
+      this.state = undefined
     } else {
       this.world = new supportCodeLibrary.World({
         attach: ::attachmentManager.create,

--- a/src/user_code_runner.js
+++ b/src/user_code_runner.js
@@ -24,7 +24,7 @@ export default class UserCodeRunner {
     }
 
     const racingPromises = []
-    const callbackInterface = false // fn.length === argsArray.length
+    const callbackInterface = fn.length === argsArray.length
     const promiseInterface = fnReturn && typeof fnReturn.then === 'function'
 
     if (callbackInterface && promiseInterface) {

--- a/src/user_code_runner.js
+++ b/src/user_code_runner.js
@@ -24,7 +24,7 @@ export default class UserCodeRunner {
     }
 
     const racingPromises = []
-    const callbackInterface = fn.length === argsArray.length
+    const callbackInterface = false // fn.length === argsArray.length
     const promiseInterface = fnReturn && typeof fnReturn.then === 'function'
 
     if (callbackInterface && promiseInterface) {


### PR DESCRIPTION
This is a new take on #745, taking the ideas from #865 and incorporating them into the core rather than building a wrapper around it.

You can try it out with:

    ./bin/cucumber-js --pure functional-spike

In `--pure` mode, all step definitions take an extra `state` parameter as the first parameter preceding any parameters from Gherkin. The `state` parameter is passed the return value from the previous step definition or hook.

TODO:
- [ ] Write scenarios that describe the new "pure" mode
- [ ] Remove the `functional-spike` directory
- [ ] Document it
- [ ] Figure out what to do with `this` for parameter types (their `transform` functions currently have the world instance as `this` in the classic (un-pure) mode.