### PR TITLE
[Issue-1087] Wrong spawning of slave processes on Windows

### DIFF
--- a/src/runtime/parallel/master.js
+++ b/src/runtime/parallel/master.js
@@ -55,7 +55,7 @@ export default class Master {
   }
 
   startSlave(id, total) {
-    const slaveProcess = childProcess.spawn(slaveCommand, [], {
+    const slaveProcess = childProcess.spawn(process.execPath, [slaveCommand], {
       env: _.assign({}, process.env, {
         CUCUMBER_PARALLEL: 'true',
         CUCUMBER_TOTAL_SLAVES: total,


### PR DESCRIPTION
This branch fixes wrong spawning of slave processes on Windows when running cucumber-js with `--parallel` flag

[Issue-1087](https://github.com/cucumber/cucumber-js/issues/1087)