### PR TITLE
Print attachment step text on error format

### DIFF
--- a/docs/support_files/attachments.md
+++ b/docs/support_files/attachments.md
@@ -81,3 +81,20 @@ After(function (testCase) {
   }
 });
 ```
+
+Attachments are also printed by the progress, progress-bar and summary formatter.
+They appears right after the step and only `text/plain` content is visible.
+It can be used to debug scenarios, especially in parallel mode.
+
+```
+// Step definition
+Given(/^a basic step$/, function() {
+  this.attach('Some info.')
+  this.attach('{"some", "JSON"}}', 'application/json')
+})
+
+// Result format
+✔ Given a basic step # path:line
+    Attachment (text/plain): Some info.
+    Attachment (application/json)
+```

--- a/docs/support_files/attachments.md
+++ b/docs/support_files/attachments.md
@@ -86,7 +86,7 @@ Attachments are also printed by the progress, progress-bar and summary formatter
 They appears right after the step and only `text/plain` content is visible.
 It can be used to debug scenarios, especially in parallel mode.
 
-```
+```javascript
 // Step definition
 Given(/^a basic step$/, function() {
   this.attach('Some info.')
@@ -94,7 +94,7 @@ Given(/^a basic step$/, function() {
 })
 
 // Result format
-✔ Given a basic step # path:line
-    Attachment (text/plain): Some info.
-    Attachment (application/json)
+// ✔ Given a basic step # path:line
+//    Attachment (text/plain): Some info.
+//    Attachment (application/json)
 ```

--- a/docs/support_files/attachments.md
+++ b/docs/support_files/attachments.md
@@ -82,8 +82,8 @@ After(function (testCase) {
 });
 ```
 
-Attachments are also printed by the progress, progress-bar and summary formatter.
-They appears right after the step and only `text/plain` content is visible.
+Attachments are also printed by the progress, progress-bar and summary formatters.
+They appear right after the step and only `text/plain` content is visible.
 It can be used to debug scenarios, especially in parallel mode.
 
 ```javascript

--- a/features/error_formatting.feature
+++ b/features/error_formatting.feature
@@ -65,7 +65,7 @@ Feature: Error formatting
 
       1) Scenario: some scenario # features/a.feature:3
          ✔ Given a basic step # features/step_definitions/cucumber_steps.js:3
-            ℹ Basic info.
+            Attachment (text/plain): Basic info.
          ✔ And a step with a doc string # features/step_definitions/cucumber_steps.js:4
              \"\"\"
              my doc string

--- a/features/error_formatting.feature
+++ b/features/error_formatting.feature
@@ -54,7 +54,7 @@ Feature: Error formatting
       """
       import {Given} from 'cucumber'
 
-      Given(/^a basic step$/, function() {})
+      Given(/^a basic step$/, function() { this.attach('Basic info.') })
       Given(/^a step with a doc string$/, function(str) {})
       Given(/^a pending step$/, function() { return 'pending' })
       """
@@ -65,6 +65,7 @@ Feature: Error formatting
 
       1) Scenario: some scenario # features/a.feature:3
          ✔ Given a basic step # features/step_definitions/cucumber_steps.js:3
+            ℹ Basic info.
          ✔ And a step with a doc string # features/step_definitions/cucumber_steps.js:4
              \"\"\"
              my doc string

--- a/features/error_formatting.feature
+++ b/features/error_formatting.feature
@@ -54,8 +54,8 @@ Feature: Error formatting
       """
       import {Given} from 'cucumber'
 
-      Given(/^a basic step$/, function() { this.attach('Basic info.') })
-      Given(/^a step with a doc string$/, function(str) {})
+      Given(/^a basic step$/, function() { this.attach('Some info.') })
+      Given(/^a step with a doc string$/, function(str) { this.attach('{"name": "some JSON"}', 'application/json') })
       Given(/^a pending step$/, function() { return 'pending' })
       """
     When I run cucumber-js
