### PR TITLE
cli: undeprecate json formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Changed
 
+* Clarify that the JSON formatter will not be removed any time soon
+
 ### Deprecated
 
 ### Removed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,7 +59,7 @@ If multiple formats are specified with the same output, only the last is used.
 
 * **message** - prints each [message](https://github.com/cucumber/cucumber/tree/master/cucumber-messages) in NDJSON form, which can then be consumed by other tools.
 * **html** - prints a rich HTML report to a standalone page
-* **json** - prints the feature as JSON. *Note: this formatter is deprecated and will be removed in the next major release. Where you need a structured data representation of your test run, it's best to use the `message` formatter. For legacy tools that depend on the deprecated JSON format, a standalone formatter is available (see https://github.com/cucumber/cucumber/tree/master/json-formatter).
+* **json** - prints the feature as JSON. *Note: this formatter is in maintenance mode and won't have new features added to it. Where you need a structured data representation of your test run, it's best to use the `message` formatter. Tools that rely on this formatter will continue to work, but are encouraged to migrate to consume the `message` output instead.*
 * **progress** - prints one character per scenario (default).
 * **progress-bar** - prints a progress bar and outputs errors/warnings along the way.
 * **rerun** - prints the paths of any non-passing scenarios ([example](/features/rerun_formatter.feature))

--- a/src/formatter/json_formatter.ts
+++ b/src/formatter/json_formatter.ts
@@ -96,9 +96,6 @@ interface UriToTestCaseAttemptsMap {
 export default class JsonFormatter extends Formatter {
   constructor(options: IFormatterOptions) {
     super(options)
-    console.warn(
-      "The built-in JSON formatter is deprecated and will be removed in the next major release. Where you need a structured data representation of your test run, it's best to use the `message` formatter. For legacy tools that depend on the deprecated JSON format, a standalone formatter is available (see https://github.com/cucumber/cucumber/tree/master/json-formatter)."
-    )
     options.eventBroadcaster.on('envelope', (envelope: IEnvelope) => {
       if (doesHaveValue(envelope.testRunFinished)) {
         this.onTestRunFinished()


### PR DESCRIPTION
Closes #1250 as agreed in today's community call for all implementations.

The previous deprecation has resulted in some hesitation to upgrade from users who use tools that rely on the JSON formatter output.

The tone now is about "maintenance mode" - it'll stay functional, but won't benefit from any new features. As the documentation and tooling around messages improves, we'll gradually encourage authors of maintained tools to switch over to that. Feedback welcome on the exact wording. Also, the noisy console warning is gone.