### PR TITLE
remove babel usage in feature test examples

### DIFF
--- a/features/ambiguous_step.feature
+++ b/features/ambiguous_step.feature
@@ -9,7 +9,7 @@ Feature: Ambiguous Steps
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When(/^a ambiguous step$/, function() {});
       When(/^a (.*) step$/, function(status) {});

--- a/features/attachments.feature
+++ b/features/attachments.feature
@@ -9,7 +9,7 @@ Feature: Attachments
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a step$/, function() {})
       """
@@ -17,7 +17,7 @@ Feature: Attachments
   Scenario: Attach a buffer
     Given a file named "features/support/hooks.js" with:
       """
-      import {Before} from 'cucumber'
+      const {Before} = require('cucumber')
 
       Before(function() {
         this.attach(Buffer.from([137, 80, 78, 71]), 'image/png')
@@ -31,8 +31,8 @@ Feature: Attachments
   Scenario: Attach a stream (callback)
     Given a file named "features/support/hooks.js" with:
       """
-      import {Before} from 'cucumber'
-      import stream from 'stream'
+      const {Before} = require('cucumber')
+      const stream = require('stream')
 
       Before(function(testCase, callback) {
         var passThroughStream = new stream.PassThrough()
@@ -50,8 +50,8 @@ Feature: Attachments
     Scenario: Attach a stream (promise)
       Given a file named "features/support/hooks.js" with:
         """
-        import {Before} from 'cucumber'
-        import stream from 'stream'
+        const {Before} = require('cucumber')
+        const stream = require('stream')
 
         Before(function() {
           var passThroughStream = new stream.PassThrough()
@@ -70,7 +70,7 @@ Feature: Attachments
   Scenario: Attach from a before hook
     Given a file named "features/support/hooks.js" with:
       """
-      import {Before} from 'cucumber'
+      const {Before} = require('cucumber')
 
       Before(function() {
         this.attach("text")
@@ -84,7 +84,7 @@ Feature: Attachments
   Scenario: Attach from an after hook
     Given a file named "features/support/hooks.js" with:
       """
-      import {After} from 'cucumber'
+      const {After} = require('cucumber')
 
       After(function() {
         this.attach("text")
@@ -98,7 +98,7 @@ Feature: Attachments
   Scenario: Attach from a step definition
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a step$/, function() {
         this.attach("text")
@@ -113,8 +113,8 @@ Feature: Attachments
   Scenario: Attaching after hook/step finishes
     Given a file named "features/support/hooks.js" with:
       """
-      import {After} from 'cucumber'
-      import Promise from 'bluebird'
+      const {After} = require('cucumber')
+      const Promise = require('bluebird')
 
       After(function() {
         // Do not return the promise so that the attach happens after the hook completes

--- a/features/before_after_all_hook_interfaces.feature
+++ b/features/before_after_all_hook_interfaces.feature
@@ -15,7 +15,7 @@ Feature: before / after all hook interfaces
       """
     And a file named "features/step_definitions/my_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given('first step', function() {})
       Given('second step', function() {})
@@ -24,7 +24,7 @@ Feature: before / after all hook interfaces
   Scenario Outline: synchronous
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
+      const {<TYPE>} = require('cucumber')
 
       <TYPE>(function() {})
       """
@@ -39,7 +39,7 @@ Feature: before / after all hook interfaces
   Scenario Outline: synchronously throws
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
+      const {<TYPE>} = require('cucumber')
 
       <TYPE>(function() {
         throw new Error('my error')
@@ -56,7 +56,7 @@ Feature: before / after all hook interfaces
   Scenario Outline: callback without error
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
+      const {<TYPE>} = require('cucumber')
 
       <TYPE>(function(callback) {
         setTimeout(callback)
@@ -73,7 +73,7 @@ Feature: before / after all hook interfaces
   Scenario Outline: callback with error
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
+      const {<TYPE>} = require('cucumber')
 
       <TYPE>(function(callback) {
         setTimeout(() => {
@@ -97,7 +97,7 @@ Feature: before / after all hook interfaces
   Scenario Outline: callback asynchronously throws
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
+      const {<TYPE>} = require('cucumber')
 
       <TYPE>(function(callback) {
         setTimeout(() => {
@@ -120,8 +120,8 @@ Feature: before / after all hook interfaces
   Scenario Outline: callback - returning a promise
     Given a file named "features/step_definitions/failing_steps.js" with:
       """
-      import {<TYPE>} from 'cucumber'
-      import Promise from 'bluebird'
+      const {<TYPE>} = require('cucumber')
+      const Promise = require('bluebird')
 
       <TYPE>(function(callback) {
         return Promise.resolve()
@@ -144,8 +144,8 @@ Feature: before / after all hook interfaces
   Scenario Outline: promise resolves
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
-      import Promise from 'bluebird'
+      const {<TYPE>} = require('cucumber')
+      const Promise = require('bluebird')
 
       <TYPE>(function() {
         return Promise.resolve()
@@ -162,8 +162,8 @@ Feature: before / after all hook interfaces
   Scenario Outline: promise rejects with error
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
-      import Promise from 'bluebird'
+      const {<TYPE>} = require('cucumber')
+      const Promise = require('bluebird')
 
       <TYPE>(function() {
         return Promise.reject(new Error('my error'))
@@ -184,8 +184,8 @@ Feature: before / after all hook interfaces
   Scenario Outline: promise rejects without error
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
-      import Promise from 'bluebird'
+      const {<TYPE>} = require('cucumber')
+      const Promise = require('bluebird')
 
       <TYPE>(function() {
         return Promise.reject()
@@ -207,8 +207,8 @@ Feature: before / after all hook interfaces
   Scenario Outline: promise asynchronously throws
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
-      import Promise from 'bluebird'
+      const {<TYPE>} = require('cucumber')
+      const Promise = require('bluebird')
 
       <TYPE>(function() {
         return new Promise(function() {

--- a/features/before_after_all_hook_timeouts.feature
+++ b/features/before_after_all_hook_timeouts.feature
@@ -9,7 +9,7 @@ Feature: before / after all hook timeouts
       """
     And a file named "features/step_definitions/steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a passing step$/, function() {});
       """
@@ -17,7 +17,7 @@ Feature: before / after all hook timeouts
   Scenario Outline: slow handler timeout
     Given a file named "features/support/handlers.js" with:
       """
-      import {<TYPE>, setDefaultTimeout} from 'cucumber'
+      const {<TYPE>, setDefaultTimeout} = require('cucumber')
 
       setDefaultTimeout(500)
 
@@ -40,7 +40,7 @@ Feature: before / after all hook timeouts
   Scenario Outline: slow handlers can increase their timeout
     Given a file named "features/supports/handlers.js" with:
       """
-      import {<TYPE>, setDefaultTimeout} from 'cucumber'
+      const {<TYPE>, setDefaultTimeout} = require('cucumber')
 
       setDefaultTimeout(500)
 

--- a/features/before_after_all_hooks.feature
+++ b/features/before_after_all_hooks.feature
@@ -17,8 +17,8 @@ Feature: Environment Hooks
   Scenario: before all / after all hooks
     Given a file named "features/support/hooks.js" with:
       """
-      import {AfterAll, BeforeAll, Given} from 'cucumber'
-      import {expect} from 'chai'
+      const {AfterAll, BeforeAll, Given} = require('cucumber')
+      const {expect} = require('chai')
 
       let counter = 1
 
@@ -48,7 +48,7 @@ Feature: Environment Hooks
   Scenario: Failing before all hook kills the suite
     Given a file named "features/support/hooks.js" with:
       """
-      import {BeforeAll} from 'cucumber'
+      const {BeforeAll} = require('cucumber')
 
       BeforeAll(function(callback) {
         callback(new Error('my error'))
@@ -64,7 +64,7 @@ Feature: Environment Hooks
   Scenario: Failing after all hook kills the suite
     Given a file named "features/support/hooks.js" with:
       """
-      import {AfterAll} from 'cucumber'
+      const {AfterAll} = require('cucumber')
 
       AfterAll(function(callback) {
         callback(new Error('my error'))

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -12,7 +12,7 @@ Feature: Command line interface
       """
     And a file named "step_definitions/cucumber_steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When(/^a step is passing$/, function() {})
       """
@@ -27,7 +27,7 @@ Feature: Command line interface
       """
     And a file named "step_definitions/cucumber_steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When(/^a step is passing$/, function() {});
       """

--- a/features/core.feature
+++ b/features/core.feature
@@ -14,7 +14,7 @@ Feature: Core feature elements execution
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a step passes$/, function() {});
       """
@@ -43,7 +43,7 @@ Feature: Core feature elements execution
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given, Then, When} from 'cucumber'
+      const {Given, Then, When} = require('cucumber')
 
       Given(/^a "Given" step passes$/, function() {})
       When(/^a "When" step passes$/, function() {})
@@ -68,8 +68,8 @@ Feature: Core feature elements execution
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {setWorldConstructor, Then, When} from 'cucumber'
-      import assert from 'assert'
+      const {setWorldConstructor, Then, When} = require('cucumber')
+      const assert = require('assert')
 
       setWorldConstructor(function () {
         this.count = 0
@@ -102,8 +102,8 @@ Feature: Core feature elements execution
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {setWorldConstructor, Then, When} from 'cucumber'
-      import assert from 'assert'
+      const {setWorldConstructor, Then, When} = require('cucumber')
+      const assert = require('assert')
 
       setWorldConstructor(function () {
         this.parameters = {}

--- a/features/custom_formatter.feature
+++ b/features/custom_formatter.feature
@@ -10,7 +10,7 @@ Feature: custom formatter
   Scenario: extending Formatter
     Given a file named "simple_formatter.js" with:
       """
-      import { Formatter, formatterHelpers, Status } from 'cucumber'
+      const { Formatter, formatterHelpers, Status } = require('cucumber')
 
       class SimpleFormatter extends Formatter {
         constructor(options) {
@@ -65,7 +65,7 @@ Feature: custom formatter
       """
     And a file named "simple_formatter.js" with:
       """
-      import { SummaryFormatter, formatterHelpers, Status } from 'cucumber'
+      const { SummaryFormatter, formatterHelpers, Status } = require('cucumber')
 
       class SimpleFormatter extends SummaryFormatter {
         constructor(options) {

--- a/features/custom_stack_trace.feature
+++ b/features/custom_stack_trace.feature
@@ -9,7 +9,7 @@ Feature: Custom stack trace
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       const _prepareStackTrace = Error.prepareStackTrace;
       Error.prepareStackTrace = () => { return 'Custom message' }

--- a/features/data_tables.feature
+++ b/features/data_tables.feature
@@ -11,8 +11,8 @@ Feature: Data Tables
       """
     Given a file named "features/step_definitions/passing_steps.js" with:
       """
-      import {Given} from 'cucumber'
-      import assert from 'assert'
+      const {Given} = require('cucumber')
+      const assert = require('assert')
 
       Given(/^a table step$/, function(table) {
         const expected = [
@@ -38,8 +38,8 @@ Feature: Data Tables
       """
     Given a file named "features/step_definitions/passing_steps.js" with:
       """
-      import {Given} from 'cucumber'
-      import assert from 'assert'
+      const {Given} = require('cucumber')
+      const assert = require('assert')
 
       Given(/^a table step$/, function(table) {
         const expected = [
@@ -64,8 +64,8 @@ Feature: Data Tables
       """
     Given a file named "features/step_definitions/passing_steps.js" with:
       """
-      import {Given} from 'cucumber'
-      import assert from 'assert'
+      const {Given} = require('cucumber')
+      const assert = require('assert')
 
       Given(/^a table step$/, function(table) {
         const expected = {
@@ -91,8 +91,8 @@ Feature: Data Tables
       """
     Given a file named "features/step_definitions/passing_steps.js" with:
       """
-      import {Given} from 'cucumber'
-      import assert from 'assert'
+      const {Given} = require('cucumber')
+      const assert = require('assert')
 
       Given(/^a table step$/, function(table) {
         const expected = [

--- a/features/direct_imports.feature
+++ b/features/direct_imports.feature
@@ -12,7 +12,7 @@ Feature: Core feature elements execution using direct imports
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a step passes$/, function() {});
       """
@@ -28,7 +28,7 @@ Feature: Core feature elements execution using direct imports
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a step fails$/, function(callback) {
         callback(new Error('my error'))

--- a/features/doc_string.feature
+++ b/features/doc_string.feature
@@ -12,8 +12,8 @@ Feature: doc string
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
-      import assert from 'assert'
+      const {Given} = require('cucumber')
+      const assert = require('assert')
 
       Given(/^a doc string step$/, function(docString) {
         assert.equal(docString, "The cucumber (Cucumis sativus) is a widely " +
@@ -35,8 +35,8 @@ Feature: doc string
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
-      import assert from 'assert'
+      const {Given} = require('cucumber')
+      const assert = require('assert')
 
       Given(/^a "([^"]*)" step$/, function(type, docString) {
         assert.equal(type, "doc string")

--- a/features/dryrun_mode.feature
+++ b/features/dryrun_mode.feature
@@ -13,7 +13,7 @@ Feature: Dryrun mode
   Scenario: default behavior
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given('a step', function() {})
       """
@@ -24,7 +24,7 @@ Feature: Dryrun mode
   Scenario: ambiguous step
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given('a step', function() {});
       Given('a(n) step', function() {});

--- a/features/error_formatting.feature
+++ b/features/error_formatting.feature
@@ -8,13 +8,13 @@ Feature: Error formatting
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a passing step$/, function() {})
       """
     And a file named "features/support/hooks.js" with:
       """
-      import {Before} from 'cucumber'
+      const {Before} = require('cucumber')
 
       Before(function(_, callback) { callback('Fail') })
       """
@@ -51,7 +51,7 @@ Feature: Error formatting
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a basic step$/, function() { this.attach('Some info.') })
       Given(/^a step with a doc string$/, function(str) { this.attach('{"name": "some JSON"}', 'application/json') })
@@ -88,7 +88,7 @@ Feature: Error formatting
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a table:$/, function(table) {})
       Given(/^a pending step$/, function() { return 'pending' })

--- a/features/exit.feature
+++ b/features/exit.feature
@@ -13,7 +13,7 @@ Feature: Exit
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given, After} from 'cucumber'
+      const {Given, After} = require('cucumber')
 
       Given('a step', function() {})
 

--- a/features/fail_fast.feature
+++ b/features/fail_fast.feature
@@ -14,7 +14,7 @@ Feature: Fail fast
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a failing step$/, function() { throw 'fail' })
       Given(/^a passing step$/, function() {})

--- a/features/failing_steps.feature
+++ b/features/failing_steps.feature
@@ -11,7 +11,7 @@ Feature: Failing steps
   Scenario: too few arguments
     Given a file named "features/step_definitions/failing_steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When(/^a (.*) step$/, function() {})
       """
@@ -25,7 +25,7 @@ Feature: Failing steps
   Scenario: too many arguments
     Given a file named "features/step_definitions/failing_steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When(/^a failing step$/, function(arg1, arg2) {})
       """
@@ -39,7 +39,7 @@ Feature: Failing steps
   Scenario: synchronous - throws
     Given a file named "features/step_definitions/failing_steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When(/^a failing step$/, function() {
         throw new Error('my error');
@@ -56,7 +56,7 @@ Feature: Failing steps
   Scenario: asynchronous - throws
     Given a file named "features/step_definitions/failing_steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When(/^a failing step$/, function(callback) {
         setTimeout(function() {
@@ -74,7 +74,7 @@ Feature: Failing steps
   Scenario: asynchronous - passing error as first argument to the callback
     Given a file named "features/step_definitions/failing_steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When(/^a failing step$/, function(callback) {
         setTimeout(function() {
@@ -92,8 +92,8 @@ Feature: Failing steps
   Scenario: asynchronous - using a callback and returning a promise
     Given a file named "features/step_definitions/failing_steps.js" with:
       """
-      import {When} from 'cucumber'
-      import Promise from 'bluebird'
+      const {When} = require('cucumber')
+      const Promise = require('bluebird')
 
       When(/^a failing step$/, function(callback) {
         return Promise.resolve()
@@ -112,8 +112,8 @@ Feature: Failing steps
   Scenario: promise - throws
     Given a file named "features/step_definitions/failing_steps.js" with:
       """
-      import {When} from 'cucumber'
-      import Promise from 'bluebird'
+      const {When} = require('cucumber')
+      const Promise = require('bluebird')
 
       When(/^a failing step$/, function() {
         return new Promise(function() {
@@ -133,8 +133,8 @@ Feature: Failing steps
   Scenario: promise - rejects
     Given a file named "features/step_definitions/failing_steps.js" with:
       """
-      import {When} from 'cucumber'
-      import Promise from 'bluebird'
+      const {When} = require('cucumber')
+      const Promise = require('bluebird')
 
       When(/^a failing step$/, function() {
         return Promise.reject(new Error('my error'))

--- a/features/fake_time.feature
+++ b/features/fake_time.feature
@@ -2,8 +2,8 @@ Feature: Allow time to be faked by utilities such as sinon.useFakeTimers
   Background: Before and After hooks to enable faking time.
     Given a file named "features/support/hooks.js" with:
     """
-    import {After, Before} from 'cucumber'
-    import sinon from 'sinon'
+    const {After, Before} = require('cucumber')
+    const sinon = require('sinon')
 
     Before(function(scenario) {
       this.clock = sinon.useFakeTimers()
@@ -24,9 +24,9 @@ Feature: Allow time to be faked by utilities such as sinon.useFakeTimers
 
     Given a file named "features/step_definitions/passing_steps.js" with:
       """
-      import assert from 'assert'
-      import {Given} from 'cucumber'
-      import sinon from 'sinon'
+      const assert = require('assert')
+      const {Given} = require('cucumber')
+      const sinon = require('sinon')
 
       Given(/^a faked time step$/, function () {
         var testFunction = sinon.stub()

--- a/features/formatter_paths.feature
+++ b/features/formatter_paths.feature
@@ -9,7 +9,7 @@ Feature: Formatter Paths
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a passing step$/, function() {})
       """

--- a/features/formatters.feature
+++ b/features/formatters.feature
@@ -20,7 +20,7 @@ Feature: Formatters
       """
     Given a file named "features/step_definitions/steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a step$/, function() {})
       """
@@ -37,7 +37,7 @@ Feature: Formatters
       """
     Given a file named "features/step_definitions/steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a step$/, function(callback) { callback(new Error('my error')) })
       """
@@ -55,7 +55,7 @@ Feature: Formatters
       """
     Given a file named "features/step_definitions/steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       let willPass = false
 

--- a/features/generator_step_definitions.feature
+++ b/features/generator_step_definitions.feature
@@ -13,8 +13,8 @@ Feature: Generator Step Definitions
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import assert from 'assert'
-      import {setWorldConstructor, Then, When} from 'cucumber'
+      const assert = require('assert')
+      const {setWorldConstructor, Then, When} = require('cucumber')
 
       setWorldConstructor(function () {
         this.context = ""
@@ -45,9 +45,9 @@ Feature: Generator Step Definitions
   Scenario: with generator function wrapper
     Given a file named "features/support/setup.js" with:
       """
-      import isGenerator from 'is-generator'
-      import {coroutine} from 'bluebird'
-      import {setDefinitionFunctionWrapper} from 'cucumber'
+      const isGenerator = require('is-generator')
+      const {coroutine} = require('bluebird')
+      const {setDefinitionFunctionWrapper} = require('cucumber')
 
       setDefinitionFunctionWrapper(function (fn) {
         if (isGenerator.fn(fn)) {

--- a/features/global_install.feature
+++ b/features/global_install.feature
@@ -10,7 +10,7 @@ Feature: Global Installs
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When(/^a step is passing$/, function() {})
       """

--- a/features/handling_step_errors.feature
+++ b/features/handling_step_errors.feature
@@ -11,7 +11,7 @@ Feature: Handling step errors
       """
     Given a file named "features/step_definitions/step_definitions.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given('I pass an error to the callback', function (cb) {
         var unusualErrorObject = {}

--- a/features/hook_interface.feature
+++ b/features/hook_interface.feature
@@ -9,7 +9,7 @@ Feature: After hook interface
       """
     And a file named "features/step_definitions/my_steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When(/^a step$/, function() {
         this.value = 1;
@@ -19,7 +19,7 @@ Feature: After hook interface
   Scenario Outline: too many arguments
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
+      const {<TYPE>} = require('cucumber')
 
       <TYPE>(function(arg1, arg2, arg3) {})
       """
@@ -38,8 +38,8 @@ Feature: After hook interface
   Scenario Outline: synchronous
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
-      import assert from 'assert'
+      const {<TYPE>} = require('cucumber')
+      const assert = require('assert')
 
       <TYPE>(function() {})
       """
@@ -54,7 +54,7 @@ Feature: After hook interface
   Scenario Outline: synchronously throws
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
+      const {<TYPE>} = require('cucumber')
 
       <TYPE>(function() {
         throw new Error('my error')
@@ -71,8 +71,8 @@ Feature: After hook interface
   Scenario Outline: callback without error
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
-      import assert from 'assert'
+      const {<TYPE>} = require('cucumber')
+      const assert = require('assert')
 
       <TYPE>(function(scenario, callback) {
         setTimeout(callback)
@@ -89,7 +89,7 @@ Feature: After hook interface
   Scenario Outline: callback with error
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
+      const {<TYPE>} = require('cucumber')
 
       <TYPE>(function(scenario, callback) {
         setTimeout(() => {
@@ -109,7 +109,7 @@ Feature: After hook interface
   Scenario Outline: callback asynchronously throws
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
+      const {<TYPE>} = require('cucumber')
 
       <TYPE>(function(scenario, callback) {
         setTimeout(() => {
@@ -128,8 +128,8 @@ Feature: After hook interface
   Scenario Outline: callback - returning a promise
     Given a file named "features/step_definitions/failing_steps.js" with:
       """
-      import {<TYPE>} from 'cucumber'
-      import Promise from 'bluebird'
+      const {<TYPE>} = require('cucumber')
+      const Promise = require('bluebird')
 
       <TYPE>(function(scenario, callback) {
         return Promise.resolve()
@@ -152,8 +152,8 @@ Feature: After hook interface
   Scenario Outline: promise resolves
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
-      import Promise from 'bluebird'
+      const {<TYPE>} = require('cucumber')
+      const Promise = require('bluebird')
 
       <TYPE>(function() {
         return Promise.resolve()
@@ -170,8 +170,8 @@ Feature: After hook interface
   Scenario Outline: promise rejects with error
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
-      import Promise from 'bluebird'
+      const {<TYPE>} = require('cucumber')
+      const Promise = require('bluebird')
 
       <TYPE>(function(){
         return Promise.reject(new Error('my error'))
@@ -192,8 +192,8 @@ Feature: After hook interface
   Scenario Outline: promise rejects without error
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
-      import Promise from 'bluebird'
+      const {<TYPE>} = require('cucumber')
+      const Promise = require('bluebird')
 
       <TYPE>(function() {
         return Promise.reject()
@@ -215,8 +215,8 @@ Feature: After hook interface
   Scenario Outline: promise asynchronously throws
     Given a file named "features/support/hooks.js" with:
       """
-      import {<TYPE>} from 'cucumber'
-      import Promise from 'bluebird'
+      const {<TYPE>} = require('cucumber')
+      const Promise = require('bluebird')
 
       <TYPE>(function(){
         return new Promise(function() {

--- a/features/hook_parameter.feature
+++ b/features/hook_parameter.feature
@@ -10,13 +10,13 @@ Feature: Hook Parameters
       """
     And a file named "features/step_definitions/my_steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When(/^a step$/, function() {})
       """
     And a file named "features/support/hooks.js" with:
       """
-      import {Before, formatterHelpers} from 'cucumber'
+      const {Before, formatterHelpers} = require('cucumber')
 
       Before(function({pickle, gherkinDocument}) {
         const { line } = formatterHelpers.PickleParser.getPickleLocation({ gherkinDocument, pickle })
@@ -46,14 +46,14 @@ Feature: Hook Parameters
       """
     And a file named "features/step_definitions/my_steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When(/^a passing step$/, function() {})
       When(/^a failing step$/, function() { throw new Error("my error") })
       """
     And a file named "features/support/hooks.js" with:
       """
-      import { After, formatterHelpers, Status } from 'cucumber'
+      const { After, formatterHelpers, Status } = require('cucumber')
 
       After(function({pickle, gherkinDocument, result}) {
         const { line } = formatterHelpers.PickleParser.getPickleLocation({ gherkinDocument, pickle })

--- a/features/hook_timeouts.feature
+++ b/features/hook_timeouts.feature
@@ -3,7 +3,7 @@ Feature: Step definition timeouts
   Background:
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Before, Given, setDefaultTimeout} from 'cucumber'
+      const {Before, Given, setDefaultTimeout} = require('cucumber')
 
       setDefaultTimeout(500);
 

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -9,7 +9,7 @@ Feature: Environment Hooks
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a step$/, function() {})
       """
@@ -17,7 +17,7 @@ Feature: Environment Hooks
   Scenario: Hooks are steps
     Given a file named "features/support/hooks.js" with:
       """
-      import {After, Before} from 'cucumber'
+      const {After, Before} = require('cucumber')
 
       Before(function() {})
       After(function() {})
@@ -32,7 +32,7 @@ Feature: Environment Hooks
   Scenario: Failing before fails the scenario
     Given a file named "features/support/hooks.js" with:
       """
-      import {Before} from 'cucumber'
+      const {Before} = require('cucumber')
 
       Before(function() { throw 'Fail' })
       """
@@ -43,7 +43,7 @@ Feature: Environment Hooks
   Scenario: Failing after hook fails the scenario
     Given a file named "features/support/hooks.js" with:
       """
-      import {After} from 'cucumber'
+      const {After} = require('cucumber')
 
       After(function() { throw 'Fail' })
       """
@@ -54,7 +54,7 @@ Feature: Environment Hooks
   Scenario: After hooks still execute after a failure
     Given a file named "features/support/hooks.js" with:
       """
-      import {After, Before} from 'cucumber'
+      const {After, Before} = require('cucumber')
 
       Before(function() { throw 'Fail' })
       After(function() {})
@@ -66,7 +66,7 @@ Feature: Environment Hooks
   Scenario: World is this in hooks
     Given a file named "features/support/world.js" with:
       """
-      import {setWorldConstructor} from 'cucumber'
+      const {setWorldConstructor} = require('cucumber')
 
       function WorldConstructor() {
         return {
@@ -78,7 +78,7 @@ Feature: Environment Hooks
       """
     Given a file named "features/support/hooks.js" with:
       """
-      import {After, Before} from 'cucumber'
+      const {After, Before} = require('cucumber')
 
       Before(function() {
         if (!this.isWorld()) {

--- a/features/language.feature
+++ b/features/language.feature
@@ -9,7 +9,7 @@ Feature: Multiple Formatters
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^une étape$/, function() {})
       """

--- a/features/multiple_formatters.feature
+++ b/features/multiple_formatters.feature
@@ -9,7 +9,7 @@ Feature: Multiple Formatters
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a passing step$/, function() {})
       """

--- a/features/multiple_hooks.feature
+++ b/features/multiple_hooks.feature
@@ -13,7 +13,7 @@ Feature: Multiple Hooks
       """
     And a file named "features/step_definitions/world.js" with:
       """
-      import {setWorldConstructor} from 'cucumber'
+      const {setWorldConstructor} = require('cucumber')
 
       setWorldConstructor(function() {
         this.value = 0
@@ -21,15 +21,15 @@ Feature: Multiple Hooks
       """
     And a file named "features/step_definitions/my_steps.js" with:
       """
-      import assert from 'assert'
-      import {Given} from 'cucumber'
+      const assert = require('assert')
+      const {Given} = require('cucumber')
 
       Given('a step', function() {})
       """
     And a file named "features/step_definitions/hooks.js" with:
       """
-      import {After, Before} from 'cucumber'
-      import assert from 'assert'
+      const {After, Before} = require('cucumber')
+      const assert = require('assert')
 
       Before(function() {
         assert.equal(this.value, 0)

--- a/features/nested_features.feature
+++ b/features/nested_features.feature
@@ -13,7 +13,7 @@ Feature: Automatically required support files for nested features
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a step$/, function() {})
       """

--- a/features/order.feature
+++ b/features/order.feature
@@ -25,7 +25,7 @@ Feature: Set the execution order
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a step$/, function() {})
       """

--- a/features/parallel.feature
+++ b/features/parallel.feature
@@ -3,8 +3,8 @@ Feature: Running scenarios in parallel
   Scenario: running in parallel can improve speed if there are async operations
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
-      import Promise from 'bluebird'
+      const {Given} = require('cucumber')
+      const Promise = require('bluebird')
 
       Given(/^a slow step$/, function(callback) {
         setTimeout(callback, 1000)
@@ -26,8 +26,8 @@ Feature: Running scenarios in parallel
   Scenario: an error in BeforeAll fails the test
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {BeforeAll, Given} from 'cucumber'
-      import Promise from 'bluebird'
+      const {BeforeAll, Given} = require('cucumber')
+      const Promise = require('bluebird')
 
       Given(/^a slow step$/, function(callback) {
         setTimeout(callback, 1000)

--- a/features/parameter_types.feature
+++ b/features/parameter_types.feature
@@ -13,8 +13,8 @@ Feature: Parameter types
       """
     Given a file named "features/step_definitions/my_steps.js" with:
       """
-      import assert from 'assert'
-      import {Given} from 'cucumber'
+      const assert = require('assert')
+      const {Given} = require('cucumber')
 
       Given('a {param} step', function(param) {
         assert.equal(param, 'PARTICULAR')
@@ -24,7 +24,7 @@ Feature: Parameter types
   Scenario: delegate transform to world
     Given a file named "features/support/transforms.js" with:
       """
-      import {setWorldConstructor, defineParameterType} from 'cucumber'
+      const {setWorldConstructor, defineParameterType} = require('cucumber')
 
       defineParameterType({
         regexp: /particular/,
@@ -47,7 +47,7 @@ Feature: Parameter types
   Scenario: sync transform (success)
     Given a file named "features/support/transforms.js" with:
       """
-      import {defineParameterType} from 'cucumber'
+      const {defineParameterType} = require('cucumber')
 
       defineParameterType({
         regexp: /particular/,
@@ -61,7 +61,7 @@ Feature: Parameter types
   Scenario: sync transform (error)
     Given a file named "features/support/transforms.js" with:
       """
-      import {defineParameterType} from 'cucumber'
+      const {defineParameterType} = require('cucumber')
 
       defineParameterType({
         regexp: /particular/,
@@ -81,7 +81,7 @@ Feature: Parameter types
   Scenario: no transform
     Given a file named "features/support/transforms.js" with:
       """
-      import {defineParameterType} from 'cucumber'
+      const {defineParameterType} = require('cucumber')
 
       defineParameterType({
         regexp: /particular/,
@@ -98,7 +98,7 @@ Feature: Parameter types
   Scenario: async transform (success)
     Given a file named "features/step_definitions/particular_steps.js" with:
       """
-      import {defineParameterType} from 'cucumber'
+      const {defineParameterType} = require('cucumber')
 
       defineParameterType({
         regexp: /particular/,
@@ -112,8 +112,8 @@ Feature: Parameter types
   Scenario: async transform (error)
     Given a file named "features/step_definitions/particular_steps.js" with:
       """
-      import {defineParameterType} from 'cucumber'
-      import Promise from 'bluebird'
+      const {defineParameterType} = require('cucumber')
+      const Promise = require('bluebird')
 
       defineParameterType({
         regexp: /particular/,

--- a/features/passing_steps.feature
+++ b/features/passing_steps.feature
@@ -11,7 +11,7 @@ Feature: Passing steps
   Scenario: synchronous
     Given a file named "features/step_definitions/passing_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a passing step$/, function() {})
       """
@@ -21,7 +21,7 @@ Feature: Passing steps
   Scenario: asynchronous
     Given a file named "features/step_definitions/passing_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a passing step$/, function(callback) {
         setTimeout(callback)
@@ -33,8 +33,8 @@ Feature: Passing steps
   Scenario: promise
     Given a file named "features/step_definitions/passing_steps.js" with:
       """
-      import {Given} from 'cucumber'
-      import Promise from 'bluebird'
+      const {Given} = require('cucumber')
+      const Promise = require('bluebird')
 
       Given(/^a passing step$/, function() {
         return Promise.resolve()

--- a/features/pending_steps.feature
+++ b/features/pending_steps.feature
@@ -11,7 +11,7 @@ Feature: Pending steps
   Scenario: Synchronous pending step
     Given a file named "features/step_definitions/failing_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a pending step$/, function() {
         return 'pending'
@@ -25,7 +25,7 @@ Feature: Pending steps
   Scenario: Callback pending step
     Given a file named "features/step_definitions/failing_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a pending step$/, function(callback) {
         callback(null, 'pending')
@@ -38,7 +38,7 @@ Feature: Pending steps
   Scenario: Promise pending step
     Given a file named "features/step_definitions/failing_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a pending step$/, function(){
         return {

--- a/features/profiles.feature
+++ b/features/profiles.feature
@@ -12,7 +12,7 @@ Feature: default command line arguments
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a passing step$/, function() {})
       """

--- a/features/rerun_formatter.feature
+++ b/features/rerun_formatter.feature
@@ -36,7 +36,7 @@ Feature: Rerun Formatter
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a passing step$/, function() {})
       Given(/^a failing step$/, function() { throw 'fail' })

--- a/features/rerun_formatter_subfolder.feature
+++ b/features/rerun_formatter_subfolder.feature
@@ -16,7 +16,7 @@ Feature: Rerun Formatter
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a passing step$/, function() {})
       Given(/^a failing step$/, function() { throw 'fail' })

--- a/features/retry.feature
+++ b/features/retry.feature
@@ -29,7 +29,7 @@ Feature: Retry flaky tests
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a failing step$/, function() { throw 'fail' })
       """
@@ -49,7 +49,7 @@ Feature: Retry flaky tests
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a failing step$/, function() { throw 'fail' })
       """
@@ -69,7 +69,7 @@ Feature: Retry flaky tests
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       let willPass = false
 
@@ -109,7 +109,7 @@ Feature: Retry flaky tests
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       let willPass = false
 
@@ -151,7 +151,7 @@ Feature: Retry flaky tests
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       let willPass = false
 
@@ -199,7 +199,7 @@ Feature: Retry flaky tests
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       let willPass = false
 
@@ -248,7 +248,7 @@ Feature: Retry flaky tests
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       let willPass = false
 
@@ -307,7 +307,7 @@ Feature: Retry flaky tests
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a failing step$/, function() { throw 'fail' })
       """
@@ -332,7 +332,7 @@ Feature: Retry flaky tests
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       let willPass = false
 
@@ -359,7 +359,7 @@ Feature: Retry flaky tests
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       let willPass = false
 
@@ -388,7 +388,7 @@ Feature: Retry flaky tests
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       let willPass = false
 
@@ -432,7 +432,7 @@ Feature: Retry flaky tests
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       let willPass = false
 
@@ -481,7 +481,7 @@ Feature: Retry flaky tests
       """
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Before, After, Given, setWorldConstructor} from 'cucumber'
+      const {Before, After, Given, setWorldConstructor} = require('cucumber')
 
       Before(function() {
         this.usedCount++

--- a/features/skipped_steps.feature
+++ b/features/skipped_steps.feature
@@ -17,7 +17,7 @@ Feature: Skipped steps
   Scenario: Synchronous skipped step
     Given a file named "features/step_definitions/skipped_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a skipped step$/, function() {
         return 'skipped'
@@ -32,7 +32,7 @@ Feature: Skipped steps
   Scenario: Callback skipped step
     Given a file named "features/step_definitions/skipped_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a skipped step$/, function(callback) {
         callback(null, 'skipped')
@@ -46,7 +46,7 @@ Feature: Skipped steps
   Scenario: Promise skipped step
     Given a file named "features/step_definitions/skipped_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a skipped step$/, function(){
         return {
@@ -66,13 +66,13 @@ Feature: Skipped steps
   Scenario: Hook skipped scenario steps
     Given a file named "features/support/hooks.js" with:
       """
-      import {After, Before} from 'cucumber'
+      const {After, Before} = require('cucumber')
 
       Before(function() {return 'skipped'})
       """
     And a file named "features/step_definitions/skipped_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a skipped step$/, function() {
         var a = 1;
@@ -86,15 +86,15 @@ Feature: Skipped steps
   Scenario: Skipped before hook should skip all before hooks
     Given a file named "features/step_definitions/world.js" with:
       """
-      import {setWorldConstructor} from 'cucumber'
+      const {setWorldConstructor} = require('cucumber')
       setWorldConstructor(function() {
         this.ran = false
       })
       """
     And a file named "features/support/hooks.js" with:
       """
-      import assert from 'assert'
-      import {After, Before} from 'cucumber'
+      const assert = require('assert')
+      const {After, Before} = require('cucumber')
 
       Before(function() {return 'skipped'})
 
@@ -104,7 +104,7 @@ Feature: Skipped steps
       """
     And a file named "features/step_definitions/skipped_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a skipped step$/, function() {
         var a = 1;
@@ -117,7 +117,7 @@ Feature: Skipped steps
   Scenario: Skipped before hook should run after hook
     Given a file named "features/support/hooks.js" with:
       """
-      import {After, Before} from 'cucumber'
+      const {After, Before} = require('cucumber')
 
       Before(function() {return 'skipped'})
 
@@ -127,7 +127,7 @@ Feature: Skipped steps
       """
     And a file named "features/step_definitions/skipped_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a skipped step$/, function() {
         var a = 1;

--- a/features/step_definition_timeouts.feature
+++ b/features/step_definition_timeouts.feature
@@ -3,8 +3,8 @@ Feature: Step definition timeouts
   Background:
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given, setDefaultTimeout} from 'cucumber'
-      import Promise from 'bluebird'
+      const {Given, setDefaultTimeout} = require('cucumber')
+      const Promise = require('bluebird')
 
       setDefaultTimeout(500)
 

--- a/features/step_wrapper_with_options.feature
+++ b/features/step_wrapper_with_options.feature
@@ -13,13 +13,13 @@ Feature: Step Wrapper with Options
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When(/^I run a step with options$/, {wrapperOptions: {retry: 2}}, function () {})
       """
     And a file named "features/support/setup.js" with:
       """
-      import {setDefinitionFunctionWrapper} from 'cucumber'
+      const {setDefinitionFunctionWrapper} = require('cucumber')
 
       setDefinitionFunctionWrapper(function (fn, options = {}) {
         if (options.retry) {

--- a/features/strict_mode.feature
+++ b/features/strict_mode.feature
@@ -14,7 +14,7 @@ Feature: Strict mode
   Scenario: Fail with pending step by default
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a step$/, function() { return 'pending' })
       """
@@ -24,7 +24,7 @@ Feature: Strict mode
   Scenario: Succeed with pending step with --no-strict
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a step$/, function() { return 'pending' })
       """

--- a/features/summary_formatter.feature
+++ b/features/summary_formatter.feature
@@ -25,7 +25,7 @@ Feature: Summary Formatter
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a step$/, function() {})
       Given(/^another step$/, function() {})

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -8,7 +8,6 @@ import tmp from 'tmp'
 
 const projectPath = path.join(__dirname, '..', '..')
 const projectNodeModulesPath = path.join(projectPath, 'node_modules')
-const projectBabelConfigPath = path.join(projectPath, 'babel.config.js')
 const moduleNames = fs.readdirSync(projectNodeModulesPath)
 
 Before('@debug', function() {
@@ -31,14 +30,6 @@ Before(function({ gherkinDocument, pickle }) {
   )
 
   fsExtra.removeSync(this.tmpDir)
-
-  const tmpDirProfilePath = path.join(this.tmpDir, 'cucumber.js')
-  const profileContent =
-    'module.exports = {default: "--require-module @babel/register"}'
-  fsExtra.outputFileSync(tmpDirProfilePath, profileContent)
-
-  const tmpDirBabelConfigPath = path.join(this.tmpDir, 'babel.config.js')
-  fsExtra.createSymlinkSync(projectBabelConfigPath, tmpDirBabelConfigPath)
 
   const tmpDirNodeModulesPath = path.join(this.tmpDir, 'node_modules')
   const tmpDirCucumberPath = path.join(tmpDirNodeModulesPath, 'cucumber')

--- a/features/tagged_hooks.feature
+++ b/features/tagged_hooks.feature
@@ -16,7 +16,7 @@ Feature: Tagged Hooks
       """
     And a file named "features/step_definitions/world.js" with:
       """
-      import {setWorldConstructor} from 'cucumber'
+      const {setWorldConstructor} = require('cucumber')
 
       setWorldConstructor(function() {
         this.value = 0
@@ -24,8 +24,8 @@ Feature: Tagged Hooks
       """
     And a file named "features/step_definitions/my_steps.js" with:
       """
-      import assert from 'assert'
-      import {Then} from 'cucumber'
+      const assert = require('assert')
+      const {Then} = require('cucumber')
 
       Then(/^the value is (\d*)$/, function(number) {
         assert.equal(number, this.value)
@@ -33,7 +33,7 @@ Feature: Tagged Hooks
       """
     And a file named "features/step_definitions/my_tagged_hooks.js" with:
       """
-      import {Before} from 'cucumber'
+      const {Before} = require('cucumber')
 
       Before({tags: '@foo'}, function() {
         this.value += 1

--- a/features/target_specific_scenarios_by_tag.feature
+++ b/features/target_specific_scenarios_by_tag.feature
@@ -28,7 +28,7 @@ Feature: Target specific scenarios
       """
     And a file named "features/step_definitions/cucumber_steps.js" with:
       """
-      import {Given} from 'cucumber'
+      const {Given} = require('cucumber')
 
       Given(/^a step is (.*)$/, function() {})
       """

--- a/features/usage_formatter.feature
+++ b/features/usage_formatter.feature
@@ -17,7 +17,7 @@ Feature: usage formatter
       """
     And a file named "features/step_definitions/steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When('step A', function(callback) { setTimeout(callback, 100) });
       When(/^(slow )?step B$/, function(slow, callback) {
@@ -68,7 +68,7 @@ Feature: usage formatter
       """
     And a file named "features/step_definitions/steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When(/^(slow )?step$/, function(slow, callback) {
         if (slow) {

--- a/features/usage_json_formatter.feature
+++ b/features/usage_json_formatter.feature
@@ -17,7 +17,7 @@ Feature: usage json formatter
       """
     And a file named "features/step_definitions/steps.js" with:
       """
-      import {When} from 'cucumber'
+      const {When} = require('cucumber')
 
       When('step A', function() {});
       When('step B', function() {});

--- a/features/world_parameters.feature
+++ b/features/world_parameters.feature
@@ -36,8 +36,8 @@ Feature: World Parameters
   Scenario: default world constructor has an empty parameters object by default
     Given a file named "features/step_definitions/my_steps.js" with:
       """
-      import assert from 'assert'
-      import {Given} from 'cucumber'
+      const assert = require('assert')
+      const {Given} = require('cucumber')
 
       Given(/^the world parameters are correct$/, function() {
         assert.deepEqual(this.parameters, {})
@@ -49,8 +49,8 @@ Feature: World Parameters
   Scenario: default world constructor saves the parameters
     Given a file named "features/step_definitions/my_steps.js" with:
       """
-      import assert from 'assert'
-      import {Given} from 'cucumber'
+      const assert = require('assert')
+      const {Given} = require('cucumber')
 
       Given(/^the world parameters are correct$/, function() {
         assert.equal(this.parameters.a, 1)
@@ -62,8 +62,8 @@ Feature: World Parameters
   Scenario: multiple world parameters are merged with the last taking precedence
     Given a file named "features/step_definitions/my_steps.js" with:
       """
-      import assert from 'assert'
-      import {Given} from 'cucumber'
+      const assert = require('assert')
+      const {Given} = require('cucumber')
 
       Given(/^the world parameters are correct$/, function() {
         assert.equal(this.parameters.a, 3)
@@ -76,7 +76,7 @@ Feature: World Parameters
   Scenario: custom world constructor is passed the parameters
     Given a file named "features/support/world.js" with:
       """
-      import {setWorldConstructor} from 'cucumber'
+      const {setWorldConstructor} = require('cucumber')
 
       function CustomWorld(options) {
         for(const key in options.parameters) {
@@ -88,8 +88,8 @@ Feature: World Parameters
       """
     Given a file named "features/step_definitions/my_steps.js" with:
       """
-      import assert from 'assert'
-      import {Given} from 'cucumber'
+      const assert = require('assert')
+      const {Given} = require('cucumber')
 
       Given(/^the world parameters are correct$/, function() {
         assert.equal(this.a, 1)


### PR DESCRIPTION
Extracting some changes from #1267 as this should allow no `*.feature` file changes in that PR