### PR TITLE
Load custom formatter by relative path only if it begins with a dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ If anything is missing from the migration guide, please submit an issue.
   * Custom formatters will need to migrate
   * `json` formatter is deprecated and will be removed in next major release. Custom formatters should migrate to use the `message` formatter, or the [standalone JSON formatter](https://github.com/cucumber/cucumber/tree/master/json-formatter) as a stopgap.
 * Remove long-deprecated `typeName` from options object for `defineParameterType` in favour of `name`
+* Custom formatters are no longer loaded relative to the current directory unless it begins with a dot (e.g. `--format=./relpath/to/formatter`)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ If anything is missing from the migration guide, please submit an issue.
   * Custom formatters will need to migrate
   * `json` formatter is deprecated and will be removed in next major release. Custom formatters should migrate to use the `message` formatter, or the [standalone JSON formatter](https://github.com/cucumber/cucumber/tree/master/json-formatter) as a stopgap.
 * Remove long-deprecated `typeName` from options object for `defineParameterType` in favour of `name`
-* Custom formatters are no longer loaded relative to the current directory unless it begins with a dot (e.g. `--format=./relpath/to/formatter`). 
+* Custom formatters are now loaded via the regular require paths relative to the current directory, unless it begins with a dot (e.g. `--format=./relpath/to/formatter`). Previously this was always loaded as a file relative to the current directory.
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ If anything is missing from the migration guide, please submit an issue.
 * Add `transpose` method to [data table interface](docs/support_files/data_table_interface.md)
 * Add `log` function to world, providing a shorthand to log plain text as [attachment(s)](docs/support_files/attachments.md)
 * Now includes [TypeScript](https://www.typescriptlang.org/) type definitions, deprecating the need for `@types/cucumber` in TypeScript projects
+* Yarn PnP can now be used with this project with custom formatters [#1413](https://github.com/cucumber/cucumber-js/pull/1413)
 
 ### Breaking changes
 
@@ -56,7 +57,7 @@ If anything is missing from the migration guide, please submit an issue.
   * Custom formatters will need to migrate
   * `json` formatter is deprecated and will be removed in next major release. Custom formatters should migrate to use the `message` formatter, or the [standalone JSON formatter](https://github.com/cucumber/cucumber/tree/master/json-formatter) as a stopgap.
 * Remove long-deprecated `typeName` from options object for `defineParameterType` in favour of `name`
-* Custom formatters are no longer loaded relative to the current directory unless it begins with a dot (e.g. `--format=./relpath/to/formatter`)
+* Custom formatters are no longer loaded relative to the current directory unless it begins with a dot (e.g. `--format=./relpath/to/formatter`). 
 
 ### Bug fixes
 

--- a/features/support/world.ts
+++ b/features/support/world.ts
@@ -54,19 +54,12 @@ export class World {
     envOverride: NodeJS.ProcessEnv = null
   ): Promise<void> {
     const messageFilename = 'message.ndjson'
-    const args = ['node', executablePath]
-      .concat(inputArgs, [
-        '--backtrace',
-        '--predictable-ids',
-        '--format',
-        `message:${messageFilename}`,
-      ])
-      .map((arg) => {
-        if (_.includes(arg, '/')) {
-          return path.normalize(arg)
-        }
-        return arg
-      })
+    const args = ['node', executablePath].concat(inputArgs, [
+      '--backtrace',
+      '--predictable-ids',
+      '--format',
+      `message:${messageFilename}`,
+    ])
     const env = _.merge({}, process.env, this.sharedEnv, envOverride)
     const cwd = this.tmpDir
 

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "cli-table3": "^0.6.0",
     "colors": "^1.4.0",
     "commander": "^5.0.0",
+    "create-require": "^1.1.0",
     "duration": "^0.2.2",
     "durations": "^3.4.2",
     "figures": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "cli-table3": "^0.6.0",
     "colors": "^1.4.0",
     "commander": "^5.0.0",
-    "create-require": "^1.1.0",
+    "create-require": "^1.1.1",
     "duration": "^0.2.2",
     "durations": "^3.4.2",
     "figures": "^3.2.0",

--- a/src/formatter/builder.ts
+++ b/src/formatter/builder.ts
@@ -108,9 +108,7 @@ const FormatterBuilder = {
   },
 
   loadCustomFormatter(customFormatterPath: string, cwd: string) {
-    let CustomFormatter = null
-
-    CustomFormatter = createRequire(cwd)(customFormatterPath)
+    const CustomFormatter = createRequire(cwd)(customFormatterPath)
 
     if (typeof CustomFormatter === 'function') {
       return CustomFormatter

--- a/src/formatter/builder.ts
+++ b/src/formatter/builder.ts
@@ -20,6 +20,7 @@ import { Writable as WritableStream } from 'stream'
 import { IParsedArgvFormatOptions } from '../cli/argv_parser'
 import { SnippetInterface } from './step_definition_snippet_builder/snippet_syntax'
 import HtmlFormatter from './html_formatter'
+import createRequire from 'create-require'
 
 interface IGetStepDefinitionSnippetBuilderOptions {
   cwd: string
@@ -109,12 +110,7 @@ const FormatterBuilder = {
   loadCustomFormatter(customFormatterPath: string, cwd: string) {
     let CustomFormatter = null
 
-    if (customFormatterPath.startsWith('.')) {
-      const fullCustomFormatterPath = path.resolve(cwd, customFormatterPath)
-      CustomFormatter = require(fullCustomFormatterPath) // eslint-disable-line @typescript-eslint/no-var-requires
-    } else {
-      CustomFormatter = require(customFormatterPath) // eslint-disable-line @typescript-eslint/no-var-requires
-    }
+    CustomFormatter = createRequire(cwd)(customFormatterPath)
 
     if (typeof CustomFormatter === 'function') {
       return CustomFormatter

--- a/src/formatter/builder.ts
+++ b/src/formatter/builder.ts
@@ -107,8 +107,15 @@ const FormatterBuilder = {
   },
 
   loadCustomFormatter(customFormatterPath: string, cwd: string) {
-    const fullCustomFormatterPath = path.resolve(cwd, customFormatterPath)
-    const CustomFormatter = require(fullCustomFormatterPath) // eslint-disable-line @typescript-eslint/no-var-requires
+    let CustomFormatter = null
+
+    if (customFormatterPath.startsWith('.')) {
+      const fullCustomFormatterPath = path.resolve(cwd, customFormatterPath)
+      CustomFormatter = require(fullCustomFormatterPath) // eslint-disable-line @typescript-eslint/no-var-requires
+    } else {
+      CustomFormatter = require(customFormatterPath) // eslint-disable-line @typescript-eslint/no-var-requires
+    }
+
     if (typeof CustomFormatter === 'function') {
       return CustomFormatter
     } else if (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es2017"],
     "module": "commonjs",
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "lib": ["es2017"],
+    "lib": ["es2017", "dom"],
     "module": "commonjs",
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1612,6 +1612,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.0.tgz#8fe85b319928953deef6f0e5c44bfea13e3c81ef"
+  integrity sha512-yEFVS7dQjDXp5iOEtWisN4uFmL+pUTyIaEizKda9Eb77XX58p6pgFOLAPaBCP+IR6ZPZ1jgJLAuf+ABk0zXYBQ==
+
 cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1612,10 +1612,10 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-require@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.0.tgz#8fe85b319928953deef6f0e5c44bfea13e3c81ef"
-  integrity sha512-yEFVS7dQjDXp5iOEtWisN4uFmL+pUTyIaEizKda9Eb77XX58p6pgFOLAPaBCP+IR6ZPZ1jgJLAuf+ABk0zXYBQ==
+create-require@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"


### PR DESCRIPTION
This commit makes it possible to load a custom formatter that is not relative to the current working directory, such as one installed
globally, or via Yarn PNP. This change makes it so we only load by a relative path if it begins with a dot, otherwise it will load
it as a regular non-relative require.

Fixes #1412 