### PR TITLE
build: define node support as 10+ in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "dependencies": {
     "assertion-error-formatter": "^3.0.0",


### PR DESCRIPTION
Missed this when I removed Node 8 support previously.