### PR TITLE
Use vanilla js for disable timeouts example

### DIFF
--- a/docs/support_files/timeouts.md
+++ b/docs/support_files/timeouts.md
@@ -32,12 +32,32 @@ If you use this, you need to implement your own timeout protection.
 Otherwise the test suite may end prematurely or hang indefinitely.
 
 ```javascript
-var {Before, Given} = require('cucumber');
-var Promise = require('bluebird');
+var {Given, When} = require('cucumber');
 
-Given('the operation completes within {n} minutes', {timeout: -1}, function(minutes) {
-  const milliseconds = (minutes + 1) * 60 * 1000
-  const message = `operation did not complete within ${minutes} minutes`
-  return Promise(this.verifyOperationComplete()).timeout(milliseconds, message);
+When('the operation completes within {n} minutes', {timeout: -1}, async( minutes ) {
+  const custom_wait_time = minutes * 60 * 1000;
+  const promise = new Promise(function( resolve, reject ) {
+    // Set up the timeout and get its id
+    const custom_timeout = setTimeout(function() {
+      reject(`Operation did not complete within ${ minutes } ms`);
+    }, custom_wait_time);
+    // Do your stuff inside a self-invoking anonymous async function
+    (async function() {
+      try {
+        const result = await myAsyncStuff();
+        resolve( result );
+      } catch (err) {
+        reject( err );
+      } finally {
+        // prevent remaining timeout hang that could otherwise happen at end of tests
+        clearTimeout( custom_timeout );
+      }
+    })();
+  });
+  
+  const the_good_stuff = await promise;
+  
+  // Do other stuff as long as it will also definitely finish
+  console.log(`Everything from here on out has to finish as well.`);
 });
 ```


### PR DESCRIPTION
Not sure if this needs any kind of version bump, etc. since it's just cucumberjs-specific documentation.

Replaces the current ['Disable timeouts' example](https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/timeouts.md) that uses `bluebird` with an example using a vanilla js `Promise`. It clears the timeout to avoid the hang (took me ages to figure that out). It also shows doing operations after the promise resolves (with a warning).

Not sure this is the most simple example possible as I don't work with promises much, but this is what worked for me and gave me an meaningful understanding of how things work inside there. It could just be hindsight, but I think I would have found this code easier to use as a starting point from which I could build. As the project my team is doing doesn't need `bluebird` for anything else, it would also avoid digging into that library.