### PR TITLE
Phase-aware step definition wrappers

### DIFF
--- a/docs/support_files/api_reference.md
+++ b/docs/support_files/api_reference.md
@@ -75,25 +75,25 @@ Multiple `BeforeAll` hooks are executed in the order that they are defined.
 
 ---
 
-#### `defineStep(pattern[, options], fn, phase)`
+#### `defineStep(pattern[, options], fn)`
 
 Defines a step.
 
 * `pattern`: A regex or string pattern to match against a gherkin step.
 * `options`: An object with the following keys:
   - `timeout`: A step-specific timeout, to override the default timeout.
-  - `wrapperOptions`: step-specific options that are passed to the definition function wrapper
+  - `wrapperOptions`: step-specific options that are passed to the definition function wrapper.
+  - `phase`: A string equal to `'given'`, `'when'`, `'then'`, or `undefined`.
 * `fn`: A function, which should be defined as follows:
   - Should have one argument for each capture in the regular expression.
   - May have an additional argument if the gherkin step has a docstring or data table.
   - When using the asynchronous callback interface, have one final argument for the callback function.
-* `phase`: A string equal to `'given'`, `'when'`, `'then'`, or `undefined`.
 
 ---
 
 #### `Given(pattern[, options], fn)`
 
-Defines a step with the phase `'given'`.
+Defines a step with `options.phase` set to `'given'`.
 
 ---
 
