### PR TITLE
docs: add link to 6.x branch for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The following documentation is for master. See below for documentation for older
 
 #### Documentation for older versions
 
+* [`6.x`](https://github.com/cucumber/cucumber-js/tree/6.x)
 * [`5.x`](https://github.com/cucumber/cucumber-js/tree/5.x)
 * [`4.x`](https://github.com/cucumber/cucumber-js/tree/4.x)
 * [`3.x`](https://github.com/cucumber/cucumber-js/tree/3.x)


### PR DESCRIPTION
We now have various unreleased breaking changes on master, including the move to cucumber-messages, so adding a link to the 6.x branch (created from 6.0.5 tag) so we can point people at docs representing the current released version.﻿
