### PR TITLE
Add node 11 to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ notifications:
 
 matrix:
   include:
+    - node_js: "11"
+      script: "yarn test-coverage"
     - node_js: "10"
       script: "yarn test-coverage"
       after_success: "nyc report --reporter=text-lcov | coveralls"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ cache:
 
 environment:
   matrix:
+    - nodejs_version: '11'
     - nodejs_version: '10'
     - nodejs_version: '8'
 


### PR DESCRIPTION
Node uses major versions to denote LTS versions however, the current version of Node can be an odd major version.

Right now the current version is Node 11, it will EOL when Node 12. See https://nodesource.com/blog/understanding-how-node-js-release-lines-work/

I think it makes sense to support the current Node version as well as LTS versions.