### PR TITLE
Removed double quotes for JSON boolean value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,7 +358,7 @@ be used to get the name / tags of the running scenario. ([#947](https://github.c
 
 * Dropped support for Node 0.10
 * CLI
-  * `--colors / --no-colors` has moved to `--format-options '{"colorsEnabled": "<BOOLEAN>"}'`
+  * `--colors / --no-colors` has moved to `--format-options '{"colorsEnabled": <BOOLEAN>}'`
   * `--require <DIR|FILE>`: the required files are no longer reordered to require anything in a `support` directory first
   * `--snippet-interface <INTERFACE>` has moved to `--format-options '{"snippetInterface": "<INTERFACE>"}'`
   * `--snippet-syntax <SYNTAX>` has moved to `--format-options '{"snippetSyntax": "<SYNTAX>"}'`


### PR DESCRIPTION
It took me a while to figure out why the console was still printing colors even though I disabled them through "--format-options", but I figured out that's because "false" is parsed as true if used as string in JSON. Correct usage: --format-options '{"colorsEnabled": false}'