### PR TITLE
Keep skipped status

### DIFF
--- a/features/skipped_steps.feature
+++ b/features/skipped_steps.feature
@@ -26,6 +26,14 @@ Feature: Skipped steps
     When I run cucumber-js
     Then it passes
     And the step "a skipped step" has status "skipped"
+    And it outputs the text:
+      """
+      -
+
+      1 scenario (1 skipped)
+      1 step (1 skipped)
+      <duration-stat>
+      """
 
 
   Scenario: Callback skipped step
@@ -40,6 +48,14 @@ Feature: Skipped steps
     When I run cucumber-js
     Then it passes
     And the step "a skipped step" has status "skipped"
+    And it outputs the text:
+      """
+      -
+
+      1 scenario (1 skipped)
+      1 step (1 skipped)
+      <duration-stat>
+      """
 
   Scenario: Promise skipped step
     Given a file named "features/step_definitions/skipped_steps.js" with:
@@ -59,6 +75,14 @@ Feature: Skipped steps
     When I run cucumber-js
     Then it passes
     And the step "a skipped step" has status "skipped"
+    And it outputs the text:
+      """
+      -
+
+      1 scenario (1 skipped)
+      1 step (1 skipped)
+      <duration-stat>
+      """
 
   Scenario: Hook skipped scenario steps
     Given a file named "features/support/hooks.js" with:
@@ -78,6 +102,14 @@ Feature: Skipped steps
     When I run cucumber-js
     Then it passes
     And the step "a skipped step" has status "skipped"
+    And it outputs the text:
+      """
+      --
+
+      1 scenario (1 skipped)
+      1 step (1 skipped)
+      <duration-stat>
+      """
 
   Scenario: Skipped before hook should skip all before hooks
     Given a file named "features/step_definitions/world.js" with:
