### PR TITLE
build: inline sources in source maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "noImplicitThis": true,
     "resolveJsonModule": true,
     "sourceMap": true,
+    "inlineSources": true,
     "target": "es2017",
     "typeRoots": [
       "./node_modules/@types",


### PR DESCRIPTION
We were already emitting source maps, but Node was unable to really use them at runtime because we don't also include the TypeScript source files in the package. Doing that feels a bit off to me - could lead to issues with end users trying to use the source files directly with their own tsconfig. This change means we inline the source content with the source map files, so stack traces and debuggers can do their thing.