@@ -129,10 +129,10 @@ function World({attach, parameters}) {
 
 #### `Then(pattern[, options], fn)`
 
-Defines a step with the phase `'then'`.
+Defines a step with `options.phase` set to `'then'`.
 
 ---
 
 #### `When(pattern[, options], fn)`
 
-Defines a step with the phase `'when'`.
+Defines a step with `options.phase` set to `'when'`.

--- a/docs/support_files/api_reference.md
+++ b/docs/support_files/api_reference.md
@@ -2,7 +2,7 @@
 
 ## API Reference
 
-Each method can be destructed from the object returned by `require('cucumber')`. 
+Each method can be destructured from the object returned by `require('cucumber')`.
 
 ---
 
@@ -75,11 +75,9 @@ Multiple `BeforeAll` hooks are executed in the order that they are defined.
 
 ---
 
-#### `defineStep(pattern[, options], fn)`
+#### `defineStep(pattern[, options], fn, phase)`
 
 Defines a step.
-
-Aliases: `Given`, `When`, `Then`.
 
 * `pattern`: A regex or string pattern to match against a gherkin step.
 * `options`: An object with the following keys:
@@ -89,12 +87,13 @@ Aliases: `Given`, `When`, `Then`.
   - Should have one argument for each capture in the regular expression.
   - May have an additional argument if the gherkin step has a docstring or data table.
   - When using the asynchronous callback interface, have one final argument for the callback function.
+* `phase`: A string equal to `'given'`, `'when'`, `'then'`, or `undefined`.
 
 ---
 
 #### `Given(pattern[, options], fn)`
 
-Alias of `defineStep`.
+Defines a step with the phase `'given'`.
 
 ---
 
@@ -130,10 +129,10 @@ function World({attach, parameters}) {
 
 #### `Then(pattern[, options], fn)`
 
-Alias of `defineStep`.
+Defines a step with the phase `'then'`.
 
 ---
 
 #### `When(pattern[, options], fn)`
 
-Alias of `defineStep`.
+Defines a step with the phase `'when'`.

--- a/features/step_wrapper_with_phase.feature
+++ b/features/step_wrapper_with_phase.feature
@@ -1,0 +1,39 @@
+Feature: Step Wrapper with Phase
+  In order to write step definition wrappers that are aware of the scenario phase
+  As a developer
+  I want Cucumber to provide a "phase" string to the wrapping function
+
+  @spawn
+  Scenario: phase passed to the step definitions wrapper
+    Given a file named "features/a.feature" with:
+      """
+      Feature: Steps with phases
+        Scenario: Steps
+          Given I run a given step
+          When I run a when step
+          Then I run a then step
+      """
+    And a file named "features/step_definitions/cucumber_steps.js" with:
+      """
+      import {Given, When, Then} from 'cucumber'
+
+      Given(/^I run a given step$/, function () {})
+      When(/^I run a when step$/, function () {})
+      Then(/^I run a then step$/, function () {})
+      """
+    And a file named "features/support/setup.js" with:
+      """
+      import {setDefinitionFunctionWrapper} from 'cucumber'
+
+      setDefinitionFunctionWrapper(function (fn, options = {}, phase) {
+        console.log("Phase: ", phase);
+        return fn;
+      })
+      """
+    When I run cucumber-js
+    Then the output contains the text:
+      """
+      Phase: given
+      Phase: when
+      Phase: then
+      """

--- a/src/models/step_definition.js
+++ b/src/models/step_definition.js
@@ -3,7 +3,8 @@ import DataTable from './data_table'
 import { buildStepArgumentIterator } from '../step_arguments'
 
 export default class StepDefinition {
-  constructor({ code, line, options, pattern, uri }) {
+  constructor({ phase, code, line, options, pattern, uri }) {
+    this.phase = phase
     this.code = code
     this.line = line
     this.options = options

--- a/src/support_code_library_builder/build_helpers.js
+++ b/src/support_code_library_builder/build_helpers.js
@@ -51,7 +51,7 @@ export function buildTestRunHookDefinition({ options, code, cwd }) {
   })
 }
 
-export function buildStepDefinition({ pattern, options, code, phase, cwd }) {
+export function buildStepDefinition({ pattern, options, code, cwd }) {
   if (typeof options === 'function') {
     code = options
     options = {}
@@ -63,7 +63,6 @@ export function buildStepDefinition({ pattern, options, code, phase, cwd }) {
     location: formatLocation({ line, uri }),
   })
   return new StepDefinition({
-    phase,
     code,
     line,
     options,

--- a/src/support_code_library_builder/build_helpers.js
+++ b/src/support_code_library_builder/build_helpers.js
@@ -51,7 +51,7 @@ export function buildTestRunHookDefinition({ options, code, cwd }) {
   })
 }
 
-export function buildStepDefinition({ pattern, options, code, cwd }) {
+export function buildStepDefinition({ pattern, options, code, phase, cwd }) {
   if (typeof options === 'function') {
     code = options
     options = {}
@@ -63,6 +63,7 @@ export function buildStepDefinition({ pattern, options, code, cwd }) {
     location: formatLocation({ line, uri }),
   })
   return new StepDefinition({
+    phase,
     code,
     line,
     options,

--- a/src/support_code_library_builder/finalize_helpers.js
+++ b/src/support_code_library_builder/finalize_helpers.js
@@ -13,7 +13,8 @@ export function wrapDefinitions({
       const codeLength = definition.code.length
       const wrappedFn = definitionFunctionWrapper(
         definition.code,
-        definition.options.wrapperOptions
+        definition.options.wrapperOptions,
+        definition.phase
       )
       if (wrappedFn !== definition.code) {
         definition.code = arity(codeLength, wrappedFn)

--- a/src/support_code_library_builder/finalize_helpers.js
+++ b/src/support_code_library_builder/finalize_helpers.js
@@ -14,7 +14,7 @@ export function wrapDefinitions({
       const wrappedFn = definitionFunctionWrapper(
         definition.code,
         definition.options.wrapperOptions,
-        definition.phase
+        definition.options.phase
       )
       if (wrappedFn !== definition.code) {
         definition.code = arity(codeLength, wrappedFn)

--- a/src/support_code_library_builder/index.js
+++ b/src/support_code_library_builder/index.js
@@ -31,15 +31,14 @@ export class SupportCodeLibraryBuilder {
         this.options.World = fn
       },
     }
-    this.methods.Given = (pattern, options, code) => {
-      return this.methods.defineStep(pattern, options, code, 'given')
-    }
-    this.methods.When = (pattern, options, code) => {
-      return this.methods.defineStep(pattern, options, code, 'when')
-    }
-    this.methods.Then = (pattern, options, code) => {
-      return this.methods.defineStep(pattern, options, code, 'then')
-    }
+    const defineStepWithPhase = phase => (pattern, options, code) =>
+      typeof code === 'function'
+        ? this.methods.defineStep(pattern, _.assign(options, { phase }), code)
+        : this.methods.defineStep(pattern, { phase }, options)
+
+    this.methods.Given = defineStepWithPhase('given')
+    this.methods.When = defineStepWithPhase('when')
+    this.methods.Then = defineStepWithPhase('then')
   }
 
   defineParameterType(options) {
@@ -47,12 +46,11 @@ export class SupportCodeLibraryBuilder {
     this.options.parameterTypeRegistry.defineParameterType(parameterType)
   }
 
-  defineStep(pattern, options, code, phase) {
+  defineStep(pattern, options, code) {
     const stepDefinition = buildStepDefinition({
       pattern,
       options,
       code,
-      phase,
       cwd: this.cwd,
     })
     this.options.stepDefinitions.push(stepDefinition)

--- a/src/support_code_library_builder/index.js
+++ b/src/support_code_library_builder/index.js
@@ -31,7 +31,15 @@ export class SupportCodeLibraryBuilder {
         this.options.World = fn
       },
     }
-    this.methods.Given = this.methods.When = this.methods.Then = this.methods.defineStep
+    this.methods.Given = (pattern, options, code) => {
+      return this.methods.defineStep(pattern, options, code, 'given')
+    }
+    this.methods.When = (pattern, options, code) => {
+      return this.methods.defineStep(pattern, options, code, 'when')
+    }
+    this.methods.Then = (pattern, options, code) => {
+      return this.methods.defineStep(pattern, options, code, 'then')
+    }
   }
 
   defineParameterType(options) {
@@ -39,11 +47,12 @@ export class SupportCodeLibraryBuilder {
     this.options.parameterTypeRegistry.defineParameterType(parameterType)
   }
 
-  defineStep(pattern, options, code) {
+  defineStep(pattern, options, code, phase) {
     const stepDefinition = buildStepDefinition({
       pattern,
       options,
       code,
+      phase,
       cwd: this.cwd,
     })
     this.options.stepDefinitions.push(stepDefinition)


### PR DESCRIPTION
My step definitions use different implementations of a common "user interface adapter" abstraction in Given/When/Then steps. You can see a rough example of this idea in the [todo-subsecond repo](https://github.com/subsecondtdd/todo-subsecond/blob/master/features/step_definitions/todo_steps.js).

I would like to enforce a strict separation of `given` steps talking directly to the domain model, versus `when` and `then` steps interacting with user interfaces.

However, because `Given`, `When` and `Then` are synonyms of `defineStep`, I cannot distinguish between these different steps in `setDefinitionFunctionWrapper`.

So this change adds a "phase" property to the `StepDefinition` model, which is then exposed as an additional argument to the `setDefinitionFunctionWrapper` helper. I'm not sure `phase` is the right name, what do you think?

If there is an alternative way of achieving what I'm after, I'd be happy to hear it!