### PR TITLE
build: fix coverage reporting

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -4,6 +4,7 @@
   "extension": [".ts"],
   "exclude": [
     "**/*_spec.ts",
+    "compatibility/**/*.ts",
     "cucumber.js",
     "features/**/*.ts",
     "test/**/*.ts",

--- a/scripts/test-coverage.sh
+++ b/scripts/test-coverage.sh
@@ -5,10 +5,10 @@ set -ex
 # Get coverage from unit tests
 ./node_modules/.bin/nyc --silent ./node_modules/.bin/mocha 'src/**/*_spec.ts'
 
-# Get coverage from cck tests
-./node_modules/.bin/nyc --silent ./node_modules/.bin/mocha 'compatibility/cck_spec.ts'
+# Get coverage from cck tests (join with previous via --no-clean)
+./node_modules/.bin/nyc --silent --no-clean ./node_modules/.bin/mocha 'compatibility/cck_spec.ts'
 
-# Get coverage from feature tests (join with unit test via --no-clean)
+# Get coverage from feature tests (join with previous via --no-clean)
 yarn build-local
 ./node_modules/.bin/nyc --silent --no-clean node ./bin/cucumber-js
 


### PR DESCRIPTION
I broke this when adding CCK.

- Exclude CCK support code from metrics
- Add missing `--no-clean` so we aren't losing data from the unit test run