### PR TITLE
set original code on `unwrappedCode` if wrapping

### DIFF
--- a/src/formatter/helpers/usage_helpers/index.js
+++ b/src/formatter/helpers/usage_helpers/index.js
@@ -2,12 +2,19 @@ import _ from 'lodash'
 import { formatLocation } from '../location_helpers'
 import { getStepLineToPickledStepMap } from '../pickle_parser'
 
+function getCodeAsString(stepDefinition) {
+  if (typeof stepDefinition.unwrappedCode === 'function') {
+    return stepDefinition.unwrappedCode.toString()
+  }
+  return stepDefinition.code.toString()
+}
+
 function buildEmptyMapping(stepDefinitions) {
   const mapping = {}
   stepDefinitions.forEach(stepDefinition => {
     const location = formatLocation(stepDefinition)
     mapping[location] = {
-      code: stepDefinition.code.toString(),
+      code: getCodeAsString(stepDefinition),
       line: stepDefinition.line,
       pattern: stepDefinition.expression.source,
       patternType: stepDefinition.expression.constructor.name,

--- a/src/formatter/helpers/usage_helpers/index_spec.js
+++ b/src/formatter/helpers/usage_helpers/index_spec.js
@@ -4,12 +4,14 @@ import { getUsage } from './'
 import EventEmitter from 'events'
 import Gherkin from 'gherkin'
 import EventDataCollector from '../event_data_collector'
+import { CucumberExpression, ParameterTypeRegistry } from 'cucumber-expressions'
 
 describe('Usage Helpers', () => {
   describe('getUsage', () => {
     beforeEach(function() {
       this.eventBroadcaster = new EventEmitter()
       this.eventDataCollector = new EventDataCollector(this.eventBroadcaster)
+      this.parameterTypeRegistry = new ParameterTypeRegistry()
       this.stepDefinitions = []
       this.getResult = () =>
         getUsage({
@@ -29,7 +31,7 @@ describe('Usage Helpers', () => {
         })
       })
 
-      describe('with a step', () => {
+      describe('with some steps', () => {
         beforeEach(function() {
           const events = Gherkin.generateEvents(
             'Feature: a\nScenario: b\nWhen abc\nThen ab',
@@ -68,6 +70,87 @@ describe('Usage Helpers', () => {
 
         it('returns an empty array', function() {
           expect(this.getResult()).to.eql([])
+        })
+      })
+    })
+
+    describe('with step definitions', () => {
+      beforeEach(function() {
+        this.stepDefinitions.push(
+          {
+            code: function() {'original code'}, // eslint-disable-line prettier/prettier
+            uri: 'steps.js',
+            expression: new CucumberExpression(
+              'abc',
+              this.parameterTypeRegistry
+            ),
+            line: 30,
+          },
+          {
+            code: function() {'wrapped code'}, // eslint-disable-line prettier/prettier
+            unwrappedCode: function() {'original code'}, // eslint-disable-line prettier/prettier
+            uri: 'steps.js',
+            expression: new CucumberExpression(
+              'ab',
+              this.parameterTypeRegistry
+            ),
+            line: 40,
+          }
+        )
+      })
+
+      describe('without steps run', () => {
+        beforeEach(function() {
+          this.eventBroadcaster.emit('test-run-finished')
+        })
+
+        it('returns an array with the step definitions', function() {
+          expect(this.getResult()).to.have.lengthOf(2)
+        })
+      })
+
+      describe('with some steps', () => {
+        beforeEach(function() {
+          const events = Gherkin.generateEvents(
+            'Feature: a\nScenario: b\nWhen abc\nThen ab',
+            'a.feature'
+          )
+          events.forEach(event => {
+            this.eventBroadcaster.emit(event.type, event)
+            if (event.type === 'pickle') {
+              this.eventBroadcaster.emit('pickle-accepted', {
+                type: 'pickle-accepted',
+                pickle: event.pickle,
+                uri: event.uri,
+              })
+            }
+          })
+          const testCase = { sourceLocation: { uri: 'a.feature', line: 2 } }
+          this.eventBroadcaster.emit('test-case-prepared', {
+            ...testCase,
+            steps: [
+              { sourceLocation: { uri: 'a.feature', line: 3 } },
+              { sourceLocation: { uri: 'a.feature', line: 4 } },
+            ],
+          })
+          this.eventBroadcaster.emit('test-step-finished', {
+            index: 0,
+            testCase,
+            result: {},
+          })
+          this.eventBroadcaster.emit('test-step-finished', {
+            index: 1,
+            testCase,
+            result: {},
+          })
+          this.eventBroadcaster.emit('test-run-finished')
+        })
+
+        it('returns an array with the step definitions, including correct stringified code', function() {
+          const result = this.getResult()
+          expect(result).to.have.lengthOf(2)
+          expect(result[0].code).to.contain('original code')
+          expect(result[1].code).to.contain('original code')
         })
       })
     })

--- a/src/support_code_library_builder/finalize_helpers.js
+++ b/src/support_code_library_builder/finalize_helpers.js
@@ -16,6 +16,7 @@ export function wrapDefinitions({
         definition.options.wrapperOptions
       )
       if (wrappedFn !== definition.code) {
+        definition.unwrappedCode = definition.code
         definition.code = arity(codeLength, wrappedFn)
       }
     })

--- a/src/support_code_library_builder/index_spec.js
+++ b/src/support_code_library_builder/index_spec.js
@@ -31,6 +31,43 @@ describe('supportCodeLibraryBuilder', () => {
     })
   })
 
+  describe('step', () => {
+    describe('without definition function wrapper', () => {
+      beforeEach(function() {
+        this.hook = function() {}
+        supportCodeLibraryBuilder.reset('path/to/project')
+        supportCodeLibraryBuilder.methods.defineStep('I do a thing', this.hook)
+        this.options = supportCodeLibraryBuilder.finalize()
+      })
+
+      it('adds a step definition and makes original code available', function() {
+        expect(this.options.stepDefinitions).to.have.lengthOf(1)
+        expect(this.options.stepDefinitions[0].code).to.eql(this.hook)
+        expect(this.options.stepDefinitions[0].unwrappedCode).to.eql(undefined)
+      })
+    })
+
+    describe('with definition function wrapper', () => {
+      beforeEach(function() {
+        this.hook = function() {}
+        supportCodeLibraryBuilder.reset('path/to/project')
+        supportCodeLibraryBuilder.methods.defineStep('I do a thing', this.hook)
+        supportCodeLibraryBuilder.methods.setDefinitionFunctionWrapper(function(
+          fn
+        ) {
+          return fn.apply(this, arguments)
+        })
+        this.options = supportCodeLibraryBuilder.finalize()
+      })
+
+      it('adds a step definition and makes original code available', function() {
+        expect(this.options.stepDefinitions).to.have.lengthOf(1)
+        expect(this.options.stepDefinitions[0].code).not.to.eql(this.hook)
+        expect(this.options.stepDefinitions[0].unwrappedCode).to.eql(this.hook)
+      })
+    })
+  })
+
   describe('After', () => {
     describe('function only', () => {
       beforeEach(function() {


### PR DESCRIPTION
When interrogating the `supportCodeLibrary` for producing a usage formatter or (in my case) documentation for all your steps, there is the `code` property on each `stepDefinition`, the value of which is the actual function you passed to `defineStep` or one of its aliases. This can then be printed, or run through a parser, etc.

However, if you use `setDefinitionFunctionWrapper`, that `code` is replaced by the generated wrapper function, which being just a delegate is not much use to look at or parse.

With this change, when applying a definition function wrapper, we preserve the original function on a new property `unwrappedCode` so it can be referenced if needed. I also updated the usage helper to reflect this. 