### PR TITLE
Using @cucumber/cucumber instead cucumber

### DIFF
--- a/docs/nodejs_example.md
+++ b/docs/nodejs_example.md
@@ -4,9 +4,11 @@
 - Install Cucumber modules with [yarn](https://yarnpkg.com/en/) **or** [npm](https://www.npmjs.com/)
 
   ```
-  yarn add -D cucumber@latest
-
-  npm i -D cucumber@latest
+  yarn add -D @cucumber/cucumber@latest
+  ```
+  or 
+  ```
+  npm i -D @cucumber/cucumber@latest
   ```
 
 * Add the following files


### PR DESCRIPTION
As the 'cucumber' package is obsolete I propose the change to '@cucumber/cucumber' in install script to version 7.0.0.