### PR TITLE
handle hook errors in parallel mode

### DIFF
--- a/features/parallel.feature
+++ b/features/parallel.feature
@@ -1,6 +1,6 @@
 Feature: Running scenarios in parallel
 
-  Background:
+  Scenario: running in parallel can improve speed if there are async operations
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
       import {Given} from 'cucumber'
@@ -10,9 +10,7 @@ Feature: Running scenarios in parallel
         setTimeout(callback, 1000)
       })
       """
-
-  Scenario: running in parallel can improve speed if there are async operations
-    Given a file named "features/a.feature" with:
+    And a file named "features/a.feature" with:
       """
       Feature: slow
         Scenario: a
@@ -23,3 +21,26 @@ Feature: Running scenarios in parallel
       """
     When I run cucumber-js with `--parallel 2`
     Then it passes
+
+  Scenario: an error in BeforeAll fails the test
+    Given a file named "features/step_definitions/cucumber_steps.js" with:
+      """
+      import {BeforeAll, Given} from 'cucumber'
+      import Promise from 'bluebird'
+
+      Given(/^a slow step$/, function(callback) {
+        setTimeout(callback, 1000)
+      })
+
+      BeforeAll(function() {
+        throw new Error('fail')
+      })
+      """
+    And a file named "features/a.feature" with:
+      """
+      Feature: slow
+        Scenario: a
+          Given a slow step
+      """
+    When I run cucumber-js with `--parallel 2`
+    Then it fails

--- a/src/runtime/parallel/master.js
+++ b/src/runtime/parallel/master.js
@@ -66,8 +66,11 @@ export default class Master {
     slave.process.on('message', message => {
       this.parseSlaveMessage(slave, message)
     })
-    slave.process.on('close', () => {
+    slave.process.on('close', error => {
       slave.closed = true
+      if (error) {
+        this.result.success = false
+      }
       this.onSlaveClose()
     })
     slave.process.send({

--- a/src/runtime/parallel/run_slave.js
+++ b/src/runtime/parallel/run_slave.js
@@ -4,7 +4,7 @@ export default async function run() {
   const slave = new Slave({
     sendMessage: m => process.send(m),
     cwd: process.cwd(),
-    exit: () => process.exit(),
+    exit: status => process.exit(status),
   })
   process.on('message', m => slave.receiveMessage(m))
 }

--- a/src/runtime/parallel/slave.js
+++ b/src/runtime/parallel/slave.js
@@ -106,10 +106,15 @@ export default class Slave {
       })
       if (error) {
         const location = formatLocation(hookDefinition)
-        throw new VError(
-          error,
-          `${name} hook errored, process exiting: ${location}`
-        )
+        console.error(
+          VError.fullStack(
+            new VError(
+              error,
+              `${name} hook errored, process exiting: ${location}`
+            )
+          )
+        ) // eslint-disable-line no-console
+        this.exit(1)
       }
     })
   }


### PR DESCRIPTION
When running in parallel mode, if the `BeforeAll` hook fails it throws an error that nothing is currently catching, resulting in an unhandled rejection error and the slave hanging forever.

I've updated the files involved to console.error log the message and exit the process with an error code (this is what the non parallel run does (https://github.com/cucumber/cucumber-js/blob/master/src/cli/run.js#L5))

Also needed to update master and slave runner to use the process error code to fail the test.