### PR TITLE
build: add yarn audit to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ notifications:
 matrix:
   include:
     - node_js: "14"
-      script: "yarn test-coverage && yarn test-browser-example"
+      script: "yarn test-coverage && yarn test-browser-example && yarn audit"
       after_success: "nyc report --reporter=text-lcov | coveralls"
     - node_js: "12"
       script: "yarn test"


### PR DESCRIPTION
Fixes #1444 

The [`yarn audit`](https://classic.yarnpkg.com/en/docs/cli/audit/) command checks (via the npm registry's audit service) for security vulnerabilities in dependencies (including transitive) and exits with a non-zero if any are found. It's checking the same database [as dependabot does](https://dependabot.com/blog/securing-javascript-transitive-dependencies/) and is also easy to do locally by running the same command.

This should mean we get a flow of:

1. Vulnerability is made public
2. Builds from `master` start to fail
3. Dependabot raises a PR, and its build passes

By default any and all issues will fail the build. We can specify a [severity level](https://docs.npmjs.com/about-audit-reports#severity) at which it starts failing if we want - open question as to whether we should e.g. only fail from `moderate` or even `high` (given dependabot will always be on the case anyway).

(This should go green right now as currently we have 0 issues!)