### PR TITLE
#1256 Fix duration being multiplied by 1000000 in JSON reporter

### DIFF
--- a/src/formatter/json_formatter.js
+++ b/src/formatter/json_formatter.js
@@ -149,7 +149,7 @@ export default class JsonFormatter extends Formatter {
       const { exception, status } = testStepResult
       data.result = { status }
       if (!_.isUndefined(testStepResult.duration)) {
-        data.result.duration = testStepResult.duration * 1000000
+        data.result.duration = testStepResult.duration
       }
       if (status === Status.FAILED && exception) {
         data.result.error_message = format(exception)

--- a/src/formatter/json_formatter_spec.js
+++ b/src/formatter/json_formatter_spec.js
@@ -71,11 +71,11 @@ describe('JsonFormatter', () => {
         this.eventBroadcaster.emit('test-step-finished', {
           index: 0,
           testCase: this.testCase,
-          result: { duration: 1, status: Status.PASSED },
+          result: { duration: 1000000, status: Status.PASSED },
         })
         this.eventBroadcaster.emit('test-case-finished', {
           ...this.testCase,
-          result: { duration: 1, status: Status.PASSED },
+          result: { duration: 1000000, status: Status.PASSED },
         })
         this.eventBroadcaster.emit('test-run-finished')
       })
@@ -146,11 +146,11 @@ describe('JsonFormatter', () => {
         this.eventBroadcaster.emit('test-step-finished', {
           index: 0,
           testCase: testCaseAttempt2,
-          result: { duration: 1, status: Status.PASSED },
+          result: { duration: 1000000, status: Status.PASSED },
         })
         this.eventBroadcaster.emit('test-case-finished', {
           ...testCaseAttempt2,
-          result: { duration: 1, status: Status.PASSED },
+          result: { duration: 1000000, status: Status.PASSED },
         })
         this.eventBroadcaster.emit('test-run-finished')
       })
@@ -179,11 +179,15 @@ describe('JsonFormatter', () => {
         this.eventBroadcaster.emit('test-step-finished', {
           index: 0,
           testCase: this.testCase,
-          result: { duration: 1, exception: 'my error', status: Status.FAILED },
+          result: {
+            duration: 1000000,
+            exception: 'my error',
+            status: Status.FAILED,
+          },
         })
         this.eventBroadcaster.emit('test-case-finished', {
           ...this.testCase,
-          result: { duration: 1, status: Status.FAILED },
+          result: { duration: 1000000, status: Status.FAILED },
         })
         this.eventBroadcaster.emit('test-run-finished')
       })


### PR DESCRIPTION
The duration (which was already in nanoseconds) was being multiplied by 1000000 in src/formatter/json_formatter.js. This lead to the duration being reported in femtoseconds instead of nanoseconds, as it was in Cucumber 5.x. I'm not sure why this addition was added, but, this PR fixes the behaviour and returns the duration to the previously correct value.

EDIT: as noted below, this error was introduced in 6.0.0, which changed the internal reporting from milliseconds to nanoseconds. The JSON formatter was not updated when the change happened.

Fixes #1256 