### PR TITLE
Add missing @cucumber/react

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "@cucumber/html-formatter": "^11.0.4",
     "@cucumber/messages": "^13.2.1",
     "@cucumber/query": "^7.0.1",
+    "@cucumber/react": "^11.0.2",
     "@cucumber/tag-expressions": "^2.0.4",
     "assertion-error-formatter": "^3.0.0",
     "bluebird": "^3.7.2",


### PR DESCRIPTION
While using the html formatter I am getting an error of missing `cucumber-react.css` CSS file from `@cucumber/react` package. I see based on code that it's expected to be installed. But it's not added to the list of dependencies.

https://github.com/cucumber/cucumber-js/blob/master/src/formatter/html_formatter.ts#L15

