### PR TITLE
create a fresh World instance for every retry

### DIFF
--- a/src/runtime/test_case_runner.js
+++ b/src/runtime/test_case_runner.js
@@ -14,7 +14,7 @@ export default class TestCaseRunner {
     supportCodeLibrary,
     worldParameters,
   }) {
-    const attachmentManager = new AttachmentManager(({ data, media }) => {
+    this.attachmentManager = new AttachmentManager(({ data, media }) => {
       if (this.testStepIndex > this.maxTestStepIndex) {
         throw new Error(
           'Cannot attach after all steps/hooks have finished running. Ensure your step/hook waits for the attach to finish.'
@@ -31,10 +31,7 @@ export default class TestCaseRunner {
     this.skip = skip
     this.testCase = testCase
     this.supportCodeLibrary = supportCodeLibrary
-    this.world = new supportCodeLibrary.World({
-      attach: ::attachmentManager.create,
-      parameters: worldParameters,
-    })
+    this.worldParameters = worldParameters
     this.beforeHookDefinitions = this.getBeforeHookDefinitions()
     this.afterHookDefinitions = this.getAfterHookDefinitions()
     this.maxTestStepIndex =
@@ -50,6 +47,10 @@ export default class TestCaseRunner {
   }
 
   resetTestProgressData() {
+    this.world = new this.supportCodeLibrary.World({
+      attach: ::this.attachmentManager.create,
+      parameters: this.worldParameters,
+    })
     this.testStepIndex = 0
     this.result = {
       duration: 0,

--- a/src/runtime/test_case_runner_spec.js
+++ b/src/runtime/test_case_runner_spec.js
@@ -27,13 +27,17 @@ describe('TestCaseRunner', () => {
       },
       uri: 'path/to/feature',
     }
+    this.onWorldConstructed = sinon.stub()
+    const owc = this.onWorldConstructed
     this.supportCodeLibrary = {
       afterTestCaseHookDefinitions: [],
       beforeTestCaseHookDefinitions: [],
       defaultTimeout: 5000,
       stepDefinitions: [],
       parameterTypeRegistry: {},
-      World() {},
+      World() {
+        owc()
+      },
     }
     sinon.stub(StepRunner, 'run')
   })
@@ -368,6 +372,10 @@ describe('TestCaseRunner', () => {
           attemptNumber: 2,
           sourceLocation,
         })
+      })
+
+      it('constructs the World twice', function() {
+        expect(this.onWorldConstructed).to.have.callCount(2)
       })
     })
 


### PR DESCRIPTION
Fixes #1248 

Moved the creation of the World into the method that resets the state before each attempt. In doing so, needed to turn a couple of local variables from the constructor into instance fields.