### PR TITLE
attachments: support attaching already-encoded base64 content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Added
 
+- Support attachments that are already base64-encoded
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Added
 
-- Support attachments that are already base64-encoded via a prefix on the MIME type e.g. `this.attach(base64String, 'base64:image/png')` ([https://github.com/cucumber/cucumber-js/pull/1552](#1552))
+- Support attachments that are already base64-encoded via a prefix on the MIME type e.g. `this.attach(base64String, 'base64:image/png')` ([#1552](https://github.com/cucumber/cucumber-js/pull/1552))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Added
 
-- Support attachments that are already base64-encoded
+- Support attachments that are already base64-encoded via a prefix on the MIME type e.g. `this.attach(base64String, 'base64:image/png')` ([https://github.com/cucumber/cucumber-js/pull/1552](#1552))
 
 ### Changed
 

--- a/docs/support_files/attachments.md
+++ b/docs/support_files/attachments.md
@@ -88,7 +88,6 @@ After(function (testCase) {
   var world = this;
   if (testCase.result.status === Status.FAILED) {
     return webDriver.takeScreenshot().then(function(screenShot) {
-      // screenShot is a base-64 encoded PNG
       world.attach(screenShot, 'base64:image/png');
     });
   }

--- a/docs/support_files/attachments.md
+++ b/docs/support_files/attachments.md
@@ -65,6 +65,19 @@ After(function (testCase) {
 });
 ```
 
+If you've already got a base64-encoded string, you can prefix your mime type with `base64:` to indicate this:
+
+```javascript
+var {After, Status} = require('@cucumber/cucumber');
+
+After(function (testCase) {
+  if (testCase.result.status === Status.FAILED) {
+    var base64String = getScreenshotOfError();
+    this.attach(base64String, 'base64:image/png');
+  }
+});
+```
+
 Here is an example of saving a screenshot using [Selenium WebDriver](https://www.npmjs.com/package/selenium-webdriver)
 when a scenario fails:
 
@@ -76,7 +89,7 @@ After(function (testCase) {
   if (testCase.result.status === Status.FAILED) {
     return webDriver.takeScreenshot().then(function(screenShot) {
       // screenShot is a base-64 encoded PNG
-      world.attach(screenShot, 'image/png');
+      world.attach(screenShot, 'base64:image/png');
     });
   }
 });

--- a/features/attachments.feature
+++ b/features/attachments.feature
@@ -28,6 +28,20 @@ Feature: Attachments
       | DATA     | MEDIA TYPE | MEDIA ENCODING |
       | iVBORw== | image/png  | BASE64         |
 
+  Scenario: Attach a string that is already base64 encoded
+    Given a file named "features/support/hooks.js" with:
+      """
+      const {Before} = require('@cucumber/cucumber')
+
+      Before(function() {
+        this.attach(Buffer.from([137, 80, 78, 71]).toString('base64'), 'image/png')
+      })
+      """
+    When I run cucumber-js
+    Then scenario "some scenario" "Before" hook has the attachments:
+      | DATA     | MEDIA TYPE | MEDIA ENCODING |
+      | iVBORw== | image/png  | BASE64         |
+
   Scenario: Attach a stream (callback)
     Given a file named "features/support/hooks.js" with:
       """

--- a/features/attachments.feature
+++ b/features/attachments.feature
@@ -34,7 +34,7 @@ Feature: Attachments
       const {Before} = require('@cucumber/cucumber')
 
       Before(function() {
-        this.attach(Buffer.from([137, 80, 78, 71]).toString('base64'), 'image/png')
+        this.attach(Buffer.from([137, 80, 78, 71]).toString('base64'), 'base64:image/png')
       })
       """
     When I run cucumber-js

--- a/src/runtime/attachment_manager/index.ts
+++ b/src/runtime/attachment_manager/index.ts
@@ -51,10 +51,17 @@ export default class AttachmentManager {
       if (doesNotHaveValue(mediaType)) {
         mediaType = 'text/plain'
       }
-      this.createStringAttachment(data, {
-        encoding: messages.Attachment.ContentEncoding.IDENTITY,
-        contentType: mediaType,
-      })
+      if (mediaType.startsWith('base64:')) {
+        this.createStringAttachment(data, {
+          encoding: messages.Attachment.ContentEncoding.BASE64,
+          contentType: mediaType.replace('base64:', ''),
+        })
+      } else {
+        this.createStringAttachment(data, {
+          encoding: messages.Attachment.ContentEncoding.IDENTITY,
+          contentType: mediaType,
+        })
+      }
     } else {
       throw Error(
         'Invalid attachment data: must be a buffer, readable stream, or string'

--- a/src/runtime/attachment_manager/index_spec.ts
+++ b/src/runtime/attachment_manager/index_spec.ts
@@ -204,6 +204,34 @@ describe('AttachmentManager', () => {
         })
       })
 
+      describe('with media type, already base64 encoded', () => {
+        it('adds the data and media', function () {
+          // Arrange
+          const attachments: IAttachment[] = []
+          const attachmentManager = new AttachmentManager((x) =>
+            attachments.push(x)
+          )
+
+          // Act
+          const result = attachmentManager.create(
+            Buffer.from('my string', 'utf8').toString('base64'),
+            'base64:text/special'
+          )
+
+          // Assert
+          expect(result).to.eql(undefined)
+          expect(attachments).to.eql([
+            {
+              data: 'bXkgc3RyaW5n',
+              media: {
+                contentType: 'text/special',
+                encoding: messages.Attachment.ContentEncoding.BASE64,
+              },
+            },
+          ])
+        })
+      })
+
       describe('without mime type', () => {
         it('adds the data with the default mime type', function () {
           // Arrange


### PR DESCRIPTION
Fixes #1550.

After the refactor to accomodate messages, we made it impossible to attach content that was already base64 encoded, since passing a string and mime type to the `attach` function will cause it to be set as "identity".

This makes it possible via a prefix on the mime type parameter e.g. `base64:image/png`. I'm not particularly wedded to this solution but it seems reasonable. Things we could do instead:

- Add a third parameter to the `attach` function
- Add an alternate function e.g. `this.attachBase64`
- Auto-detect internally - possible but a lot of wasted computation as we'd need to base64 decode and then encode each string to understand if it started out base64 encoded or not

