### PR TITLE
publish features use stubbed reports server

### DIFF
--- a/features/publish.feature
+++ b/features/publish.feature
@@ -105,7 +105,8 @@ Feature: Publish reports
       """
   @spawn
   Scenario: the publication banner is not shown when publication is done
-    When I run cucumber-js with arguments `<args>` and env `<env>`
+    Given a report server is running on 'http://localhost:9987'
+    When I run cucumber-js with arguments `<args>` and env `<env> CUCUMBER_PUBLISH_URL=http://localhost:9987/api/reports`
     Then the error output does not contain the text:
       """
       Share your Cucumber Report with your team at https://reports.cucumber.io

--- a/features/publish.feature
+++ b/features/publish.feature
@@ -1,7 +1,9 @@
 Feature: Publish reports
 
   Background:
-    Given a file named "features/a.feature" with:
+    Given a report server is running on 'http://localhost:9987'
+    And my env includes "CUCUMBER_PUBLISH_URL=http://localhost:9987/api/reports"
+    And a file named "features/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -16,8 +18,7 @@ Feature: Publish reports
 
   @spawn
   Scenario: Report is published when --publish is specified
-    Given a report server is running on 'http://localhost:9987'
-    When I run cucumber-js with arguments `--publish` and env `CUCUMBER_PUBLISH_URL=http://localhost:9987/api/reports`
+    When I run cucumber-js with arguments `--publish` and env ``
     Then it passes
     And the server should receive the following message types:
       | meta             |
@@ -35,8 +36,7 @@ Feature: Publish reports
 
   @spawn
   Scenario: Report is published when CUCUMBER_PUBLISH_ENABLED is set
-    Given a report server is running on 'http://localhost:9987'
-    When I run cucumber-js with arguments `` and env `CUCUMBER_PUBLISH_ENABLED=1 CUCUMBER_PUBLISH_URL=http://localhost:9987/api/reports`
+    When I run cucumber-js with arguments `` and env `CUCUMBER_PUBLISH_ENABLED=1`
     Then it passes
     And the server should receive the following message types:
       | meta             |
@@ -54,8 +54,7 @@ Feature: Publish reports
 
   @spawn
   Scenario: Report is published when CUCUMBER_PUBLISH_TOKEN is set
-    Given a report server is running on 'http://localhost:9987'
-    When I run cucumber-js with arguments `` and env `CUCUMBER_PUBLISH_TOKEN=keyboardcat CUCUMBER_PUBLISH_URL=http://localhost:9987/api/reports`
+    When I run cucumber-js with arguments `` and env `CUCUMBER_PUBLISH_TOKEN=keyboardcat`
     Then it passes
     And the server should receive the following message types:
       | meta             |
@@ -74,8 +73,7 @@ Feature: Publish reports
 
   @spawn
   Scenario: a banner is displayed after publication
-    Given a report server is running on 'http://localhost:9987'
-    When I run cucumber-js with arguments `--publish` and env `CUCUMBER_PUBLISH_URL=http://localhost:9987/api/reports`
+    When I run cucumber-js with arguments `--publish` and env ``
     Then the error output contains the text:
       """
       ┌──────────────────────────────────────────────────────────────────────────┐
@@ -105,8 +103,7 @@ Feature: Publish reports
       """
   @spawn
   Scenario: the publication banner is not shown when publication is done
-    Given a report server is running on 'http://localhost:9987'
-    When I run cucumber-js with arguments `<args>` and env `<env> CUCUMBER_PUBLISH_URL=http://localhost:9987/api/reports`
+    When I run cucumber-js with arguments `<args>` and env `<env>`
     Then the error output does not contain the text:
       """
       Share your Cucumber Report with your team at https://reports.cucumber.io

--- a/features/step_definitions/cli_steps.ts
+++ b/features/step_definitions/cli_steps.ts
@@ -12,6 +12,10 @@ import { World } from '../support/world'
 
 const { version } = require('../../package.json') // eslint-disable-line @typescript-eslint/no-var-requires
 
+When('my env includes {string}', function (this: World, envString: string) {
+  this.sharedEnv = this.parseEnvString(envString)
+})
+
 When(
   /^I run cucumber-js(?: with `(|.+)`)?$/,
   { timeout: 10000 },
@@ -25,21 +29,11 @@ When(
 When(
   /^I run cucumber-js with arguments `(|.+)` and env `(|.+)`$/,
   { timeout: 10000 },
-  async function (this: World, args: string, envs: string) {
+  async function (this: World, args: string, envString: string) {
     const renderedArgs = Mustache.render(valueOrDefault(args, ''), this)
     const stringArgs = stringArgv(renderedArgs)
-    const initialValue: NodeJS.ProcessEnv = {}
-    const env: NodeJS.ProcessEnv = (envs === null ? '' : envs)
-      .split(/\s+/)
-      .map((keyValue) => keyValue.split('='))
-      .reduce((dict, pair) => {
-        dict[pair[0]] = pair[1]
-        return dict
-      }, initialValue)
-    return await this.run(this.localExecutablePath, stringArgs, {
-      ...process.env,
-      ...env,
-    })
+    const env = this.parseEnvString(envString)
+    return await this.run(this.localExecutablePath, stringArgs, env)
   }
 )
 


### PR DESCRIPTION
Recently had failing tests related to getting a 401 from the reports server.

https://travis-ci.org/github/cucumber/cucumber-js/jobs/737307595

Updated our feature tests to always use the stubbed reports server.