### PR TITLE
docs: update built-in formatters after cucumber-messages migration

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,7 +44,7 @@ This option may be used multiple times in order to output different formats to d
 If multiple formats are specified with the same output, only the last is used.
 
 Built-in formatters
-* event-protocol - prints the event protocol. See [current docs](https://docs.cucumber.io/event-protocol/) and the [proposed updates](https://github.com/cucumber/cucumber/pull/172) which were implemented.
+* message - prints the full [`cucumber-messages`](https://github.com/cucumber/cucumber/tree/master/cucumber-messages) object in [varint](https://developers.google.com/protocol-buffers/docs/encoding#varints)-delimited protobuf binary form, which can then be piped to other tools.
 * json - prints the feature as JSON.
 * progress - prints one character per scenario (default).
 * progress-bar - prints a progress bar and outputs errors/warnings along the way.


### PR DESCRIPTION
Remove reference to `event-protocol` formatter and instead mention `message` formatter with a link to the messages library.