### PR TITLE
runtime: don't execute BeforeAll and AfterAll hooks when in dry-run

### DIFF
--- a/features/dryrun_mode.feature
+++ b/features/dryrun_mode.feature
@@ -1,3 +1,4 @@
+@dryrun
 Feature: Dryrun mode
 
   Using the `--dry-run` or `-d` flag gives you a way to quickly scan your features without actually running them.
@@ -37,3 +38,18 @@ Feature: Dryrun mode
     When I run cucumber-js with `--dry-run`
     Then it fails
     And scenario "some scenario" step "Given a step" has status "undefined"
+
+  Scenario: hooks
+    Given a file named "features/step_definitions/cucumber_steps.js" with:
+      """
+      const {BeforeAll, Before, After, AfterAll, Given} = require('cucumber')
+
+      BeforeAll(function() {throw 'shouldnt run'})
+      Before(function() {throw 'shouldnt run'})
+      After(function() {throw 'shouldnt run'})
+      AfterAll(function() {throw 'shouldnt run'})
+
+      Given('a step', function() {})
+      """
+    When I run cucumber-js with `--dry-run`
+    Then it passes

--- a/features/dryrun_mode.feature
+++ b/features/dryrun_mode.feature
@@ -1,4 +1,3 @@
-@dryrun
 Feature: Dryrun mode
 
   Using the `--dry-run` or `-d` flag gives you a way to quickly scan your features without actually running them.

--- a/features/dryrun_mode.feature
+++ b/features/dryrun_mode.feature
@@ -38,7 +38,7 @@ Feature: Dryrun mode
     Then it fails
     And scenario "some scenario" step "Given a step" has status "undefined"
 
-  Scenario: hooks should not execute in dry run, single runtime
+  Scenario: hooks should not execute in dry run, serial runtime
     Given a file named "features/step_definitions/cucumber_steps.js" with:
     """
     const {BeforeAll, Before, After, AfterAll, Given} = require('cucumber')

--- a/features/dryrun_mode.feature
+++ b/features/dryrun_mode.feature
@@ -44,10 +44,11 @@ Feature: Dryrun mode
       """
       const {BeforeAll, Before, After, AfterAll, Given} = require('cucumber')
 
-      BeforeAll(function() {throw 'shouldnt run'})
-      Before(function() {throw 'shouldnt run'})
-      After(function() {throw 'shouldnt run'})
-      AfterAll(function() {throw 'shouldnt run'})
+      Before(function() {throw 'shouldnt run Before'})
+      After(function() {throw 'shouldnt run After'})
+
+      BeforeAll(function() {throw 'shouldnt run BeforeAll'})
+      AfterAll(function() {throw 'shouldnt run AfterAll'})
 
       Given('a step', function() {})
       """

--- a/features/dryrun_mode.feature
+++ b/features/dryrun_mode.feature
@@ -39,18 +39,35 @@ Feature: Dryrun mode
     Then it fails
     And scenario "some scenario" step "Given a step" has status "undefined"
 
-  Scenario: hooks
+  Scenario: hooks should not execute in dry run, single runtime
     Given a file named "features/step_definitions/cucumber_steps.js" with:
-      """
-      const {BeforeAll, Before, After, AfterAll, Given} = require('cucumber')
+    """
+    const {BeforeAll, Before, After, AfterAll, Given} = require('cucumber')
 
-      Before(function() {throw 'shouldnt run Before'})
-      After(function() {throw 'shouldnt run After'})
+    Before(function() {throw 'shouldnt run Before'})
+    After(function() {throw 'shouldnt run After'})
 
-      BeforeAll(function() {throw 'shouldnt run BeforeAll'})
-      AfterAll(function() {throw 'shouldnt run AfterAll'})
+    BeforeAll(function() {throw 'shouldnt run BeforeAll'})
+    AfterAll(function() {throw 'shouldnt run AfterAll'})
 
-      Given('a step', function() {})
-      """
+    Given('a step', function() {})
+    """
     When I run cucumber-js with `--dry-run`
+    Then it passes
+
+  @spawn
+  Scenario: hooks should not execute in dry run, parallel runtime
+    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    """
+    const {BeforeAll, Before, After, AfterAll, Given} = require('cucumber')
+
+    Before(function() {throw 'shouldnt run Before'})
+    After(function() {throw 'shouldnt run After'})
+
+    BeforeAll(function() {throw 'shouldnt run BeforeAll'})
+    AfterAll(function() {throw 'shouldnt run AfterAll'})
+
+    Given('a step', function() {})
+    """
+    When I run cucumber-js with `--dry-run --parallel 2`
     Then it passes

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -61,6 +61,9 @@ export default class Runtime {
   }
 
   async runTestRunHooks(key: string, name: string): Promise<void> {
+    if (this.options.dryRun) {
+      return
+    }
     await bluebird.each(
       this.supportCodeLibrary[key],
       async (hookDefinition: TestRunHookDefinition) => {

--- a/src/runtime/parallel/command_types.ts
+++ b/src/runtime/parallel/command_types.ts
@@ -1,4 +1,5 @@
 import { messages } from 'cucumber-messages'
+import { IRuntimeOptions } from '../index'
 
 // Messages from Master to Slave
 
@@ -12,7 +13,7 @@ export interface ISlaveCommandInitialize {
   filterStacktraces: boolean
   supportCodePaths: string[]
   supportCodeRequiredModules: string[]
-  worldParameters: any
+  options: IRuntimeOptions
 }
 
 export interface ISlaveCommandRun {

--- a/src/runtime/parallel/master.ts
+++ b/src/runtime/parallel/master.ts
@@ -161,7 +161,7 @@ export default class Master {
         filterStacktraces: this.options.filterStacktraces,
         supportCodePaths: this.supportCodePaths,
         supportCodeRequiredModules: this.supportCodeRequiredModules,
-        worldParameters: this.options.worldParameters,
+        options: this.options,
       },
     }
     slave.process.send(initializeCommand)


### PR DESCRIPTION
Fixes #1258