### PR TITLE
Display error banner when Reports server returns status code ≠ 2xx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version: [10.x, 12.x, 14.x, 15.x]
+      # This could be disabled before merging PR, but honestly, it's a bit frustrating
+      # not having an overview of what works and what don't as soon as one job fails.
+      fail-fast: false
+
     steps:
     - uses: actions/checkout@v2
     - name: with Node.js ${{ matrix.node-version }} on ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version: [10.x, 12.x, 14.x, 15.x]
-      # This could be disabled before merging PR, but honestly, it's a bit frustrating
-      # not having an overview of what works and what don't as soon as one job fails.
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 * Fix types for hook functions so they can return e.g. `'skipped'` ([#1542](https://github.com/cucumber/cucumber-js/pull/1542))
 
+* Do not display stack trace when reports server returns a status code greater than 400, display the server banner instead.
+
 ## [7.0.0] (2020-12-21)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 ### Fixed
 
 * Fix types for hook functions so they can return e.g. `'skipped'` ([#1542](https://github.com/cucumber/cucumber-js/pull/1542))
-
-* Do not display stack trace when reports server returns a status code greater than 400, display the server banner instead.
+* Display the response of the reports server when an error is returned before failing. ([#1608](https://github.com/cucumber/cucumber-js/pull/1608))
 
 ## [7.0.0] (2020-12-21)
 

--- a/cucumber.js
+++ b/cucumber.js
@@ -1,9 +1,7 @@
 const feature = [
   '--require-module ts-node/register',
   '--require features/**/*.ts',
-  `--format ${
-    process.env.CI || !process.stdout.isTTY ? 'progress' : 'progress-bar'
-  }`,
+  `--format progress-bar`,
   '--format rerun:@rerun.txt',
   '--format usage:usage.txt',
   '--format message:messages.ndjson',

--- a/features/publish.feature
+++ b/features/publish.feature
@@ -112,7 +112,7 @@ Feature: Publish reports
       │ Error invalid token │
       └─────────────────────┘
 
-      Error: Unexpected http status 401 from GET http://localhost:9987
+      Unexpected http status 401 from GET http://localhost:9987
       """
 
   @spawn

--- a/features/publish.feature
+++ b/features/publish.feature
@@ -54,7 +54,7 @@ Feature: Publish reports
 
   @spawn
   Scenario: Report is published when CUCUMBER_PUBLISH_TOKEN is set
-    When I run cucumber-js with arguments `` and env `CUCUMBER_PUBLISH_TOKEN=keyboardcat`
+    When I run cucumber-js with arguments `` and env `CUCUMBER_PUBLISH_TOKEN=f318d9ec-5a3d-4727-adec-bd7b69e2edd3`
     Then it passes
     And the server should receive the following message types:
       | meta             |
@@ -69,7 +69,7 @@ Feature: Publish reports
       | testStepFinished |
       | testCaseFinished |
       | testRunFinished  |
-    And the server should receive an "Authorization" header with value "Bearer keyboardcat"
+    And the server should receive an "Authorization" header with value "Bearer f318d9ec-5a3d-4727-adec-bd7b69e2edd3"
 
   @spawn
   Scenario: a banner is displayed after publication
@@ -101,6 +101,17 @@ Feature: Publish reports
       │ module.exports = { default: '--publish-quiet' }                          │
       └──────────────────────────────────────────────────────────────────────────┘
       """
+
+  @spawn
+  Scenario: when results are not published due to an error raised by the server, the banner is displayed
+    When I run cucumber-js with env `CUCUMBER_PUBLISH_TOKEN=keyboardcat`
+    Then the error output contains the text:
+      """
+      ┌─────────────────────┐
+      │ Error invalid token │
+      └─────────────────────┘
+      """
+
   @spawn
   Scenario: the publication banner is not shown when publication is done
     When I run cucumber-js with arguments `<args>` and env `<env>`
@@ -110,10 +121,10 @@ Feature: Publish reports
       """
 
   Examples:
-    | args      | env                           |
-    | --publish |                               |
-    |           | CUCUMBER_PUBLISH_ENABLED=true |
-    |           | CUCUMBER_PUBLISH_TOKEN=123456 |
+    | args      | env                                                         |
+    | --publish |                                                             |
+    |           | CUCUMBER_PUBLISH_ENABLED=true                               |
+    |           | CUCUMBER_PUBLISH_TOKEN=f318d9ec-5a3d-4727-adec-bd7b69e2edd3 |
 
   @spawn
   Scenario: the publication banner is not shown when publication is disabled

--- a/features/publish.feature
+++ b/features/publish.feature
@@ -105,13 +105,13 @@ Feature: Publish reports
   @spawn
   Scenario: when results are not published due to an error raised by the server, the banner is displayed
     When I run cucumber-js with env `CUCUMBER_PUBLISH_TOKEN=keyboardcat`
-    Then the error output contains the text:
+    Then it fails
+    And the error output contains the text:
       """
       ┌─────────────────────┐
       │ Error invalid token │
       └─────────────────────┘
       """
-    And it fails
 
   @spawn
   Scenario: the publication banner is not shown when publication is done

--- a/features/publish.feature
+++ b/features/publish.feature
@@ -111,6 +111,8 @@ Feature: Publish reports
       ┌─────────────────────┐
       │ Error invalid token │
       └─────────────────────┘
+
+      Error: Unexpected http status 401 from GET http://localhost:9987
       """
 
   @spawn

--- a/features/publish.feature
+++ b/features/publish.feature
@@ -111,6 +111,7 @@ Feature: Publish reports
       │ Error invalid token │
       └─────────────────────┘
       """
+    And it fails
 
   @spawn
   Scenario: the publication banner is not shown when publication is done

--- a/features/step_definitions/cli_steps.ts
+++ b/features/step_definitions/cli_steps.ts
@@ -38,6 +38,15 @@ When(
 )
 
 When(
+  /^I run cucumber-js with env `(|.+)`$/,
+  { timeout: 10000 },
+  async function (this: World, envString: string) {
+    const env = this.parseEnvString(envString)
+    return await this.run(this.localExecutablePath, [], env)
+  }
+)
+
+When(
   /^I run cucumber-js with all formatters(?: and `(|.+)`)?$/,
   { timeout: 10000 },
   async function (this: World, args: string) {

--- a/features/step_definitions/cli_steps.ts
+++ b/features/step_definitions/cli_steps.ts
@@ -76,10 +76,14 @@ When(
 Then(/^it passes$/, () => {}) // eslint-disable-line @typescript-eslint/no-empty-function
 
 Then(/^it fails$/, function (this: World) {
-  const actualCode = doesHaveValue(this.lastRun.error)
+  const actualCode: number = doesHaveValue(this.lastRun.error)
     ? this.lastRun.error.code
     : 0
-  expect(actualCode).not.to.eql(0)
+
+  expect(actualCode).not.to.eql(
+    0,
+    `Expected non-zero exit status, but got ${actualCode}`
+  )
   this.verifiedLastRunError = true
 })
 

--- a/features/support/hooks.ts
+++ b/features/support/hooks.ts
@@ -96,8 +96,6 @@ Before('@global-install', function (this: World) {
 
 After(async function (this: World) {
   if (this.reportServer?.started) {
-    // TODO: remove temporary debug
-    console.error('Stopping fake server')
     await this.reportServer.stop()
   }
 

--- a/features/support/hooks.ts
+++ b/features/support/hooks.ts
@@ -94,7 +94,11 @@ Before('@global-install', function (this: World) {
   )
 })
 
-After(function (this: World) {
+After(async function (this: World) {
+  if (this.reportServer?.started) {
+    await this.reportServer.stop()
+  }
+
   if (
     doesHaveValue(this.lastRun) &&
     doesHaveValue(this.lastRun.error) &&
@@ -104,11 +108,5 @@ After(function (this: World) {
       `Last run errored unexpectedly. Output:\n\n${this.lastRun.output}\n\n` +
         `Error Output:\n\n${this.lastRun.errorOutput}`
     )
-  }
-})
-
-After(async function (this: World) {
-  if (this.reportServer?.started) {
-    await this.reportServer.stop()
   }
 })

--- a/features/support/hooks.ts
+++ b/features/support/hooks.ts
@@ -96,6 +96,8 @@ Before('@global-install', function (this: World) {
 
 After(async function (this: World) {
   if (this.reportServer?.started) {
+    // TODO: remove temporary debug
+    console.error('Stopping fake server')
     await this.reportServer.stop()
   }
 

--- a/package.json
+++ b/package.json
@@ -279,7 +279,9 @@
   },
   "tsd": {
     "compilerOptions": {
-      "types": ["long"]
+      "types": [
+        "long"
+      ]
     }
   },
   "bin": {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -121,7 +121,13 @@ export default class Cli {
 
         stream.on('error', (error) => {
           console.error(error.stack)
-          console.error('Exiting due to failing stream', { stream, error })
+          if (stream instanceof HttpStream) {
+            console.error('Exiting due to failing stream', {
+              status: stream.currentStatus,
+              stream,
+              error,
+            })
+          }
 
           process.exit(1)
         })

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -108,6 +108,7 @@ export default class Cli {
                 writeCallback
               ) {
                 console.error(httpResult.responseBody)
+                if (!httpResult.httpOk) process.exit(2)
                 writeCallback()
               },
             })

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -120,7 +120,7 @@ export default class Cli {
         }
 
         stream.on('error', (error) => {
-          console.error('Exiting due to failing stream', { stream, error})
+          console.error('Exiting due to failing stream', { stream, error })
           console.error(error.stack)
           process.exit(1)
         })

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,7 +27,7 @@ import { doesNotHaveValue } from '../value_checker'
 import GherkinStreams from '@cucumber/gherkin/dist/src/stream/GherkinStreams'
 import { ISupportCodeLibrary } from '../support_code_library_builder/types'
 import { IParsedArgvFormatOptions } from './argv_parser'
-import HttpStream, { HttpResult } from '../formatter/http_stream'
+import HttpStream from '../formatter/http_stream'
 import { Writable } from 'stream'
 
 const { incrementing, uuid } = IdGenerator
@@ -102,13 +102,8 @@ export default class Cli {
             stream = new HttpStream(outputTo, 'GET', headers)
             const readerStream = new Writable({
               objectMode: true,
-              write: function (
-                httpResult: HttpResult,
-                encoding,
-                writeCallback
-              ) {
-                console.error(httpResult.responseBody)
-                if (!httpResult.httpOk) process.exit(2)
+              write: function (responseBody: string, encoding, writeCallback) {
+                console.error(responseBody)
                 writeCallback()
               },
             })
@@ -120,15 +115,7 @@ export default class Cli {
         }
 
         stream.on('error', (error) => {
-          console.error(error.stack)
-          if (stream instanceof HttpStream) {
-            console.error('Exiting due to failing stream', {
-              status: stream.currentStatus,
-              stream,
-              error,
-            })
-          }
-
+          console.error(error.message)
           process.exit(1)
         })
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,6 +28,7 @@ import GherkinStreams from '@cucumber/gherkin/dist/src/stream/GherkinStreams'
 import { ISupportCodeLibrary } from '../support_code_library_builder/types'
 import { IParsedArgvFormatOptions } from './argv_parser'
 import HttpStream from '../formatter/http_stream'
+import { Stream } from 'node:stream'
 
 const { incrementing, uuid } = IdGenerator
 
@@ -107,11 +108,19 @@ export default class Cli {
                 if (doesHaveValue(err)) throw err
               }
             )
+
+            stream.pipe(process.stderr)
           } else {
             const fd = await fs.open(path.resolve(this.cwd, outputTo), 'w')
             stream = fs.createWriteStream(null, { fd })
           }
         }
+
+        stream.on('error', (error) => {
+          console.error(error.stack)
+          process.exit(1)
+        })
+
         const typeOptions = {
           cwd: this.cwd,
           eventBroadcaster,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -98,9 +98,10 @@ export default class Cli {
               headers.Authorization = `Bearer ${process.env.CUCUMBER_PUBLISH_TOKEN}`
             }
 
-            stream = new HttpStream(outputTo, 'GET', headers, (content) =>
+            stream = new HttpStream(outputTo, 'GET', headers, (content) => {
               console.error(content)
-            )
+              console.error('..........')
+            })
           } else {
             const fd = await fs.open(path.resolve(this.cwd, outputTo), 'w')
             stream = fs.createWriteStream(null, { fd })

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -100,7 +100,6 @@ export default class Cli {
 
             stream = new HttpStream(outputTo, 'GET', headers, (content) => {
               console.error(content)
-              console.error('..........')
             })
           } else {
             const fd = await fs.open(path.resolve(this.cwd, outputTo), 'w')

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -120,8 +120,9 @@ export default class Cli {
         }
 
         stream.on('error', (error) => {
-          console.error('Exiting due to failing stream', { stream, error })
           console.error(error.stack)
+          console.error('Exiting due to failing stream', { stream, error })
+
           process.exit(1)
         })
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -102,7 +102,7 @@ export default class Cli {
               outputTo,
               'GET',
               headers,
-              (content, err) => {
+              (err, content) => {
                 console.error(content)
                 if (doesHaveValue(err)) throw err
               }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,7 +23,7 @@ import supportCodeLibraryBuilder from '../support_code_library_builder'
 import { IdGenerator } from '@cucumber/messages'
 import { IFormatterStream } from '../formatter'
 import { WriteStream as TtyWriteStream } from 'tty'
-import { doesNotHaveValue } from '../value_checker'
+import { doesHaveValue, doesNotHaveValue } from '../value_checker'
 import GherkinStreams from '@cucumber/gherkin/dist/src/stream/GherkinStreams'
 import { ISupportCodeLibrary } from '../support_code_library_builder/types'
 import { IParsedArgvFormatOptions } from './argv_parser'
@@ -98,9 +98,15 @@ export default class Cli {
               headers.Authorization = `Bearer ${process.env.CUCUMBER_PUBLISH_TOKEN}`
             }
 
-            stream = new HttpStream(outputTo, 'GET', headers, (content) => {
-              console.error(content)
-            })
+            stream = new HttpStream(
+              outputTo,
+              'GET',
+              headers,
+              (content, err) => {
+                console.error(content)
+                if (doesHaveValue(err)) throw err
+              }
+            )
           } else {
             const fd = await fs.open(path.resolve(this.cwd, outputTo), 'w')
             stream = fs.createWriteStream(null, { fd })

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -120,6 +120,7 @@ export default class Cli {
         }
 
         stream.on('error', (error) => {
+          console.error('Exiting due to failing stream', { stream, error})
           console.error(error.stack)
           process.exit(1)
         })

--- a/src/formatter/http_stream.ts
+++ b/src/formatter/http_stream.ts
@@ -36,7 +36,10 @@ export default class HttpStream extends Writable {
     private readonly url: string,
     private readonly method: HttpMethod,
     private readonly headers: { [name: string]: string },
-    private readonly reportLocation: (content: string) => void
+    private readonly reportLocation: (
+      content: string,
+      error: Error | null | undefined
+    ) => void
   ) {
     super()
   }
@@ -65,7 +68,7 @@ export default class HttpStream extends Writable {
         this.url,
         this.method,
         (err: Error | null | undefined) => {
-          this.reportLocation(this.responseBodyFromGet)
+          this.reportLocation(this.responseBodyFromGet, err)
           return callback(err)
         }
       )
@@ -89,7 +92,7 @@ export default class HttpStream extends Writable {
         if (res.statusCode >= 400) {
           res.on('end', () => {
             this.responseBodyFromGet = body.toString('utf-8')
-            callback(
+            return callback(
               new Error(`${method} ${url} returned status ${res.statusCode}`)
             )
           })

--- a/src/formatter/http_stream.ts
+++ b/src/formatter/http_stream.ts
@@ -129,14 +129,24 @@ export default class HttpStream extends Transform {
     })
     req.on('error', (err) => this.emit('error', err))
     req.on('response', (res) => {
-      res.on('error', (err) => this.emit('error', err))
+      // TODO: remove temporary debug
+      console.error('Response received: status: ', res.statusCode)
+      res.on('error', (err) => {
+        // TODO: remove temporary debug
+        console.error(
+          'Emmitting error in req.response:',
+          err.message,
+          err.stack
+        )
+        this.emit('error', err)
+      })
       callback(null, res)
     })
 
     if (upload) {
       pipeline(fs.createReadStream(this.tempFilePath), req, (err) => {
         if (doesHaveValue(err)) {
-          // temporary debug
+          // TODO: remove temporary debug
           console.error('Emitting error:', err.stack)
           this.emit('error', err)
         }

--- a/src/formatter/http_stream.ts
+++ b/src/formatter/http_stream.ts
@@ -65,9 +65,8 @@ export default class HttpStream extends Writable {
         this.url,
         this.method,
         (err: Error | null | undefined) => {
-          if (doesHaveValue(err)) return callback(err)
           this.reportLocation(this.responseBodyFromGet)
-          callback(null)
+          return callback(err)
         }
       )
     })
@@ -90,7 +89,9 @@ export default class HttpStream extends Writable {
         if (res.statusCode >= 400) {
           res.on('end', () => {
             this.responseBodyFromGet = body.toString('utf-8')
-            callback(null)
+            callback(
+              new Error(`${method} ${url} returned status ${res.statusCode}`)
+            )
           })
         }
 

--- a/src/formatter/http_stream.ts
+++ b/src/formatter/http_stream.ts
@@ -135,7 +135,11 @@ export default class HttpStream extends Transform {
 
     if (upload) {
       pipeline(fs.createReadStream(this.tempFilePath), req, (err) => {
-        if (doesHaveValue(err)) this.emit('error', err)
+        if (doesHaveValue(err)) {
+          // temporary debug
+          console.error('Emitting error:', err.stack)
+          this.emit('error', err)
+        }
       })
     } else {
       req.end()

--- a/src/formatter/http_stream.ts
+++ b/src/formatter/http_stream.ts
@@ -37,8 +37,8 @@ export default class HttpStream extends Writable {
     private readonly method: HttpMethod,
     private readonly headers: { [name: string]: string },
     private readonly reportLocation: (
-      content: string,
-      error: Error | null | undefined
+      error: Error | null | undefined,
+      content: string
     ) => void
   ) {
     super()
@@ -68,7 +68,7 @@ export default class HttpStream extends Writable {
         this.url,
         this.method,
         (err: Error | null | undefined) => {
-          this.reportLocation(this.responseBodyFromGet, err)
+          this.reportLocation(err, this.responseBodyFromGet)
           return callback(err)
         }
       )

--- a/src/formatter/http_stream.ts
+++ b/src/formatter/http_stream.ts
@@ -107,7 +107,7 @@ export default class HttpStream extends Transform {
         if (res.statusCode >= 400) {
           res.on('end', () => {
             this.responseBodyFromGet = body.toString('utf-8')
-            return callback(null, url)
+            callback(null, url)
           })
         }
 

--- a/src/formatter/http_stream.ts
+++ b/src/formatter/http_stream.ts
@@ -129,25 +129,13 @@ export default class HttpStream extends Transform {
     })
     req.on('error', (err) => this.emit('error', err))
     req.on('response', (res) => {
-      // TODO: remove temporary debug
-      console.error('Response received: status: ', res.statusCode)
-      res.on('error', (err) => {
-        // TODO: remove temporary debug
-        console.error(
-          'Emmitting error in req.response:',
-          err.message,
-          err.stack
-        )
-        this.emit('error', err)
-      })
+      res.on('error', (err) => this.emit('error', err))
       callback(null, res)
     })
 
     if (upload) {
       pipeline(fs.createReadStream(this.tempFilePath), req, (err) => {
         if (doesHaveValue(err)) {
-          // TODO: remove temporary debug
-          console.error('Emitting error:', err.stack)
           this.emit('error', err)
         }
       })

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -162,7 +162,6 @@ describe('HttpStream', () => {
 
   for (let i = 0; i < 1000; i++) {
     it(`runs race condition test ${i}`, (callback) => {
-      console.log({ port })
       const stream = new HttpStream(
         `http://localhost:${port}/api/reports`,
         'GET',

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -185,6 +185,11 @@ describe('HttpStream', () => {
       })
       stream.write('hello')
       stream.end()
+      sleep(75)
     })
   }
 })
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -81,11 +81,7 @@ describe('HttpStream', () => {
     const stream = new HttpStream(
       `http://localhost:${port}/api/reports`,
       'GET',
-      {} //,
-      // (err, content) => {
-      //   if (err) return callback(err)
-      //   reported = content
-      // }
+      {}
     )
 
     const readerStream = new Writable({
@@ -106,17 +102,17 @@ describe('HttpStream', () => {
         .stop()
         .then(() => {
           try {
-            assert.strictEqual(
-              reported.responseBody,
-              `┌──────────────────────────────────────────────────────────────────────────┐
+            const expectedResult: HttpResult = {
+              httpOk: true,
+              responseBody: `┌──────────────────────────────────────────────────────────────────────────┐
 │ View your Cucumber Report at:                                            │
 │ https://reports.cucumber.io/reports/f318d9ec-5a3d-4727-adec-bd7b69e2edd3 │
 │                                                                          │
 │ This report will self-destruct in 24h unless it is claimed or deleted.   │
 └──────────────────────────────────────────────────────────────────────────┘
-`
-            )
-            assert(reported.httpOk)
+`,
+            }
+            assert.deepStrictEqual(reported, expectedResult)
             callback()
           } catch (err) {
             callback(err)
@@ -155,14 +151,14 @@ describe('HttpStream', () => {
       reportServer
         .stop()
         .then(() => {
-          assert.strictEqual(
-            reported.responseBody,
-            `┌─────────────────────┐
+          const expectedResult: HttpResult = {
+            httpOk: false,
+            responseBody: `┌─────────────────────┐
 │ Error invalid token │
 └─────────────────────┘
-`
-          )
-          assert(!reported.httpOk)
+`,
+          }
+          assert.deepStrictEqual(reported, expectedResult)
           callback()
         })
         .catch((err) => {

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -176,33 +176,15 @@ describe('HttpStream', () => {
       })
 
       stream.pipe(readerStream)
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      readerStream.on('error', async (err) => {
-        await sleepThenCallback(callback, err)
-      })
+      readerStream.on('error', callback)
       readerStream.on('finish', () => {
         reportServer
           .stop()
-          .then(async () => {
-            await sleepThenCallback(callback)
-          })
-          .catch(async (err) => {
-            await sleepThenCallback(callback, err)
-          })
+          .then(() => callback())
+          .catch(callback)
       })
       stream.write('hello')
       stream.end()
     })
   }
 })
-
-async function sleepThenCallback(
-  callback: Callback,
-  err?: Error
-): Promise<void> {
-  await new Promise(() =>
-    setTimeout(() => {
-      callback(err)
-    }, 75)
-  )
-}

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -160,8 +160,8 @@ describe('HttpStream', () => {
     stream.end()
   })
 
-  for (let i = 0; i < 100; i++) {
-    it(`runs fuzz test ${i}`, (callback) => {
+  for (let i = 0; i < 1000; i++) {
+    it(`runs race condition test ${i}`, (callback) => {
       const stream = new HttpStream(
         `http://localhost:${port}/api/reports`,
         'GET',

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -134,7 +134,7 @@ describe('HttpStream', () => {
       }
     )
 
-    stream.on('error', callback)
+    stream.on('error', () => {})
     stream.on('finish', () => {
       reportServer
         .stop()

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -96,7 +96,7 @@ describe('HttpStream', () => {
     stream.on('finish', () => {
       reportServer
         .stop()
-        .then((receivedBodies) => {
+        .then(() => {
           try {
             assert.strictEqual(
               reported,
@@ -106,6 +106,43 @@ describe('HttpStream', () => {
 │                                                                          │
 │ This report will self-destruct in 24h unless it is claimed or deleted.   │
 └──────────────────────────────────────────────────────────────────────────┘
+`
+            )
+            callback()
+          } catch (err) {
+            callback(err)
+          }
+        })
+        .catch(callback)
+    })
+
+    stream.write('hello')
+    stream.end()
+  })
+
+  it('outputs the body provided by the server even when an error is returned by the server', (callback: Callback) => {
+    let reported: string
+
+    const stream = new HttpStream(
+      `http://localhost:${port}/api/reports`,
+      'GET',
+      { Authorization: `Bearer an-invalid-token` },
+      (content) => {
+        reported = content
+      }
+    )
+
+    stream.on('error', callback)
+    stream.on('finish', () => {
+      reportServer
+        .stop()
+        .then(() => {
+          try {
+            assert.strictEqual(
+              reported,
+              `┌─────────────────────┐
+│ Error invalid token │
+└─────────────────────┘
 `
             )
             callback()

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -159,4 +159,32 @@ describe('HttpStream', () => {
     stream.write('hello')
     stream.end()
   })
+
+  for (let i = 0; i < 100; i++) {
+    it(`runs fuzz test ${i}`, (callback) => {
+      const stream = new HttpStream(
+        `http://localhost:${port}/api/reports`,
+        'GET',
+        {}
+      )
+
+      const readerStream = new Writable({
+        objectMode: true,
+        write: function (responseBody: string, encoding, writeCallback) {
+          writeCallback()
+        },
+      })
+
+      stream.pipe(readerStream)
+      readerStream.on('error', callback)
+      readerStream.on('finish', () => {
+        reportServer
+          .stop()
+          .then(() => callback())
+          .catch(callback)
+      })
+      stream.write('hello')
+      stream.end()
+    })
+  }
 })

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -87,7 +87,8 @@ describe('HttpStream', () => {
       `http://localhost:${port}/api/reports`,
       'GET',
       {},
-      (content) => {
+      (err, content) => {
+        if (err) return callback(err)
         reported = content
       }
     )
@@ -128,7 +129,7 @@ describe('HttpStream', () => {
       `http://localhost:${port}/api/reports`,
       'GET',
       { Authorization: `Bearer an-invalid-token` },
-      (content, err) => {
+      (err, content) => {
         reported = content
         errorThrown = err
       }

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -6,12 +6,12 @@ import { Writable } from 'stream'
 type Callback = (err?: Error | null) => void
 
 describe('HttpStream', () => {
-  const port = 8998
   let reportServer: FakeReportServer
+  let port: number
 
   beforeEach(async () => {
-    reportServer = new FakeReportServer(port)
-    await reportServer.start()
+    reportServer = new FakeReportServer(0)
+    port = await reportServer.start()
   })
 
   it(`sends a PUT request with written data when the stream is closed`, (callback: Callback) => {
@@ -162,6 +162,7 @@ describe('HttpStream', () => {
 
   for (let i = 0; i < 1000; i++) {
     it(`runs race condition test ${i}`, (callback) => {
+      console.log({ port })
       const stream = new HttpStream(
         `http://localhost:${port}/api/reports`,
         'GET',

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -176,19 +176,22 @@ describe('HttpStream', () => {
       })
 
       stream.pipe(readerStream)
-      readerStream.on('error', callback)
+      readerStream.on('error', (err) => sleepThenCallback(callback, err))
       readerStream.on('finish', () => {
         reportServer
           .stop()
-          .then(() => callback())
-          .catch(callback)
+          .then(() => sleepThenCallback(callback))
+          .catch((err) => sleepThenCallback(callback, err))
       })
       stream.write('hello')
       stream.end()
-      sleep(75)
     })
   }
 })
+
+function sleepThenCallback( callback: Callback, err?: Error) {
+  sleep(75).then(() => callback(err))
+}
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -42,10 +42,12 @@ describe('HttpStream', () => {
   })
 
   it(`follows location from GET response, and sends body and headers in a PUT request`, (callback: Callback) => {
+    const bearerToken = 'f318d9ec-5a3d-4727-adec-bd7b69e2edd3'
+
     const stream = new HttpStream(
       `http://localhost:${port}/api/reports`,
       'GET',
-      { Authorization: 'Bearer blablabla' },
+      { Authorization: `Bearer ${bearerToken}` },
       () => undefined
     )
 
@@ -63,7 +65,7 @@ describe('HttpStream', () => {
             )
             assert.strictEqual(
               reportServer.receivedHeaders.authorization,
-              'Bearer blablabla'
+              `Bearer ${bearerToken}`
             )
             callback()
           } catch (err) {

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -176,12 +176,19 @@ describe('HttpStream', () => {
       })
 
       stream.pipe(readerStream)
-      readerStream.on('error', (err) => sleepThenCallback(callback, err))
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      readerStream.on('error', async (err) => {
+        await sleepThenCallback(callback, err)
+      })
       readerStream.on('finish', () => {
         reportServer
           .stop()
-          .then(() => sleepThenCallback(callback))
-          .catch((err) => sleepThenCallback(callback, err))
+          .then(async () => {
+            await sleepThenCallback(callback)
+          })
+          .catch(async (err) => {
+            await sleepThenCallback(callback, err)
+          })
       })
       stream.write('hello')
       stream.end()
@@ -189,10 +196,13 @@ describe('HttpStream', () => {
   }
 })
 
-function sleepThenCallback( callback: Callback, err?: Error) {
-  sleep(75).then(() => callback(err))
-}
-
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+async function sleepThenCallback(
+  callback: Callback,
+  err?: Error
+): Promise<void> {
+  await new Promise(() =>
+    setTimeout(() => {
+      callback(err)
+    }, 75)
+  )
 }

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -148,7 +148,10 @@ describe('HttpStream', () => {
 └─────────────────────┘
 `
           )
-          assert(errorThrown, 'Stream has thrown an error event')
+          // There seems to be different handling of this depending on npm version, so let's
+          // use the CI to investigate that.
+          console.log({ errorThrown })
+          // assert(errorThrown, 'Stream has thrown an error event')
           callback()
         })
         .catch((err) => {

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -122,21 +122,19 @@ describe('HttpStream', () => {
 
   it('reports the body provided by the server even when an error is returned by the server and still fail', (callback: Callback) => {
     let reported: string
-    let errorThrown = false
+    let errorThrown: Error | undefined
 
     const stream = new HttpStream(
       `http://localhost:${port}/api/reports`,
       'GET',
       { Authorization: `Bearer an-invalid-token` },
-      (content) => {
+      (content, err) => {
         reported = content
+        errorThrown = err
       }
     )
 
-    stream.on('error', () => {
-      errorThrown = true
-    })
-
+    stream.on('error', callback)
     stream.on('finish', () => {
       reportServer
         .stop()
@@ -148,10 +146,7 @@ describe('HttpStream', () => {
 └─────────────────────┘
 `
           )
-          // There seems to be different handling of this depending on npm version, so let's
-          // use the CI to investigate that.
-          console.log({ errorThrown })
-          // assert(errorThrown, 'Stream has thrown an error event')
+          assert.notStrictEqual(errorThrown, undefined)
           callback()
         })
         .catch((err) => {

--- a/src/formatter/http_stream_spec.ts
+++ b/src/formatter/http_stream_spec.ts
@@ -159,32 +159,4 @@ describe('HttpStream', () => {
     stream.write('hello')
     stream.end()
   })
-
-  for (let i = 0; i < 1000; i++) {
-    it(`runs race condition test ${i}`, (callback) => {
-      const stream = new HttpStream(
-        `http://localhost:${port}/api/reports`,
-        'GET',
-        {}
-      )
-
-      const readerStream = new Writable({
-        objectMode: true,
-        write: function (responseBody: string, encoding, writeCallback) {
-          writeCallback()
-        },
-      })
-
-      stream.pipe(readerStream)
-      readerStream.on('error', callback)
-      readerStream.on('finish', () => {
-        reportServer
-          .stop()
-          .then(() => callback())
-          .catch(callback)
-      })
-      stream.write('hello')
-      stream.end()
-    })
-  }
 })

--- a/test/fake_report_server.ts
+++ b/test/fake_report_server.ts
@@ -32,7 +32,7 @@ export default class FakeReportServer {
 
       pipeline(req, captureBodyStream, (err) => {
         if (doesHaveValue(err)) return res.status(500).end(err.stack)
-        res.end()
+        res.end('Do not display this response')
       })
     })
 

--- a/test/fake_report_server.ts
+++ b/test/fake_report_server.ts
@@ -91,7 +91,7 @@ export default class FakeReportServer {
           new Promise<void>((resolve, reject) => {
             // TODO: remove temporary debug
             console.error('socket destroyed?', socket.destroyed)
-            if (socket.destroyed) return resolve()
+            // if (socket.destroyed) return resolve()
             socket.on('close', resolve)
             socket.on('error', reject)
           })

--- a/test/fake_report_server.ts
+++ b/test/fake_report_server.ts
@@ -97,7 +97,7 @@ export default class FakeReportServer {
           })
       )
     )
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       this.server.close((err) => {
         if (doesHaveValue(err)) return reject(err)
         resolve(this.receivedBodies)

--- a/test/fake_report_server.ts
+++ b/test/fake_report_server.ts
@@ -97,7 +97,7 @@ export default class FakeReportServer {
           })
       )
     )
-    return await new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       this.server.close((err) => {
         if (doesHaveValue(err)) return reject(err)
         resolve(this.receivedBodies)

--- a/test/fake_report_server.ts
+++ b/test/fake_report_server.ts
@@ -1,4 +1,4 @@
-import { Server, Socket } from 'net'
+import { AddressInfo, Server, Socket } from 'net'
 import express from 'express'
 import { pipeline, Writable } from 'stream'
 import http from 'http'
@@ -17,7 +17,7 @@ export default class FakeReportServer {
   private receivedBodies = Buffer.alloc(0)
   public receivedHeaders: http.IncomingHttpHeaders = {}
 
-  constructor(private readonly port: number) {
+  constructor(private port: number) {
     const app = express()
 
     app.put('/s3', (req, res) => {
@@ -51,7 +51,7 @@ export default class FakeReportServer {
         return
       }
 
-      res.setHeader('Location', `http://localhost:${port}/s3`)
+      res.setHeader('Location', `http://localhost:${this.port}/s3`)
       res.status(202)
 
       setTimeout(() => {
@@ -73,9 +73,11 @@ export default class FakeReportServer {
     })
   }
 
-  async start(): Promise<void> {
+  async start(): Promise<number> {
     const listen = promisify(this.server.listen.bind(this.server))
     await listen(this.port)
+    this.port = (this.server.address() as AddressInfo).port
+    return this.port
   }
 
   /**

--- a/test/fake_report_server.ts
+++ b/test/fake_report_server.ts
@@ -31,6 +31,8 @@ export default class FakeReportServer {
       })
 
       pipeline(req, captureBodyStream, (err) => {
+        // TODO: remove temporary debug
+        console.error('FakeServer::Res.end. Error?: ', err)
         if (doesHaveValue(err)) return res.status(500).end(err.stack)
         res.end('Do not display this response')
       })
@@ -63,6 +65,8 @@ export default class FakeReportServer {
     this.server.on('connection', (socket) => {
       this.sockets.add(socket)
       socket.on('close', () => {
+        // TODO: remove temporary debug
+        console.error('FakeServer on close deleting sockets')
         this.sockets.delete(socket)
       })
     })
@@ -77,12 +81,16 @@ export default class FakeReportServer {
    * @return all the received request bodies
    */
   async stop(): Promise<Buffer> {
+    // TODO: remove temporary debug
+    console.error('FakeServer: stop()')
     // Wait for all sockets to be closed
     await Promise.all(
       Array.from(this.sockets).map(
         // eslint-disable-next-line @typescript-eslint/promise-function-async
         (socket) =>
           new Promise<void>((resolve, reject) => {
+            // TODO: remove temporary debug
+            console.error('socket destroyed?', socket.destroyed)
             if (socket.destroyed) return resolve()
             socket.on('close', resolve)
             socket.on('error', reject)

--- a/test/fake_report_server.ts
+++ b/test/fake_report_server.ts
@@ -31,12 +31,8 @@ export default class FakeReportServer {
       })
 
       pipeline(req, captureBodyStream, (err) => {
-        // TODO: remove temporary debug
-        console.error('FakeServer::Res.end. Error?: ', err)
         if (doesHaveValue(err)) return res.status(500).end(err.stack)
-        setTimeout(() => {
-          res.end('Do not display this response')
-        }, Math.random() * 10)
+        res.end('Do not display this response')
       })
     })
 
@@ -54,15 +50,13 @@ export default class FakeReportServer {
       res.setHeader('Location', `http://localhost:${this.port}/s3`)
       res.status(202)
 
-      setTimeout(() => {
-        res.end(`┌──────────────────────────────────────────────────────────────────────────┐
+      res.end(`┌──────────────────────────────────────────────────────────────────────────┐
 │ View your Cucumber Report at:                                            │
 │ https://reports.cucumber.io/reports/f318d9ec-5a3d-4727-adec-bd7b69e2edd3 │
 │                                                                          │
 │ This report will self-destruct in 24h unless it is claimed or deleted.   │
 └──────────────────────────────────────────────────────────────────────────┘
 `)
-      }, Math.random() * 10)
     })
 
     this.server = http.createServer(app)
@@ -84,17 +78,13 @@ export default class FakeReportServer {
    * @return all the received request bodies
    */
   async stop(): Promise<Buffer> {
-    // TODO: remove temporary debug
-    console.error('FakeServer: stop()')
     // Wait for all sockets to be closed
     await Promise.all(
       Array.from(this.sockets).map(
         // eslint-disable-next-line @typescript-eslint/promise-function-async
         (socket) =>
           new Promise<void>((resolve, reject) => {
-            // TODO: remove temporary debug
-            console.error('socket destroyed?', socket.destroyed)
-            // if (socket.destroyed) return resolve()
+            if (socket.destroyed) return resolve()
             socket.on('close', resolve)
             socket.on('error', reject)
           })

--- a/test/fake_report_server.ts
+++ b/test/fake_report_server.ts
@@ -34,7 +34,9 @@ export default class FakeReportServer {
         // TODO: remove temporary debug
         console.error('FakeServer::Res.end. Error?: ', err)
         if (doesHaveValue(err)) return res.status(500).end(err.stack)
-        res.end('Do not display this response')
+        setTimeout(() => {
+          res.end('Do not display this response')
+        }, Math.random() * 10)
       })
     })
 
@@ -51,24 +53,23 @@ export default class FakeReportServer {
 
       res.setHeader('Location', `http://localhost:${port}/s3`)
       res.status(202)
-        .end(`┌──────────────────────────────────────────────────────────────────────────┐
+
+      setTimeout(() => {
+        res.end(`┌──────────────────────────────────────────────────────────────────────────┐
 │ View your Cucumber Report at:                                            │
 │ https://reports.cucumber.io/reports/f318d9ec-5a3d-4727-adec-bd7b69e2edd3 │
 │                                                                          │
 │ This report will self-destruct in 24h unless it is claimed or deleted.   │
 └──────────────────────────────────────────────────────────────────────────┘
 `)
+      }, Math.random() * 10)
     })
 
     this.server = http.createServer(app)
 
     this.server.on('connection', (socket) => {
       this.sockets.add(socket)
-      socket.on('close', () => {
-        // TODO: remove temporary debug
-        console.error('FakeServer on close deleting sockets')
-        this.sockets.delete(socket)
-      })
+      socket.on('close', () => this.sockets.delete(socket))
     })
   }
 

--- a/test/fake_report_server.ts
+++ b/test/fake_report_server.ts
@@ -38,6 +38,14 @@ export default class FakeReportServer {
 
     app.get('/api/reports', (req, res) => {
       this.receivedHeaders = { ...this.receivedHeaders, ...req.headers }
+      const token = extractAuthorizationToken(req.headers.authorization)
+      if (token && !isValidUUID(token)) {
+        res.status(401).end(`┌─────────────────────┐
+│ Error invalid token │
+└─────────────────────┘
+`)
+        return
+      }
 
       res.setHeader('Location', `http://localhost:${port}/s3`)
       res.status(202)
@@ -92,4 +100,18 @@ export default class FakeReportServer {
   get started(): boolean {
     return this.server.listening
   }
+}
+
+function extractAuthorizationToken(
+  authorizationHeader: string | undefined
+): string | null {
+  if (!authorizationHeader) return null
+
+  const tokenMatch = authorizationHeader.match(/Bearer (.*)/)
+  return tokenMatch ? tokenMatch[1] : null
+}
+
+function isValidUUID(token: string): boolean {
+  const v4 = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
+  return v4.test(token)
 }


### PR DESCRIPTION
Other Cucumber implementations display the content send by the server upon failure. For example, with Cucumber ruby:

```
$ CUCUMBER_PUBLISH_TOKEN=plop bundle exec cucumber features/docs/getting_started.feature
WARNING: Nokogiri was built against LibXML version 2.9.10, but has dynamically loaded 2.9.4
Using the default profile...
........

2 scenarios (2 passed)
8 steps (8 passed)
0m0.023s
┌──────────────────────────────────────────────────────────────┐
│ Invalid CUCUMBER_PUBLISH_TOKEN: plop                         │
│ Go to https://reports.cucumber.io/profile to get your token. │
└──────────────────────────────────────────────────────────────┘
Traceback (most recent call last):
	1: from /Users/vincent.pretre/dev/open-source/cucumber-ruby-meta/cucumber-ruby/lib/cucumber/formatter/io.rb:40:in `block (3 levels) in new'
/Users/vincent.pretre/dev/open-source/cucumber-ruby-meta/cucumber-ruby/lib/cucumber/formatter/http_io.rb:79:in `close': request to https://messages.cucumber.io/api/reports failed with status 401 (StandardError)
```

This is an attempt to get the same behavior in `cucumber-js`

TODO:
 - [x] Add a example of what's excepted
 - [x] Display the server response
 - [x] Fail when the server does not return 2xx
 - [ ] Solve the `null` line displayed above the banner