### PR TITLE
Using https where possible. Removing offline sites.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1695,7 +1695,7 @@ be used to get the name / tags of the running scenario. ([#947](https://github.c
 
 #### New features
 
-* Publish Cucumber.js to NPM as [`cucumber`](http://search.npmjs.org/#/cucumber) (Julien Biezemans)
+* Publish Cucumber.js to NPM as [`cucumber`](https://www.npmjs.com/search?q=cucumber) (Julien Biezemans)
 
 #### Changed features
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,12 @@ See the `package.json` scripts section for how to run the tests.
 
 * lint
   * [prettier](https://github.com/prettier/prettier)
-  * [eslint](http://eslint.org/)
+  * [eslint](https://eslint.org/)
   * [dependency-lint](https://github.com/charlierudolph/dependency-lint)
 * unit tests
   * [mocha](https://mochajs.org/)
-  * [chai](http://chaijs.com/)
-  * [sinon](http://sinonjs.org/)
+  * [chai](https://www.chaijs.com/)
+  * [sinon](https://sinonjs.org/)
 * feature tests
   * cucumber-js tests itself
 
@@ -76,6 +76,6 @@ Review the changes, if everything looks good, squash merge into master.
 * commit message should have the format "Release 0.1.2" (replacing *0.1.2* with the actual version)
 * Tag commit as "v0.1.2"
 * CI will publish to NPM
-* Update [docs.cucumber.io](https://github.com/cucumber/docs.cucumber.io) 
+* Update [docs.cucumber.io](https://github.com/cucumber/docs.cucumber.io)
   * Update the cucumber-js version `data/versions.yaml`
   * Ensure the javascript examples are up to date

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cucumber.js
 
-[![OpenCollective](https://opencollective.com/cucumber/backers/badge.svg)](https://opencollective.com/cucumber) 
+[![OpenCollective](https://opencollective.com/cucumber/backers/badge.svg)](https://opencollective.com/cucumber)
 [![OpenCollective](https://opencollective.com/cucumber/sponsors/badge.svg)](https://opencollective.com/cucumber)
 
 [![TravisCI](https://img.shields.io/travis/cucumber/cucumber-js/master.svg?label=travis-ci)](https://travis-ci.org/cucumber/cucumber-js/branches)
@@ -17,7 +17,7 @@ Cucumber.js is the JavaScript implementation of Cucumber and runs on the [mainta
 
 ## Try it now
 
-We've put a demo of Cucumber.js to [run in your browser](http://cucumber.github.io/cucumber-js/). Why don't you give it a try before anything else?
+We've put a demo of Cucumber.js to [run in your browser](https://cucumber.github.io/cucumber-js/). Why don't you give it a try before anything else?
 
 ## Help & support
 
@@ -33,8 +33,7 @@ Everyone interacting in this codebase and issue tracker is expected to follow th
 
 ## Install
 
-[![npm downloads](https://img.shields.io/npm/dm/cucumber.svg?style=flat-square)](http://npm-stat.com/charts.html?package=cucumber&from=2015-09-01)
-
+[![npm downloads](https://img.shields.io/npm/dm/cucumber.svg?style=flat-square)](https://npm-stat.com/charts.html?package=cucumber&from=2015-09-01)
 
 ### Node
 
@@ -50,7 +49,7 @@ $ npm install cucumber
 
 ## Documentation
 
-The following documentation is for master. See below for documentation for older versions. 
+The following documentation is for master. See below for documentation for older versions.
 
 * [CLI](/docs/cli.md)
 * [Custom Formatters](/docs/custom_formatters.md)

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "tests"
   ],
   "version": "6.0.5",
-  "homepage": "http://github.com/cucumber/cucumber-js",
-  "author": "Julien Biezemans <jb@jbpros.com> (http://jbpros.net)",
+  "homepage": "https://github.com/cucumber/cucumber-js",
+  "author": "Julien Biezemans <jb@jbpros.com>",
   "contributors": [
-    "Julien Biezemans <jb@jbpros.com> (http://jbpros.net)",
+    "Julien Biezemans <jb@jbpros.com>",
     "Fernando Acorreia <fernandoacorreia@gmail.com>",
     "Paul Jensen <paulbjensen@gmail.com>",
     "Kushal Pisavadia",
@@ -31,8 +31,8 @@
     "Michael Zedeler <michael@zedeler.dk>",
     "Tom V <tom@toc.com>",
     "David Godfrey <reactiveraven@reactiveraven.co.uk>",
-    "Paul Shannon (http://devpaul.com)",
-    "Simon Dean <simon@simondean.org> (http://www.simondean.org)",
+    "Paul Shannon (https://devpaul.com)",
+    "Simon Dean <simon@simondean.org>",
     "John Wright <johngeorge.wright@gmail.com>",
     "Johny Jose <johny@playlyfe.com>",
     "Marat Dyatko <vectart@gmail.com>",
@@ -145,7 +145,7 @@
   },
   "bugs": {
     "email": "cukes@googlegroups.com",
-    "url": "http://github.com/cucumber/cucumber-js/issues"
+    "url": "https://github.com/cucumber/cucumber-js/issues"
   },
   "directories": {
     "lib": "./lib"


### PR DESCRIPTION
I noticed that the demo site is linked without https and doesn't have a redirect in place. That seemed worth fixing.

I went through the rest of the project looking for other links that could be improved:
* to add https
* where the ultimate site was different (e.g. paths changed or needed a www subdomain)
* where the websites were no longer responding:
  * jbpros.net is offline
  * simondean.org is a placeholder cpanel page

The last 2 items are the most worth attention, I think.