### PR TITLE
replace use of Dictionary with Record

### DIFF
--- a/src/cli/profile_loader.ts
+++ b/src/cli/profile_loader.ts
@@ -1,4 +1,4 @@
-import _, { Dictionary } from 'lodash'
+import _ from 'lodash'
 import fs from 'mz/fs'
 import path from 'path'
 import stringArgv from 'string-argv'
@@ -11,7 +11,7 @@ export default class ProfileLoader {
     this.directory = directory
   }
 
-  async getDefinitions(): Promise<Dictionary<string>> {
+  async getDefinitions(): Promise<Record<string, string>> {
     const definitionsFilePath = path.join(this.directory, 'cucumber.js')
     const exists = await fs.exists(definitionsFilePath)
     if (!exists) {

--- a/src/formatter/helpers/event_data_collector.ts
+++ b/src/formatter/helpers/event_data_collector.ts
@@ -1,4 +1,4 @@
-import _, { Dictionary, values } from 'lodash'
+import _, { values } from 'lodash'
 import { messages } from '@cucumber/messages'
 import { doesHaveValue, doesNotHaveValue } from '../../value_checker'
 import { EventEmitter } from 'events'
@@ -7,8 +7,8 @@ import { Query } from '@cucumber/query'
 interface ITestCaseAttemptData {
   attempt: number
   testCaseId: string
-  stepAttachments: Dictionary<messages.IAttachment[]>
-  stepResults: Dictionary<messages.TestStepFinished.ITestStepResult>
+  stepAttachments: Record<string, messages.IAttachment[]>
+  stepResults: Record<string, messages.TestStepFinished.ITestStepResult>
   worstTestStepResult: messages.TestStepFinished.ITestStepResult
 }
 
@@ -16,17 +16,17 @@ export interface ITestCaseAttempt {
   attempt: number
   gherkinDocument: messages.IGherkinDocument
   pickle: messages.IPickle
-  stepAttachments: Dictionary<messages.IAttachment[]>
-  stepResults: Dictionary<messages.TestStepFinished.ITestStepResult>
+  stepAttachments: Record<string, messages.IAttachment[]>
+  stepResults: Record<string, messages.TestStepFinished.ITestStepResult>
   testCase: messages.ITestCase
   worstTestStepResult: messages.TestStepFinished.ITestStepResult
 }
 
 export default class EventDataCollector {
-  private gherkinDocumentMap: Dictionary<messages.IGherkinDocument> = {}
-  private pickleMap: Dictionary<messages.IPickle> = {}
-  private testCaseMap: Dictionary<messages.ITestCase> = {}
-  private testCaseAttemptDataMap: Dictionary<ITestCaseAttemptData> = {}
+  private gherkinDocumentMap: Record<string, messages.IGherkinDocument> = {}
+  private pickleMap: Record<string, messages.IPickle> = {}
+  private testCaseMap: Record<string, messages.ITestCase> = {}
+  private testCaseAttemptDataMap: Record<string, ITestCaseAttemptData> = {}
   readonly undefinedParameterTypes: messages.IUndefinedParameterType[] = []
   readonly query = new Query()
 

--- a/src/formatter/helpers/gherkin_document_parser.ts
+++ b/src/formatter/helpers/gherkin_document_parser.ts
@@ -1,10 +1,10 @@
-import _, { Dictionary } from 'lodash'
+import _ from 'lodash'
 import { messages } from '@cucumber/messages'
 import { doesHaveValue } from '../../value_checker'
 
 export function getGherkinStepMap(
   gherkinDocument: messages.IGherkinDocument
-): Dictionary<messages.GherkinDocument.Feature.IStep> {
+): Record<string, messages.GherkinDocument.Feature.IStep> {
   return _.chain(gherkinDocument.feature.children)
     .map(extractStepContainers)
     .flatten()
@@ -35,7 +35,7 @@ function extractStepContainers(
 
 export function getGherkinScenarioMap(
   gherkinDocument: messages.IGherkinDocument
-): Dictionary<messages.GherkinDocument.Feature.IScenario> {
+): Record<string, messages.GherkinDocument.Feature.IScenario> {
   return _.chain(gherkinDocument.feature.children)
     .map((child: messages.GherkinDocument.Feature.IFeatureChild) => {
       if (doesHaveValue(child.rule)) {
@@ -56,7 +56,7 @@ export function getGherkinScenarioMap(
 
 export function getGherkinExampleRuleMap(
   gherkinDocument: messages.IGherkinDocument
-): Dictionary<messages.GherkinDocument.Feature.FeatureChild.IRule> {
+): Record<string, messages.GherkinDocument.Feature.FeatureChild.IRule> {
   return _.chain(gherkinDocument.feature.children)
     .filter('rule')
     .map('rule')
@@ -72,11 +72,12 @@ export function getGherkinExampleRuleMap(
 
 export function getGherkinScenarioLocationMap(
   gherkinDocument: messages.IGherkinDocument
-): Dictionary<messages.ILocation> {
-  const locationMap: Dictionary<messages.ILocation> = {}
-  const scenarioMap: Dictionary<messages.GherkinDocument.Feature.IScenario> = getGherkinScenarioMap(
-    gherkinDocument
-  )
+): Record<string, messages.ILocation> {
+  const locationMap: Record<string, messages.ILocation> = {}
+  const scenarioMap: Record<
+    string,
+    messages.GherkinDocument.Feature.IScenario
+  > = getGherkinScenarioMap(gherkinDocument)
   _.entries<messages.GherkinDocument.Feature.IScenario>(scenarioMap).forEach(
     ([id, scenario]) => {
       locationMap[id] = scenario.location

--- a/src/formatter/helpers/issue_helpers.ts
+++ b/src/formatter/helpers/issue_helpers.ts
@@ -6,7 +6,6 @@ import { IColorFns } from '../get_color_fns'
 import StepDefinitionSnippetBuilder from '../step_definition_snippet_builder'
 import { ISupportCodeLibrary } from '../../support_code_library_builder/types'
 import { ITestCaseAttempt } from './event_data_collector'
-import { Dictionary } from 'lodash'
 
 export function isFailure(
   result: messages.TestStepFinished.ITestStepResult
@@ -72,7 +71,7 @@ export function formatUndefinedParameterTypes(
   undefinedParameterTypes: messages.IUndefinedParameterType[]
 ): string {
   const output = [`Undefined parameter types:\n\n`]
-  const withLatest: Dictionary<messages.IUndefinedParameterType> = {}
+  const withLatest: Record<string, messages.IUndefinedParameterType> = {}
   undefinedParameterTypes.forEach((parameterType) => {
     withLatest[parameterType.name] = parameterType
   })

--- a/src/formatter/helpers/pickle_parser.ts
+++ b/src/formatter/helpers/pickle_parser.ts
@@ -1,4 +1,4 @@
-import _, { Dictionary } from 'lodash'
+import _ from 'lodash'
 import { getGherkinScenarioLocationMap } from './gherkin_document_parser'
 import { messages } from '@cucumber/messages'
 
@@ -9,12 +9,12 @@ export interface IGetPickleLocationRequest {
 
 export interface IGetStepKeywordRequest {
   pickleStep: messages.Pickle.IPickleStep
-  gherkinStepMap: Dictionary<messages.GherkinDocument.Feature.IStep>
+  gherkinStepMap: Record<string, messages.GherkinDocument.Feature.IStep>
 }
 
 export interface IGetScenarioDescriptionRequest {
   pickle: messages.IPickle
-  gherkinScenarioMap: Dictionary<messages.GherkinDocument.Feature.IScenario>
+  gherkinScenarioMap: Record<string, messages.GherkinDocument.Feature.IScenario>
 }
 
 export function getScenarioDescription({
@@ -41,7 +41,7 @@ export function getStepKeyword({
 
 export function getPickleStepMap(
   pickle: messages.IPickle
-): Dictionary<messages.Pickle.IPickleStep> {
+): Record<string, messages.Pickle.IPickleStep> {
   return _.chain(pickle.steps)
     .map((pickleStep) => [pickleStep.id, pickleStep])
     .fromPairs()

--- a/src/formatter/helpers/test_case_attempt_parser.ts
+++ b/src/formatter/helpers/test_case_attempt_parser.ts
@@ -1,4 +1,4 @@
-import _, { Dictionary } from 'lodash'
+import _ from 'lodash'
 import Status from '../../status'
 import { getStepKeywordType, KeywordType } from './keyword_type'
 import {
@@ -40,7 +40,7 @@ export interface IParsedTestCaseAttempt {
 
 interface IParseStepRequest {
   isBeforeHook: boolean
-  gherkinStepMap: Dictionary<messages.GherkinDocument.Feature.IStep>
+  gherkinStepMap: Record<string, messages.GherkinDocument.Feature.IStep>
   keyword: string
   keywordType: KeywordType
   pickleStep: messages.Pickle.IPickleStep

--- a/src/formatter/helpers/usage_helpers/index.ts
+++ b/src/formatter/helpers/usage_helpers/index.ts
@@ -1,4 +1,4 @@
-import _, { Dictionary } from 'lodash'
+import _ from 'lodash'
 import { getPickleStepMap } from '../pickle_parser'
 import path from 'path'
 import { getGherkinStepMap } from '../gherkin_document_parser'
@@ -33,8 +33,8 @@ export interface IGetUsageRequest {
 
 function buildEmptyMapping(
   stepDefinitions: StepDefinition[]
-): Dictionary<IUsage> {
-  const mapping: Dictionary<IUsage> = {}
+): Record<string, IUsage> {
+  const mapping: Record<string, IUsage> = {}
   stepDefinitions.forEach((stepDefinition) => {
     mapping[stepDefinition.id] = {
       code: stepDefinition.unwrappedCode.toString(),
@@ -52,7 +52,7 @@ function buildMapping({
   cwd,
   stepDefinitions,
   eventDataCollector,
-}: IGetUsageRequest): Dictionary<IUsage> {
+}: IGetUsageRequest): Record<string, IUsage> {
   const mapping = buildEmptyMapping(stepDefinitions)
   _.each(eventDataCollector.getTestCaseAttempts(), (testCaseAttempt) => {
     const pickleStepMap = getPickleStepMap(testCaseAttempt.pickle)
@@ -97,7 +97,7 @@ function invertDuration(duration: messages.IDuration): number {
   return 1
 }
 
-function buildResult(mapping: Dictionary<IUsage>): IUsage[] {
+function buildResult(mapping: Record<string, IUsage>): IUsage[] {
   return _.chain(mapping)
     .map(({ matches, ...rest }: IUsage) => {
       const sortedMatches = _.sortBy(matches, [

--- a/src/formatter/json_formatter.ts
+++ b/src/formatter/json_formatter.ts
@@ -313,7 +313,7 @@ export default class JsonFormatter extends Formatter {
   }: {
     feature: IFeature
     pickle: IPickle
-    gherkinScenarioMap: { [id: string]: IScenario }
+    gherkinScenarioMap: Record<string, IScenario>
   }): IJsonTag[] {
     const scenario = gherkinScenarioMap[pickle.astNodeIds[0]]
 

--- a/src/formatter/json_formatter.ts
+++ b/src/formatter/json_formatter.ts
@@ -1,4 +1,4 @@
-import _, { Dictionary } from 'lodash'
+import _ from 'lodash'
 import Formatter, { IFormatterOptions } from './'
 import Status from '../status'
 import { formatLocation, GherkinDocumentParser, PickleParser } from './helpers'
@@ -74,17 +74,17 @@ interface IBuildJsonFeatureOptions {
 
 interface IBuildJsonScenarioOptions {
   feature: messages.GherkinDocument.IFeature
-  gherkinScenarioMap: Dictionary<IScenario>
-  gherkinExampleRuleMap: Dictionary<IRule>
-  gherkinScenarioLocationMap: Dictionary<messages.ILocation>
+  gherkinScenarioMap: Record<string, IScenario>
+  gherkinExampleRuleMap: Record<string, IRule>
+  gherkinScenarioLocationMap: Record<string, messages.ILocation>
   pickle: messages.IPickle
   steps: IJsonStep[]
 }
 
 interface IBuildJsonStepOptions {
   isBeforeHook: boolean
-  gherkinStepMap: Dictionary<messages.GherkinDocument.Feature.IStep>
-  pickleStepMap: Dictionary<messages.Pickle.IPickleStep>
+  gherkinStepMap: Record<string, messages.GherkinDocument.Feature.IStep>
+  pickleStepMap: Record<string, messages.Pickle.IPickleStep>
   testStep: messages.TestCase.ITestStep
   testStepAttachments: messages.IAttachment[]
   testStepResult: messages.TestStepFinished.ITestStepResult
@@ -242,7 +242,7 @@ export default class JsonFormatter extends Formatter {
   }: {
     feature: IFeature
     pickle: IPickle
-    gherkinExampleRuleMap: Dictionary<IRule>
+    gherkinExampleRuleMap: Record<string, IRule>
   }): string {
     let parts: any[]
     const rule = gherkinExampleRuleMap[pickle.astNodeIds[0]]

--- a/src/models/data_table.ts
+++ b/src/models/data_table.ts
@@ -33,7 +33,7 @@ export default class DataTable {
     return copy
   }
 
-  rowsHash(): Record<string, any> {
+  rowsHash(): Record<string, string> {
     const rows = this.raw()
     const everyRowHasTwoColumns = _.every(rows, (row) => row.length === 2)
     if (!everyRowHasTwoColumns) {

--- a/src/models/data_table.ts
+++ b/src/models/data_table.ts
@@ -1,4 +1,4 @@
-import _, { Dictionary } from 'lodash'
+import _ from 'lodash'
 import { messages } from '@cucumber/messages'
 
 export default class DataTable {
@@ -33,7 +33,7 @@ export default class DataTable {
     return copy
   }
 
-  rowsHash(): Dictionary<any> {
+  rowsHash(): Record<string, any> {
     const rows = this.raw()
     const everyRowHasTwoColumns = _.every(rows, (row) => row.length === 2)
     if (!everyRowHasTwoColumns) {

--- a/src/pickle_filter.ts
+++ b/src/pickle_filter.ts
@@ -1,4 +1,4 @@
-import _, { Dictionary } from 'lodash'
+import _ from 'lodash'
 import path from 'path'
 import parse from '@cucumber/tag-expressions'
 import { getGherkinScenarioLocationMap } from './formatter/helpers/gherkin_document_parser'
@@ -53,7 +53,7 @@ export default class PickleFilter {
 }
 
 export class PickleLineFilter {
-  private readonly featureUriToLinesMapping: Dictionary<number[]>
+  private readonly featureUriToLinesMapping: Record<string, number[]>
 
   constructor(cwd: string, featurePaths: string[] = []) {
     this.featureUriToLinesMapping = this.getFeatureUriToLinesMapping({
@@ -68,8 +68,8 @@ export class PickleLineFilter {
   }: {
     cwd: string
     featurePaths: string[]
-  }): Dictionary<number[]> {
-    const mapping: Dictionary<number[]> = {}
+  }): Record<string, number[]> {
+    const mapping: Record<string, number[]> = {}
     featurePaths.forEach((featurePath) => {
       const match = FEATURE_LINENUM_REGEXP.exec(featurePath)
       if (doesHaveValue(match)) {

--- a/src/runtime/parallel/coordinator.ts
+++ b/src/runtime/parallel/coordinator.ts
@@ -1,4 +1,4 @@
-import _, { Dictionary } from 'lodash'
+import _ from 'lodash'
 import { ChildProcess, fork } from 'child_process'
 import path from 'path'
 import Status from '../../status'
@@ -47,8 +47,8 @@ export default class Coordinator {
   private nextPickleIdIndex: number
   private readonly options: IRuntimeOptions
   private readonly pickleIds: string[]
-  private workers: Dictionary<IWorker>
-  private supportCodeIdMap: Dictionary<string>
+  private workers: Record<string, IWorker>
+  private supportCodeIdMap: Record<string, string>
   private readonly supportCodeLibrary: ISupportCodeLibrary
   private readonly supportCodePaths: string[]
   private readonly supportCodeRequiredModules: string[]

--- a/src/support_code_library_builder/validate_arguments.ts
+++ b/src/support_code_library_builder/validate_arguments.ts
@@ -1,4 +1,4 @@
-import _, { Dictionary } from 'lodash'
+import _ from 'lodash'
 import { doesNotHaveValue } from '../value_checker'
 import { DefineStepPattern, IDefineStepOptions } from './types'
 
@@ -36,7 +36,7 @@ const fnValidation = {
   },
 }
 
-const validations: Dictionary<IValidation[]> = {
+const validations: Record<string, IValidation[]> = {
   defineTestRunHook: [
     { identifier: 'first argument', ...optionsValidation },
     optionsTimeoutValidation,


### PR DESCRIPTION
Helps with #1532 - avoids an implicit dependency on `@types/lodash` where TypeScript users reference some of our models and functions.