### PR TITLE
remove typeName from options object for defineParameterType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
   * `event-protocol` formatter has been removed and replaced with `message`
   * Custom formatters will need to migrate
   * `json` formatter is deprecated and will be removed in next major release. Custom formatters should migrate to use the `message` formatter, or the [standalone JSON formatter](https://github.com/cucumber/cucumber/tree/master/json-formatter) as a stopgap.
-* Remove `typeName` from options object for `defineParameterType` in favour of `name`
+* Remove long-deprecated `typeName` from options object for `defineParameterType` in favour of `name`
 
 #### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
   * `event-protocol` formatter has been removed and replaced with `message`
   * Custom formatters will need to migrate
   * `json` formatter is deprecated and will be removed in next major release. Custom formatters should migrate to use the `message` formatter, or the [standalone JSON formatter](https://github.com/cucumber/cucumber/tree/master/json-formatter) as a stopgap.
+* Remove `typeName` from options object for `defineParameterType` in favour of `name`
 
 #### Bug fixes
 

--- a/src/support_code_library_builder/build_helpers.ts
+++ b/src/support_code_library_builder/build_helpers.ts
@@ -1,14 +1,9 @@
-import { deprecate } from 'util'
 import _ from 'lodash'
 import { ParameterType } from 'cucumber-expressions'
 import path from 'path'
 import StackTrace from 'stacktrace-js'
 import { isFileNameInCucumber } from '../stack_trace_filter'
-import {
-  doesHaveValue,
-  doesNotHaveValue,
-  valueOrDefault,
-} from '../value_checker'
+import { doesHaveValue, valueOrDefault } from '../value_checker'
 import { ILineAndUri } from '../types'
 import { IParameterTypeDefinition } from './types'
 
@@ -34,19 +29,11 @@ export function getDefinitionLineAndUri(cwd: string): ILineAndUri {
 
 export function buildParameterType({
   name,
-  typeName,
   regexp,
   transformer,
   useForSnippets,
   preferForRegexpMatch,
 }: IParameterTypeDefinition<any>): ParameterType<any> {
-  const getTypeName = deprecate(
-    () => typeName,
-    'Cucumber defineParameterType: Use name instead of typeName'
-  )
-  if (doesNotHaveValue(name) && doesHaveValue(typeName)) {
-    name = getTypeName()
-  }
   if (typeof useForSnippets !== 'boolean') useForSnippets = true
   if (typeof preferForRegexpMatch !== 'boolean') preferForRegexpMatch = false
   return new ParameterType(

--- a/src/support_code_library_builder/types.ts
+++ b/src/support_code_library_builder/types.ts
@@ -37,7 +37,6 @@ export interface IDefineTestRunHookOptions {
 
 export interface IParameterTypeDefinition<T> {
   name: string
-  typeName: string
   regexp: RegExp
   transformer: (...match: string[]) => T
   useForSnippets: boolean


### PR DESCRIPTION
Since we are building up to a major release - this was [deprecated](https://github.com/cucumber/cucumber-js/pull/904) back in 2017.