### PR TITLE
Use more recent version of glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "escape-string-regexp": "^1.0.5",
     "figures": "2.0.0",
     "gherkin": "^5.0.0",
-    "glob": "^7.0.0",
+    "glob": "^7.1.3",
     "indent-string": "^3.1.0",
     "is-generator": "^1.0.2",
     "is-stream": "^1.1.0",


### PR DESCRIPTION
The lowest version(s) of `glob` allowed to be used as a dependency for cucumber does not create absolute paths on my setup, despite `absolute: true` on this line: https://github.com/hypesystem/cucumber-js/blob/master/src/cli/configuration_builder.js#L75

I think the fix may have been https://github.com/isaacs/node-glob/pull/303. At least, setting the version to `^7.1.3` fixes the issue on my setup.

To avoid the issue for other people, I suggest upping the version of `glob` 😄 