@@ -108,6 +140,14 @@ Feature: Skipped steps
       """
     When I run cucumber-js
     Then it passes 
+    And it outputs the text:
+      """
+      ---.
+
+      1 scenario (1 skipped)
+      1 step (1 skipped)
+      <duration-stat>
+      """
 
   Scenario: Skipped before hook should run after hook 
     Given a file named "features/support/hooks.js" with:
@@ -131,3 +171,11 @@ Feature: Skipped steps
     When I run cucumber-js
     Then it passes
     And the "After" hook has status "passed"
+    And it outputs the text:
+      """
+      ---.
+
+      1 scenario (1 skipped)
+      1 step (1 skipped)
+      <duration-stat>
+      """

--- a/src/runtime/test_case_runner.js
+++ b/src/runtime/test_case_runner.js
@@ -130,9 +130,9 @@ export default class TestCaseRunner {
       case Status.UNDEFINED:
       case Status.FAILED:
       case Status.AMBIGUOUS:
-        return (
-          this.result.status !== Status.FAILED ||
-          this.result.status !== Status.AMBIGUOUS
+        return !_.some(
+          [Status.FAILED, Status.AMBIGUOUS, Status.UNDEFINED],
+          this.result.status
         )
       default:
         return this.result.status === Status.PASSED

--- a/src/runtime/test_case_runner.js
+++ b/src/runtime/test_case_runner.js
@@ -135,10 +135,7 @@ export default class TestCaseRunner {
           this.result.status !== Status.AMBIGUOUS
         )
       default:
-        return (
-          this.result.status === Status.PASSED ||
-          this.result.status === Status.SKIPPED
-        )
+        return this.result.status === Status.PASSED
     }
   }
 

--- a/src/runtime/test_case_runner.js
+++ b/src/runtime/test_case_runner.js
@@ -127,6 +127,7 @@ export default class TestCaseRunner {
 
   shouldUpdateStatus(testStepResult) {
     switch (testStepResult.status) {
+      case Status.UNDEFINED:
       case Status.FAILED:
       case Status.AMBIGUOUS:
         return (


### PR DESCRIPTION
## Problem description

If I skip a Scenario from a Before hook (like explained [here](https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/hooks.md#skipping-in-a-before-hook)) but I also add an After hook, the execution of the After hook causes the status of the scenario to change from `SKIPPED` to `PASSED`

To see the issue on the [browser example](http://cucumber.github.io/cucumber-js/), paste the following code in the steps definitions
<details><summary>Step definitions</summary>
<p>

```javascript
// Cucumber and chai have been loaded in the browser
var setWorldConstructor = Cucumber.setWorldConstructor;
var Given = Cucumber.Given;
var When = Cucumber.When;
var Then = Cucumber.Then;
var Before = Cucumber.Before;
var After = Cucumber.After;
var expect = chai.expect;

///// World /////
//
// Call 'setWorldConstructor' with to your custom world (optional)
//

var CustomWorld = function() {
  this.variable = 0;
};

CustomWorld.prototype.setTo = function(number) {
  this.variable = parseInt(number);
};

CustomWorld.prototype.incrementBy = function(number) {
  this.variable += parseInt(number);
};

setWorldConstructor(CustomWorld);

///// Step definitions /////
//
// use 'Given', 'When' and 'Then' to declare step definitions
//

Before(function(){
    return 'skipped';
});

Given('a variable set to {int}', function(number) {
  this.setTo(number);
});

When('I increment the variable by {int}', function(number) {
  this.incrementBy(number);
});

Then('the variable should contain {int}', function(number) {
  expect(this.variable).to.eql(number)
});

After(function(){
    // some code
})
```
</p>
</details>

The output is the following:
![image](https://user-images.githubusercontent.com/6963984/50731857-50f68d00-114d-11e9-9468-9013c1b96a9c.png)

But I would expect this:
![image](https://user-images.githubusercontent.com/6963984/50731861-6370c680-114d-11e9-8f51-a74142aa9ad9.png)

## Motivation for the change:

As mentioned by @charlierudolph [here](https://github.com/cucumber/cucumber-js/issues/873#issuecomment-312775245) the After hooks must be executed even if the Scenario is skipped, but the Scenario should be marked as `SKIPPED` nevertheless in order to provide accurate metrics.

## The solution 
`shouldUpdateStatus` in `src/runtime/test_case_runner.js` now returns `false` if the current status of the test case is `SKIPPED`, with the only exception if the last step is `UNDEFINED`

In a more natural language: If there is at least one step SKIPPED, then the Scenario starts to skip the rest and is marked as SKIPPED, unless it has UNDEFINED steps

## Notes:
* Relates to #873 #912 
* Running `npm test` locally I get the following message:
<details><summary>test output</summary>
<p>

```
1) Scenario: Ability to specify multiple formatters # features/language.feature:17
   ✔ Before # features/support/hooks.js:21
   ✔ Given a file named "features/a.feature" with: # features/step_definitions/file_steps.js:11
       """
       Fonctionnalité: Bonjour
         Scénario: Monde
           Soit une étape
       """
   ✔ And a file named "features/step_definitions/cucumber_steps.js" with: # features/step_definitions/file_steps.js:11
       """
       import {Given} from 'cucumber'

       Given(/^une étape$/, function() {})
       """
   ✔ When I run cucumber-js with `--language fr` # features/step_definitions/cli_steps.js:9
   ✖ Then it outputs the text: # features/step_definitions/cli_steps.js:36
       """
       .

       1 scenario (1 passed)
       1 step (1 passed)
       <duration-stat>
       """
       AssertionError
           + expected - actual

           +.
           +
           +1 scenario (1 passed)
           +1 step (1 passed)
           +<duration-stat>
       
           at World.eql (/home/useloom/repos/cucumber-js/features/step_definitions/cli_steps.js:39:27)
   ✖ After # features/support/hooks.js:76
       Error: Last run errored unexpectedly. Output:



       Error Output:

       TypeError: Cannot read property 'line' of undefined
           at Object.generateEvents (/home/useloom/repos/cucumber-js/node_modules/gherkin/lib/gherkin/generate_events.js:61:38)
           at /home/useloom/repos/cucumber-js/lib/cli/helpers.js:111:37
           at Generator.next (<anonymous>)
           at asyncGeneratorStep (/home/useloom/repos/cucumber-js/lib/cli/helpers.js:29:103)
           at _next (/home/useloom/repos/cucumber-js/lib/cli/helpers.js:31:194)
           at /home/useloom/repos/cucumber-js/lib/cli/helpers.js:31:364
           at new Promise (<anonymous>)
           at /home/useloom/repos/cucumber-js/lib/cli/helpers.js:31:97
           at getTestCases (/home/useloom/repos/cucumber-js/lib/cli/helpers.js:97:24)
           at /home/useloom/repos/cucumber-js/lib/cli/helpers.js:77:39
           at Generator.next (<anonymous>)
           at asyncGeneratorStep (/home/useloom/repos/cucumber-js/lib/cli/helpers.js:29:103)
           at _next (/home/useloom/repos/cucumber-js/lib/cli/helpers.js:31:194)
           at <anonymous>
           at World.<anonymous> (/home/useloom/repos/cucumber-js/features/support/hooks.js:78:11)


216 scenarios (1 failed, 215 passed)
1067 steps (1 failed, 1066 passed)
1m08.437s
error Command failed with exit code 1.
```

</p>
</details>

* That was happening before I made any change to the code. I am unsure of the cause, (may be a problem with my local set up?)