### PR TITLE
pass pattern to definitionFunctionWrapper

### DIFF
--- a/src/support_code_library_builder/finalize_helpers.js
+++ b/src/support_code_library_builder/finalize_helpers.js
@@ -13,7 +13,8 @@ export function wrapDefinitions({
       const codeLength = definition.code.length
       const wrappedFn = definitionFunctionWrapper(
         definition.code,
-        definition.options.wrapperOptions
+        definition.options.wrapperOptions,
+        definition.pattern
       )
       if (wrappedFn !== definition.code) {
         definition.code = arity(codeLength, wrappedFn)

--- a/src/support_code_library_builder/finalize_helpers_spec.js
+++ b/src/support_code_library_builder/finalize_helpers_spec.js
@@ -1,0 +1,34 @@
+import { beforeEach, describe, it } from 'mocha'
+import sinon from 'sinon'
+import { wrapDefinitions } from './finalize_helpers'
+
+describe('wrapDefinitions', () => {
+  describe('pass parameters to wrapper', () => {
+    beforeEach(function() {
+      this.code = ''
+      this.definitionFunctionWrapper = sinon.mock().returns(this.code)
+      this.expected_pattern = 'expected pattern'
+      this.definitions = [
+        {
+          code: this.code,
+          options: { wrapperOptions: {} },
+          pattern: this.expected_pattern,
+        },
+      ]
+    })
+
+    it('passes the pattern to the wrapper', function() {
+      wrapDefinitions({
+        cwd: '.',
+        definitionFunctionWrapper: this.definitionFunctionWrapper,
+        definitions: this.definitions,
+      })
+      sinon.assert.calledWith(
+        this.definitionFunctionWrapper,
+        sinon.match.any,
+        sinon.match.any,
+        sinon.match(this.expected_pattern)
+      )
+    })
+  })
+})


### PR DESCRIPTION
required to get access to the step's definition pattern
when writing a BeforeStep / AfterStep hook as mentioned in #997 

comments / feedback welcome :)