### PR TITLE
Update string-argv

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "serialize-error": "^2.1.0",
     "stack-chain": "^2.0.0",
     "stacktrace-js": "^2.0.0",
-    "string-argv": "0.0.2",
+    "string-argv": "0.1.1",
     "title-case": "^2.1.1",
     "util-arity": "^1.0.2",
     "verror": "^1.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4575,9 +4575,9 @@ stream-to-string@^1.1.0:
   dependencies:
     promise-polyfill "^1.1.6"
 
-string-argv@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
+string-argv@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.1.1.tgz#66bd5ae3823708eaa1916fa5412703150d4ddfaf"
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
The older string-argv versions lack a full license text and thus are to be treated as a proprietary code.

Related to https://github.com/cucumber/cucumber-js/issues/1124