### PR TITLE
cleanup run slave + fix parallel time

### DIFF
--- a/bin/run_slave
+++ b/bin/run_slave
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-require('../lib/runtime/parallel/run_slave.js').default()

--- a/package.json
+++ b/package.json
@@ -174,7 +174,6 @@
     "is-stream": "^2.0.0",
     "knuth-shuffle-seeded": "^1.0.6",
     "lodash": "^4.17.14",
-    "long": "^4.0.0",
     "mz": "^2.4.0",
     "progress": "^2.0.0",
     "resolve": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "is-stream": "^2.0.0",
     "knuth-shuffle-seeded": "^1.0.6",
     "lodash": "^4.17.14",
+    "long": "^4.0.0",
     "mz": "^2.4.0",
     "progress": "^2.0.0",
     "resolve": "^1.3.3",

--- a/src/runtime/parallel/master.ts
+++ b/src/runtime/parallel/master.ts
@@ -15,14 +15,7 @@ import {
 } from './command_types'
 import { doesHaveValue } from '../../value_checker'
 
-const slaveCommand = path.resolve(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'bin',
-  'run_slave'
-)
+const runSlavePath = path.resolve(__dirname, 'run_slave.js')
 
 export interface INewMasterOptions {
   cwd: string
@@ -138,7 +131,7 @@ export default class Master {
   }
 
   startSlave(id: string, total: number): void {
-    const slaveProcess = fork(slaveCommand, [], {
+    const slaveProcess = fork(runSlavePath, [], {
       cwd: this.cwd,
       env: _.assign({}, process.env, {
         CUCUMBER_PARALLEL: 'true',

--- a/src/runtime/parallel/run_slave.ts
+++ b/src/runtime/parallel/run_slave.ts
@@ -2,7 +2,7 @@ import Slave from './slave'
 import VError from 'verror'
 import { doesHaveValue } from '../../value_checker'
 
-export default function run(): void {
+function run(): void {
   const exit = (exitCode: number, error?: Error, message?: string): void => {
     if (doesHaveValue(error)) {
       console.error(VError.fullStack(new VError(error, message))) // eslint-disable-line no-console
@@ -23,3 +23,5 @@ export default function run(): void {
       )
   })
 }
+
+run()

--- a/src/time.ts
+++ b/src/time.ts
@@ -42,10 +42,10 @@ export function addDurations(
   if (doesNotHaveValue(b)) {
     return a
   }
-  let seconds = new Long(0).add(a.seconds).add(b.seconds)
+  let seconds = toNumber(a.seconds) + toNumber(b.seconds)
   let nanos = a.nanos + b.nanos
   if (nanos > NANOSECONDS_IN_SECOND) {
-    seconds = seconds.add(1)
+    seconds += 1
     nanos -= NANOSECONDS_IN_SECOND
   }
   return new messages.Duration({ seconds, nanos })

--- a/src/time.ts
+++ b/src/time.ts
@@ -1,5 +1,6 @@
 import { messages } from 'cucumber-messages'
 import { doesNotHaveValue } from './value_checker'
+import Long from 'long'
 
 export const NANOSECONDS_IN_MILLISECOND = 1e6
 export const MILLISECONDS_IN_SECOND = 1e3
@@ -30,6 +31,10 @@ function getTimestamp(): number {
   return new methods.Date().getTime()
 }
 
+function toNumber(x: number | Long): number {
+  return typeof x === 'number' ? x : x.toNumber()
+}
+
 export function addDurations(
   a: messages.IDuration,
   b: messages.IDuration
@@ -37,10 +42,10 @@ export function addDurations(
   if (doesNotHaveValue(b)) {
     return a
   }
-  let seconds = (a.seconds as number) + (b.seconds as number)
+  let seconds = new Long(0).add(a.seconds).add(b.seconds)
   let nanos = a.nanos + b.nanos
   if (nanos > NANOSECONDS_IN_SECOND) {
-    seconds += 1
+    seconds = seconds.add(1)
     nanos -= NANOSECONDS_IN_SECOND
   }
   return new messages.Duration({ seconds, nanos })
@@ -59,14 +64,13 @@ export function millisecondsToDuration(
 }
 
 export function durationToMilliseconds(duration: messages.IDuration): number {
-  return (
-    (duration.seconds as number) * MILLISECONDS_IN_SECOND +
-    duration.nanos / NANOSECONDS_IN_MILLISECOND
-  )
+  const secondMillis = toNumber(duration.seconds) * MILLISECONDS_IN_SECOND
+  const nanoMillis = duration.nanos / NANOSECONDS_IN_MILLISECOND
+  return secondMillis + nanoMillis
 }
 
 export function durationToNanoseconds(duration: messages.IDuration): number {
-  return (duration.seconds as number) * NANOSECONDS_IN_SECOND + duration.nanos
+  return toNumber(duration.seconds) * NANOSECONDS_IN_SECOND + duration.nanos
 }
 
 export function getZeroDuration(): messages.IDuration {


### PR DESCRIPTION
Don't need run_slave in bin since we are using fork where we pass the path to a node file.

While testing out parallel, also noticed some the parallel reported time was broken. No tests for those as we should switch to using some from cucumber-messages soon