### PR TITLE
Use Node's built-in assertion library in example

### DIFF
--- a/docs/nodejs_example.md
+++ b/docs/nodejs_example.md
@@ -60,7 +60,7 @@
   // features/support/steps.js
   const { Given, When, Then } = require("cucumber");
   const assert = require("assert").strict
-  
+
   Given("a variable set to {int}", function(number) {
     this.setTo(number);
   });

--- a/docs/nodejs_example.md
+++ b/docs/nodejs_example.md
@@ -1,12 +1,12 @@
 ## Setup
 
 - Install [Node.js](https://nodejs.org) (6 or higher)
-- Install the last version of [Chai](https://www.chaijs.com/) and Cucumber modules with [yarn](https://yarnpkg.com/en/) **or** [npm](https://www.npmjs.com/)
+- Install Cucumber modules with [yarn](https://yarnpkg.com/en/) **or** [npm](https://www.npmjs.com/)
 
   ```
-  yarn add -D chai@latest cucumber@latest
+  yarn add -D cucumber@latest
 
-  npm i -D chai@latest cucumber@latest
+  npm i -D cucumber@latest
   ```
 
 * Add the following files
@@ -59,8 +59,8 @@
   ```javascript
   // features/support/steps.js
   const { Given, When, Then } = require("cucumber");
-  const { expect } = require("chai");
-
+  const assert = require("assert").strict
+  
   Given("a variable set to {int}", function(number) {
     this.setTo(number);
   });
@@ -70,7 +70,7 @@
   });
 
   Then("the variable should contain {int}", function(number) {
-    expect(this.variable).to.eql(number);
+    assert.equal(this.variable, number);
   });
   ```
 


### PR DESCRIPTION
Using `expect` from the `chai` package` in Cucumber documentation creates the misleading perception that Cucumber-JS requires or recommends chai in any way. At the very least, it requires people who don't know chai to learn about it. Node now provides a [built-in assertion library](https://nodejs.org/api/assert.html). How do you feel about using it in the Cucumber documentation?