### PR TITLE
Issues: 997 - Adding beforeStep/afterStep hooks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,12 +22,14 @@ export { default as UsageFormatter } from './formatter/usage_formatter'
 export { default as UsageJsonFormatter } from './formatter/usage_json_formatter'
 export { formatterHelpers }
 
-// Support Code Fuctions
+// Support Code Functions
 const { methods } = supportCodeLibraryBuilder
 export const After = methods.After
 export const AfterAll = methods.AfterAll
+export const AfterStep = methods.AfterStep
 export const Before = methods.Before
 export const BeforeAll = methods.BeforeAll
+export const BeforeStep = methods.BeforeStep
 export const defineParameterType = methods.defineParameterType
 export const defineStep = methods.defineStep
 export const Given = methods.Given

--- a/src/models/test_step_hook_definition.ts
+++ b/src/models/test_step_hook_definition.ts
@@ -1,0 +1,34 @@
+import { PickleTagFilter } from '../pickle_filter'
+import Definition, {
+  IDefinition,
+  IGetInvocationDataResponse,
+  IGetInvocationDataRequest,
+  IDefinitionParameters,
+  IHookDefinitionOptions,
+} from './definition'
+import { messages } from 'cucumber-messages'
+
+export default class TestStepHookDefinition extends Definition
+  implements IDefinition {
+  private readonly pickleTagFilter: PickleTagFilter
+
+  constructor(data: IDefinitionParameters<IHookDefinitionOptions>) {
+    super(data)
+    this.pickleTagFilter = new PickleTagFilter(data.options.tags)
+  }
+
+  appliesToTestCase(pickle: messages.IPickle): boolean {
+    return this.pickleTagFilter.matchesAllTagExpressions(pickle)
+  }
+
+  async getInvocationParameters({
+    hookParameter,
+  }: IGetInvocationDataRequest): Promise<IGetInvocationDataResponse> {
+    return Promise.resolve({
+      getInvalidCodeLengthMessage: () =>
+        this.buildInvalidCodeLengthMessage('0 or 1', '2'),
+      parameters: [hookParameter],
+      validCodeLengths: [0, 1, 2],
+    })
+  }
+}

--- a/src/support_code_library_builder/index.ts
+++ b/src/support_code_library_builder/index.ts
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import { buildParameterType, getDefinitionLineAndUri } from './build_helpers'
 import { IdGenerator } from 'cucumber-messages'
 import TestCaseHookDefinition from '../models/test_case_hook_definition'
+import TestStepHookDefinition from '../models/test_step_hook_definition'
 import TestRunHookDefinition from '../models/test_run_hook_definition'
 import StepDefinition from '../models/step_definition'
 import { formatLocation } from '../formatter/helpers'
