### PR TITLE
cleanup pickle runner

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -115,8 +115,8 @@ export default class Runtime {
       supportCodeLibrary: this.supportCodeLibrary,
       worldParameters: this.options.worldParameters,
     })
-    const testResult = await pickleRunner.run()
-    if (this.shouldCauseFailure(testResult.status)) {
+    const status = await pickleRunner.run()
+    if (this.shouldCauseFailure(status)) {
       this.success = false
     }
   }

--- a/src/runtime/pickle_runner.ts
+++ b/src/runtime/pickle_runner.ts
@@ -208,6 +208,11 @@ export default class PickleRunner {
   }
 
   getWorstStepResult(): messages.TestStepFinished.ITestStepResult {
+    if (this.testStepResults.length == 0) {
+      return messages.TestStepFinished.TestStepResult.fromObject({
+        status: this.skip ? Status.SKIPPED : Status.PASSED,
+      })
+    }
     return new Query().getWorstTestStepResult(this.testStepResults)
   }
 

--- a/src/runtime/pickle_runner.ts
+++ b/src/runtime/pickle_runner.ts
@@ -1,9 +1,8 @@
-import _, { clone } from 'lodash'
+import { clone } from 'lodash'
 import { getAmbiguousStepException } from './helpers'
 import AttachmentManager from './attachment_manager'
 import StepRunner from './step_runner'
 import { IdGenerator, messages } from '@cucumber/messages'
-import { addDurations, getZeroDuration } from '../time'
 import { EventEmitter } from 'events'
 import {
   ISupportCodeLibrary,
@@ -54,7 +53,7 @@ export default class PickleRunner {
   private readonly supportCodeLibrary: ISupportCodeLibrary
   private readonly testCaseId: string
   private readonly testSteps: ITestStep[]
-  private testStepResults: messages.TestStepFinished.ITestStepResult[];
+  private testStepResults: messages.TestStepFinished.ITestStepResult[]
   private world: any
   private readonly worldParameters: any
 
@@ -300,7 +299,9 @@ export default class PickleRunner {
               testCaseStartedId: this.currentTestCaseStartedId,
             }
             if (!testStep.isBeforeHook) {
-              hookParameter.result = { status: this.getWorstStepResult().status }
+              hookParameter.result = {
+                status: this.getWorstStepResult().status,
+              }
             }
             return await this.runHook(
               testStep.hookDefinition,

--- a/src/runtime/pickle_runner.ts
+++ b/src/runtime/pickle_runner.ts
@@ -208,7 +208,7 @@ export default class PickleRunner {
   }
 
   getWorstStepResult(): messages.TestStepFinished.ITestStepResult {
-    if (this.testStepResults.length == 0) {
+    if (this.testStepResults.length === 0) {
       return messages.TestStepFinished.TestStepResult.fromObject({
         status: this.skip ? Status.SKIPPED : Status.PASSED,
       })

--- a/src/runtime/pickle_runner.ts
+++ b/src/runtime/pickle_runner.ts
@@ -304,9 +304,7 @@ export default class PickleRunner {
               testCaseStartedId: this.currentTestCaseStartedId,
             }
             if (!testStep.isBeforeHook) {
-              hookParameter.result = {
-                status: this.getWorstStepResult().status,
-              }
+              hookParameter.result = this.getWorstStepResult()
             }
             return await this.runHook(
               testStep.hookDefinition,

--- a/src/runtime/pickle_runner_spec.ts
+++ b/src/runtime/pickle_runner_spec.ts
@@ -150,7 +150,7 @@ describe('PickleRunner', () => {
             },
           }),
         ])
-        expect(result).to.eql(passedTestResult)
+        expect(result).to.eql(Status.PASSED)
       })
     })
 
@@ -260,7 +260,7 @@ describe('PickleRunner', () => {
         expect(envelopes[3].testStepFinished.testStepResult).to.eql(
           failingTestResult
         )
-        expect(result).to.eql(failingTestResult)
+        expect(result).to.eql(Status.FAILED)
       })
     })
 
@@ -460,7 +460,7 @@ describe('PickleRunner', () => {
             },
           }),
         ])
-        expect(result).to.eql(envelopes[7].testStepFinished.testStepResult)
+        expect(result).to.eql(Status.PASSED)
       })
     })
 

--- a/src/runtime/pickle_runner_spec.ts
+++ b/src/runtime/pickle_runner_spec.ts
@@ -24,7 +24,7 @@ interface ITestPickleRunnerRequest {
 
 interface ITestPickleRunnerResponse {
   envelopes: messages.IEnvelope[]
-  result: messages.TestStepFinished.ITestStepResult
+  result: messages.TestStepFinished.TestStepResult.Status
 }
 
 async function testPickleRunner(
@@ -302,11 +302,8 @@ describe('PickleRunner', () => {
             },
           })
         )
-        expect(result.status).to.eql(
+        expect(result).to.eql(
           envelopes[3].testStepFinished.testStepResult.status
-        )
-        expect(result.message).to.eql(
-          envelopes[3].testStepFinished.testStepResult.message
         )
       })
     })
@@ -341,7 +338,7 @@ describe('PickleRunner', () => {
             },
           })
         )
-        expect(result.status).to.eql(
+        expect(result).to.eql(
           envelopes[3].testStepFinished.testStepResult.status
         )
       })
@@ -502,7 +499,7 @@ describe('PickleRunner', () => {
             },
           })
         )
-        expect(result.status).to.eql(
+        expect(result).to.eql(
           envelopes[3].testStepFinished.testStepResult.status
         )
       })
@@ -569,7 +566,7 @@ describe('PickleRunner', () => {
             },
           })
         )
-        expect(result.status).to.eql(
+        expect(result).to.eql(
           envelopes[7].testStepFinished.testStepResult.status
         )
       })


### PR DESCRIPTION
removes the internal concept of a `pickleRunner` result. This is outdated and based on when a testCase had a result and now we only report testStep results and use the `getWorstTestStepResult` from cucumber query.

Idea for the refactor came out of reviewing #1416 where `pickleRunner.result` was being used in the wrong way.