### PR TITLE
chore(deps): bump lodash from 4.17.16 to 4.17.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,6 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 * don't execute BeforeAll and AfterAll hooks when in dry-run
 * support correct case for `--retry-tag-filter` CLI argument
 
-#### Internals
-
-* Bump Lodash
-
 ### [6.0.5](https://github.com/cucumber/cucumber-js/compare/v6.0.4...v6.0.5) (2019-11-13)
 
 #### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 * don't execute BeforeAll and AfterAll hooks when in dry-run
 * support correct case for `--retry-tag-filter` CLI argument
 
+#### Internals
+
+* Bump Lodash
+
 ### [6.0.5](https://github.com/cucumber/cucumber-js/compare/v6.0.4...v6.0.5) (2019-11-13)
 
 #### Bug fixes

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "is-generator": "^1.0.2",
     "is-stream": "^2.0.0",
     "knuth-shuffle-seeded": "^1.0.6",
-    "lodash": "^4.17.16",
+    "lodash": "^4.17.19",
     "mz": "^2.4.0",
     "progress": "^2.0.0",
     "resolve": "^1.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2834,7 +2834,7 @@ lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.2.1:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@^4.17.16:
+lodash@^4.17.19:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==


### PR DESCRIPTION
Hi ! :wave: 

Advisory : https://www.npmjs.com/advisories/1523

I don't know why renovate didn't update that one yet.