@@ -65,11 +65,12 @@ Feature: Error formatting
 
       1) Scenario: some scenario # features/a.feature:3
          ✔ Given a basic step # features/step_definitions/cucumber_steps.js:3
-            Attachment (text/plain): Basic info.
+             Attachment (text/plain): Some info.
          ✔ And a step with a doc string # features/step_definitions/cucumber_steps.js:4
              \"\"\"
              my doc string
              \"\"\"
+             Attachment (application/json)
          ? And a pending step # features/step_definitions/cucumber_steps.js:5
              Pending
       """

--- a/src/formatter/helpers/issue_helpers.js
+++ b/src/formatter/helpers/issue_helpers.js
@@ -93,14 +93,6 @@ function formatStep({
   }
   text += '\n'
 
-  if (testStep.attachments) {
-    testStep.attachments
-      .filter(({ media }) => media.type === 'text/plain')
-      .forEach(({ data }) => {
-        text += indentString('Attachment (text/plain): ' + data, 4) + '\n'
-      })
-  }
-
   if (pickleStep) {
     let str
     const iterator = buildStepArgumentIterator({
@@ -112,6 +104,14 @@ function formatStep({
       text += indentString(`${colorFn(str)}\n`, 4)
     }
   }
+
+  if (testStep.attachments) {
+    testStep.attachments.forEach(({ media, data }) => {
+      const message = media.type === 'text/plain' ? `: ${data}` : ''
+      text += indentString(`Attachment (${media.type})${message}\n`, 4)
+    })
+  }
+
   const message = getStepMessage({
     colorFns,
     keywordType,

--- a/src/formatter/helpers/issue_helpers.js
+++ b/src/formatter/helpers/issue_helpers.js
@@ -93,6 +93,18 @@ function formatStep({
   }
   text += '\n'
 
+  if (Array.isArray(testStep.attachments)) {
+    testStep.attachments
+      .filter(({ media }) => media.type === 'text/plain')
+      .forEach(({ data }) => {
+        text +=
+          indentString(
+            colorFns[Status.UNDEFINED](figures.info + ' ' + data),
+            4
+          ) + '\n'
+      })
+  }
+
   if (pickleStep) {
     let str
     const iterator = buildStepArgumentIterator({

--- a/src/formatter/helpers/issue_helpers.js
+++ b/src/formatter/helpers/issue_helpers.js
@@ -93,15 +93,11 @@ function formatStep({
   }
   text += '\n'
 
-  if (Array.isArray(testStep.attachments)) {
+  if (testStep.attachments) {
     testStep.attachments
       .filter(({ media }) => media.type === 'text/plain')
       .forEach(({ data }) => {
-        text +=
-          indentString(
-            colorFns[Status.UNDEFINED](figures.info + ' ' + data),
-            4
-          ) + '\n'
+        text += indentString('Attachment (text/plain): ' + data, 4) + '\n'
       })
   }
 

--- a/src/formatter/helpers/issue_helpers_spec.js
+++ b/src/formatter/helpers/issue_helpers_spec.js
@@ -241,21 +241,21 @@ describe('IssueHelpers', () => {
         this.testCase.steps[0].result = this.passedStepResult
         this.testCase.steps[0].attachments = [
           {
-            data: 'First info.',
+            data: 'Some info.',
             media: {
               type: 'text/plain',
             },
           },
           {
-            data: 'Nop',
+            data: '{"name": "some JSON"}',
             media: {
-              type: 'text/special',
+              type: 'application/json',
             },
           },
           {
-            data: 'Second info.',
+            data: Buffer.from([]),
             media: {
-              type: 'text/plain',
+              type: 'image/png',
             },
           },
         ]
@@ -269,7 +269,7 @@ describe('IssueHelpers', () => {
         }
         this.testCase.steps[1].attachments = [
           {
-            data: 'Third info.',
+            data: 'Other info.',
             media: {
               type: 'text/plain',
             },
@@ -283,10 +283,11 @@ describe('IssueHelpers', () => {
         expect(this.formattedIssue).to.eql(
           '1) Scenario: my scenario # a.feature:2\n' +
             `   ${figures.tick} Given step1 # steps.js:2\n` +
-            `       Attachment (text/plain): First info.\n` +
-            `       Attachment (text/plain): Second info.\n` +
+            `       Attachment (text/plain): Some info.\n` +
+            `       Attachment (application/json)\n` +
+            `       Attachment (image/png)\n` +
             `   ${figures.cross} When step2 # steps.js:3\n` +
-            `       Attachment (text/plain): Third info.\n` +
+            `       Attachment (text/plain): Other info.\n` +
             '       error\n' +
             '   - Then step3 # steps.js:4\n\n'
         )

--- a/src/formatter/helpers/issue_helpers_spec.js
+++ b/src/formatter/helpers/issue_helpers_spec.js
@@ -235,5 +235,62 @@ describe('IssueHelpers', () => {
         )
       })
     })
+
+    describe('step with attachment text', () => {
+      beforeEach(function() {
+        this.testCase.steps[0].result = this.passedStepResult
+        this.testCase.steps[0].attachments = [
+          {
+            data: 'First info.',
+            media: {
+              type: 'text/plain',
+            },
+          },
+          {
+            data: 'Nop',
+            media: {
+              type: 'text/special',
+            },
+          },
+          {
+            data: 'Second info.',
+            media: {
+              type: 'text/plain',
+            },
+          },
+        ]
+        this.testCase.steps[1] = {
+          actionLocation: { line: 3, uri: 'steps.js' },
+          sourceLocation: { line: 4, uri: 'a.feature' },
+          result: {
+            exception: 'error',
+            status: Status.FAILED,
+          },
+        }
+        this.testCase.steps[1].attachments = [
+          {
+            data: 'Third info.',
+            media: {
+              type: 'text/plain',
+            },
+          },
+        ]
+        this.testCase.steps[2].result = this.skippedStepResult
+        this.formattedIssue = formatIssue(this.options)
+      })
+
+      it('prints the scenario', function() {
+        expect(this.formattedIssue).to.eql(
+          '1) Scenario: my scenario # a.feature:2\n' +
+            `   ${figures.tick} Given step1 # steps.js:2\n` +
+            `       ${figures.info} First info.\n` +
+            `       ${figures.info} Second info.\n` +
+            `   ${figures.cross} When step2 # steps.js:3\n` +
+            `       ${figures.info} Third info.\n` +
+            '       error\n' +
+            '   - Then step3 # steps.js:4\n\n'
+        )
+      })
+    })
   })
 })

--- a/src/formatter/helpers/issue_helpers_spec.js
+++ b/src/formatter/helpers/issue_helpers_spec.js
@@ -283,10 +283,10 @@ describe('IssueHelpers', () => {
         expect(this.formattedIssue).to.eql(
           '1) Scenario: my scenario # a.feature:2\n' +
             `   ${figures.tick} Given step1 # steps.js:2\n` +
-            `       ${figures.info} First info.\n` +
-            `       ${figures.info} Second info.\n` +
+            `       Attachment (text/plain): First info.\n` +
+            `       Attachment (text/plain): Second info.\n` +
             `   ${figures.cross} When step2 # steps.js:3\n` +
-            `       ${figures.info} Third info.\n` +
+            `       Attachment (text/plain): Third info.\n` +
             '       error\n' +
             '   - Then step3 # steps.js:4\n\n'
         )


### PR DESCRIPTION
I found hard to log information right after a step without rewriting a whole custom formatter.

I suggest formatting each step attachment (text only) as line in the error summary.

![cucumber](https://user-images.githubusercontent.com/6873926/36262383-8ba33092-1267-11e8-881b-ed1cd17aa219.png)

What do you think ?
