### PR TITLE
docs: add changelog note about typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 * Add support for Gherkin's [Rule/Example syntax](https://cucumber.io/docs/gherkin/reference/#rule)
 * Add `transpose` method to [data table interface](docs/support_files/data_table_interface.md)
 * Add `log` function to world, providing a shorthand to log plain text as [attachment(s)](docs/support_files/attachments.md)
-* `cucumber-js` is now written in [TypeScript](https://www.typescriptlang.org/) and includes its own typings, so you no longer need to depend on `@types/cucumber` in your own TypeScript projects
+* Now includes [TypeScript](https://www.typescriptlang.org/) type definitions, deprecating the need for `@types/cucumber` in TypeScript projects
 
 #### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 * Add support for Gherkin's [Rule/Example syntax](https://cucumber.io/docs/gherkin/reference/#rule)
 * Add `transpose` method to [data table interface](docs/support_files/data_table_interface.md)
 * Add `log` function to world, providing a shorthand to log plain text as [attachment(s)](docs/support_files/attachments.md)
+* `cucumber-js` is now written in [TypeScript](https://www.typescriptlang.org/) and includes its own typings, so you no longer need to depend on `@types/cucumber` in your own TypeScript projects
 
 #### Breaking changes
 


### PR DESCRIPTION
Not sure if we should call out any differences between `@types/cucumber` and our own typings. For example `TableDefinition` -> `DataTable`.

I started looking at using [tsd](https://github.com/SamVerschueren/tsd) to test the example code from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/cucumber) to expose the differences, going to continue with that today.

Fixes #1269