@@ -19,7 +20,9 @@ import {
   DefineStepPattern,
   IDefineStepOptions,
   IDefineTestCaseHookOptions,
+  IDefineTestStepHookOptions,
   TestCaseHookFunction,
+  TestStepHookFunction,
   IDefineTestRunHookOptions,
   ISupportCodeLibrary,
   IParameterTypeDefinition,
@@ -41,6 +44,13 @@ interface ITestCaseHookDefinitionConfig {
   uri: string
 }
 
+interface ITestStepHookDefinitionConfig {
+  code: any
+  line: number
+  options: any
+  uri: string
+}
+
 interface ITestRunHookDefinitionConfig {
   code: any
   line: number
@@ -53,8 +63,10 @@ export class SupportCodeLibraryBuilder {
 
   private afterTestCaseHookDefinitionConfigs: ITestCaseHookDefinitionConfig[]
   private afterTestRunHookDefinitionConfigs: ITestRunHookDefinitionConfig[]
+  private afterTestStepHookDefinitionConfigs: ITestStepHookDefinitionConfig[]
   private beforeTestCaseHookDefinitionConfigs: ITestCaseHookDefinitionConfig[]
   private beforeTestRunHookDefinitionConfigs: ITestRunHookDefinitionConfig[]
+  private beforeTestStepHookDefinitionConfigs: ITestStepHookDefinitionConfig[]
   private cwd: string
   private defaultTimeout: number
   private definitionFunctionWrapper: any
@@ -72,11 +84,17 @@ export class SupportCodeLibraryBuilder {
       AfterAll: this.defineTestRunHook(
         () => this.afterTestRunHookDefinitionConfigs
       ),
+      AfterStep: this.defineTestStepHook(
+        () => this.afterTestStepHookDefinitionConfigs
+      ),
       Before: this.defineTestCaseHook(
         () => this.beforeTestCaseHookDefinitionConfigs
       ),
       BeforeAll: this.defineTestRunHook(
         () => this.beforeTestRunHookDefinitionConfigs
+      ),
+      BeforeStep: this.defineTestStepHook(
+        () => this.beforeTestStepHookDefinitionConfigs
       ),
       defineParameterType: this.defineParameterType.bind(this),
       defineStep,
@@ -155,6 +173,37 @@ export class SupportCodeLibraryBuilder {
     }
   }
 
+  defineTestStepHook(
+    getCollection: () => ITestStepHookDefinitionConfig[]
+  ): (
+    options: string | IDefineTestStepHookOptions | TestStepHookFunction,
+    code?: TestStepHookFunction
+  ) => void {
+    return (
+      options: string | IDefineTestStepHookOptions | TestStepHookFunction,
+      code?: TestStepHookFunction
+    ) => {
+      if (typeof options === 'string') {
+        options = { tags: options }
+      } else if (typeof options === 'function') {
+        code = options
+        options = {}
+      }
+      const { line, uri } = getDefinitionLineAndUri(this.cwd)
+      validateArguments({
+        args: { code, options },
+        fnName: 'defineTestStepHook',
+        location: formatLocation({ line, uri }),
+      })
+      getCollection().push({
+        code,
+        line,
+        options,
+        uri,
+      })
+    }
+  }
+
   defineTestRunHook(
     getCollection: () => ITestRunHookDefinitionConfig[]
   ): (options: IDefineTestRunHookOptions | Function, code?: Function) => void {
@@ -205,6 +254,25 @@ export class SupportCodeLibraryBuilder {
         wrapperOptions: options.wrapperOptions,
       })
       return new TestCaseHookDefinition({
+        code: wrappedCode,
+        id: this.newId(),
+        line,
+        options,
+        unwrappedCode: code,
+        uri,
+      })
+    })
+  }
+
+  buildTestStepHookDefinitions(
+    configs: ITestStepHookDefinitionConfig[]
+  ): TestStepHookDefinition[] {
+    return configs.map(({ code, line, options, uri }) => {
+      const wrappedCode = this.wrapCode({
+        code,
+        wrapperOptions: options.wrapperOptions,
+      })
+      return new TestStepHookDefinition({
         code: wrappedCode,
         id: this.newId(),
         line,
@@ -279,11 +347,17 @@ export class SupportCodeLibraryBuilder {
       afterTestRunHookDefinitions: this.buildTestRunHookDefinitions(
         this.afterTestRunHookDefinitionConfigs
       ).reverse(),
+      afterTestStepHookDefinitions: this.buildTestStepHookDefinitions(
+        this.afterTestStepHookDefinitionConfigs
+      ).reverse(),
       beforeTestCaseHookDefinitions: this.buildTestCaseHookDefinitions(
         this.beforeTestCaseHookDefinitionConfigs
       ),
       beforeTestRunHookDefinitions: this.buildTestRunHookDefinitions(
         this.beforeTestRunHookDefinitionConfigs
+      ),
+      beforeTestStepHookDefinitions: this.buildTestStepHookDefinitions(
+        this.beforeTestStepHookDefinitionConfigs
       ),
       defaultTimeout: this.defaultTimeout,
       parameterTypeRegistry: this.parameterTypeRegistry,
@@ -297,8 +371,10 @@ export class SupportCodeLibraryBuilder {
     this.newId = newId
     this.afterTestCaseHookDefinitionConfigs = []
     this.afterTestRunHookDefinitionConfigs = []
+    this.afterTestStepHookDefinitionConfigs = []
     this.beforeTestCaseHookDefinitionConfigs = []
     this.beforeTestRunHookDefinitionConfigs = []
+    this.beforeTestStepHookDefinitionConfigs = []
     this.definitionFunctionWrapper = null
     this.defaultTimeout = 5000
     this.parameterTypeRegistry = new ParameterTypeRegistry()

--- a/src/support_code_library_builder/types.ts
+++ b/src/support_code_library_builder/types.ts
@@ -1,5 +1,6 @@
 import { messages } from 'cucumber-messages'
 import TestCaseHookDefinition from '../models/test_case_hook_definition'
+import TestStepHookDefinition from '../models/test_step_hook_definition'
 import TestRunHookDefinition from '../models/test_run_hook_definition'
 import StepDefinition from '../models/step_definition'
 import { ParameterTypeRegistry } from 'cucumber-expressions'
@@ -7,6 +8,13 @@ import { ParameterTypeRegistry } from 'cucumber-expressions'
 export type DefineStepPattern = string | RegExp
 
 export interface ITestCaseHookParameter {
+  gherkinDocument: messages.IGherkinDocument
+  pickle: messages.IPickle
+  result?: messages.ITestResult
+  testCaseStartedId: string
+}
+
+export interface ITestStepHookParameter {
   gherkinDocument: messages.IGherkinDocument
   pickle: messages.IPickle
   result?: messages.ITestResult
@@ -21,12 +29,25 @@ export type TestCaseHookFunction =
   | TestCaseHookFunctionWithoutParameter
   | TestCaseHookFunctionWithParameter
 
+export type TestStepHookFunctionWithoutParameter = () => void
+export type TestStepHookFunctionWithParameter = (
+  arg: ITestStepHookParameter
+) => void
+export type TestStepHookFunction =
+  | TestStepHookFunctionWithoutParameter
+  | TestStepHookFunctionWithParameter
+
 export interface IDefineStepOptions {
   timeout?: number
   wrapperOptions?: any
 }
 
 export interface IDefineTestCaseHookOptions {
+  tags?: string
+  timeout?: number
+}
+
+export interface IDefineTestStepHookOptions {
   tags?: string
   timeout?: number
 }
@@ -57,11 +78,23 @@ export interface IDefineSupportCodeMethods {
   After(code: TestCaseHookFunction): void
   After(tags: string, code: TestCaseHookFunction): void
   After(options: IDefineTestCaseHookOptions, code: TestCaseHookFunction): void
+  AfterStep(code: TestStepHookFunction): void
+  AfterStep(tags: string, code: TestStepHookFunction): void
+  AfterStep(
+    options: IDefineTestStepHookOptions,
+    code: TestStepHookFunction
+  ): void
   AfterAll(code: Function): void
   AfterAll(options: IDefineTestRunHookOptions, code: Function): void
   Before(code: TestCaseHookFunction): void
   Before(tags: string, code: TestCaseHookFunction): void
   Before(options: IDefineTestCaseHookOptions, code: TestCaseHookFunction): void
+  BeforeStep(code: TestStepHookFunction): void
+  BeforeStep(tags: string, code: TestStepHookFunction): void
+  BeforeStep(
+    options: IDefineTestStepHookOptions,
+    code: TestStepHookFunction
+  ): void
   BeforeAll(code: Function): void
   BeforeAll(options: IDefineTestRunHookOptions, code: Function): void
   Given(pattern: DefineStepPattern, code: Function): void
@@ -86,8 +119,10 @@ export interface IDefineSupportCodeMethods {
 
 export interface ISupportCodeLibrary {
   readonly afterTestCaseHookDefinitions: TestCaseHookDefinition[]
+  readonly afterTestStepHookDefinitions: TestStepHookDefinition[]
   readonly afterTestRunHookDefinitions: TestRunHookDefinition[]
   readonly beforeTestCaseHookDefinitions: TestCaseHookDefinition[]
+  readonly beforeTestStepHookDefinitions: TestStepHookDefinition[]
   readonly beforeTestRunHookDefinitions: TestRunHookDefinition[]
   readonly defaultTimeout: number
   readonly stepDefinitions: StepDefinition[]

--- a/src/support_code_library_builder/validate_arguments.ts
+++ b/src/support_code_library_builder/validate_arguments.ts
@@ -54,6 +54,18 @@ const validations: Dictionary<IValidation[]> = {
     optionsTimeoutValidation,
     { identifier: 'second argument', ...fnValidation },
   ],
+  defineTestStepHook: [
+    { identifier: 'first argument', ...optionsValidation },
+    {
+      identifier: '"options.tags"',
+      expectedType: 'string',
+      predicate({ options }) {
+        return doesNotHaveValue(options.tags) || _.isString(options.tags)
+      },
+    },
+    optionsTimeoutValidation,
+    { identifier: 'second argument', ...fnValidation },
+  ],
   defineStep: [
     {
       identifier: 'first argument',


### PR DESCRIPTION
This is my proposed solution for the problem: cucumber/cucumber-js#997
Basically I'm treating the beforeStep/afterStep hooks as steps, which allowed me to integrate them with minimal change.

Please let me know what you think about this solution, or if you want me to update/change something.