### PR TITLE
docs: add note about resolveJsonModule for TS

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -180,7 +180,9 @@ If your files end with an extension other than `js`, make sure to also include t
 --require-module coffeescript/register --require 'features/**/*.coffee'
 ```
 
-### Typescript
+### TypeScript
+
+Your `tsconfig.json` should have the `resolveJsonModule` compiler option switched on. Other than that, a pretty standard TypeScript setup should work as expected.
 
 #### With ts-node
 
@@ -211,6 +213,7 @@ require('ts-node').register({
   transpileOnly: true,
   compilerOptions: {
     "module": "commonjs",
+    "resolveJsonModule": true,
   },
 });
 ```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -48,3 +48,5 @@ There are a few minor differences to be aware of:
 
 - The type for data tables was named `TableDefinition` - it's now named `DataTable`
 - `World` was typed as an interface, but it's actually a class - you should `extend` it when [building a custom formatter](./custom_formatters.md)
+
+Also, your `tsconfig.json` should have the `resolveJsonModule` compiler option switched on. Other than that, a pretty standard TypeScript setup should work as expected.


### PR DESCRIPTION
Last piece of #1532.

We need TypeScript users to have this on due to an upstream library that exports typings doing an `import` of a JSON file. I think this is very common and it seems more sensible to advise users to switch the compiler option on than try to control what goes on in libraries.