### PR TITLE
Decouple process.env

### DIFF
--- a/compatibility/cck_spec.ts
+++ b/compatibility/cck_spec.ts
@@ -41,6 +41,7 @@ describe('Cucumber Compatibility Kit', () => {
         await new Cli({
           argv: args,
           cwd: PROJECT_PATH,
+          env: {},
           stdout,
         }).run()
       } catch (ignored) {

--- a/src/cli/configuration_builder.ts
+++ b/src/cli/configuration_builder.ts
@@ -41,6 +41,7 @@ export interface IConfiguration {
 export interface INewConfigurationBuilderOptions {
   argv: string[]
   cwd: string
+  env: Record<string, string | undefined>
 }
 
 const DEFAULT_CUCUMBER_PUBLISH_URL = 'https://messages.cucumber.io/api/reports'
@@ -54,11 +55,13 @@ export default class ConfigurationBuilder {
   }
 
   private readonly cwd: string
+  private readonly env: Record<string, string | undefined>
   private readonly args: string[]
   private readonly options: IParsedArgvOptions
 
-  constructor({ argv, cwd }: INewConfigurationBuilderOptions) {
+  constructor({ argv, cwd, env }: INewConfigurationBuilderOptions) {
     this.cwd = cwd
+    this.env = env
 
     ArgvParser.lint(argv)
     const parsedArgv = ArgvParser.parse(argv)
@@ -167,15 +170,15 @@ export default class ConfigurationBuilder {
   isPublishing(): boolean {
     return (
       this.options.publish ||
-      this.isTruthyString(process.env.CUCUMBER_PUBLISH_ENABLED) ||
-      process.env.CUCUMBER_PUBLISH_TOKEN !== undefined
+      this.isTruthyString(this.env.CUCUMBER_PUBLISH_ENABLED) ||
+      this.env.CUCUMBER_PUBLISH_TOKEN !== undefined
     )
   }
 
   isPublishAdvertisementSuppressed(): boolean {
     return (
       this.options.publishQuiet ||
-      this.isTruthyString(process.env.CUCUMBER_PUBLISH_QUIET)
+      this.isTruthyString(this.env.CUCUMBER_PUBLISH_QUIET)
     )
   }
 
@@ -187,7 +190,7 @@ export default class ConfigurationBuilder {
     })
     if (this.isPublishing()) {
       const publishUrl = valueOrDefault(
-        process.env.CUCUMBER_PUBLISH_URL,
+        this.env.CUCUMBER_PUBLISH_URL,
         DEFAULT_CUCUMBER_PUBLISH_URL
       )
 

--- a/src/cli/configuration_builder_spec.ts
+++ b/src/cli/configuration_builder_spec.ts
@@ -16,6 +16,7 @@ async function buildTestWorkingDirectory(): Promise<string> {
 }
 
 const baseArgv = ['/path/to/node', '/path/to/cucumber-js']
+const env: Record<string, string | undefined> = {}
 
 describe('Configuration', () => {
   describe('no argv', () => {
@@ -25,7 +26,7 @@ describe('Configuration', () => {
       const argv = baseArgv
 
       // Act
-      const result = await ConfigurationBuilder.build({ argv, cwd })
+      const result = await ConfigurationBuilder.build({ argv, cwd, env })
 
       // Assert
       expect(result).to.eql({
@@ -80,7 +81,7 @@ describe('Configuration', () => {
         featurePaths,
         pickleFilterOptions,
         supportCodePaths,
-      } = await ConfigurationBuilder.build({ argv, cwd })
+      } = await ConfigurationBuilder.build({ argv, cwd, env })
 
       // Assert
       expect(featurePaths).to.eql([featurePath])
@@ -103,7 +104,7 @@ describe('Configuration', () => {
         featurePaths,
         pickleFilterOptions,
         supportCodePaths,
-      } = await ConfigurationBuilder.build({ argv, cwd })
+      } = await ConfigurationBuilder.build({ argv, cwd, env })
 
       // Assert
       expect(featurePaths).to.eql([featurePath])
@@ -128,7 +129,7 @@ describe('Configuration', () => {
         featurePaths,
         pickleFilterOptions,
         supportCodePaths,
-      } = await ConfigurationBuilder.build({ argv, cwd })
+      } = await ConfigurationBuilder.build({ argv, cwd, env })
 
       // Assert
       expect(featurePaths).to.eql([featurePath])
@@ -155,7 +156,7 @@ describe('Configuration', () => {
         featurePaths,
         pickleFilterOptions,
         supportCodePaths,
-      } = await ConfigurationBuilder.build({ argv, cwd })
+      } = await ConfigurationBuilder.build({ argv, cwd, env })
 
       // Assert
       expect(featurePaths).to.eql([featurePath])
@@ -171,7 +172,7 @@ describe('Configuration', () => {
       const argv = baseArgv
 
       // Act
-      const { formats } = await ConfigurationBuilder.build({ argv, cwd })
+      const { formats } = await ConfigurationBuilder.build({ argv, cwd, env })
 
       // Assert
       expect(formats).to.eql([{ outputTo: '', type: 'progress' }])
@@ -183,7 +184,7 @@ describe('Configuration', () => {
       const argv = baseArgv.concat(['--publish'])
 
       // Act
-      const { formats } = await ConfigurationBuilder.build({ argv, cwd })
+      const { formats } = await ConfigurationBuilder.build({ argv, cwd, env })
 
       // Assert
       expect(formats).to.eql([
@@ -198,7 +199,7 @@ describe('Configuration', () => {
     it('sets publishing to true when --publish is specified', async function () {
       const cwd = await buildTestWorkingDirectory()
       const argv = baseArgv.concat(['--publish'])
-      const configuration = await ConfigurationBuilder.build({ argv, cwd })
+      const configuration = await ConfigurationBuilder.build({ argv, cwd, env })
 
       expect(configuration.publishing).to.eq(true)
     })
@@ -206,7 +207,7 @@ describe('Configuration', () => {
     it('sets suppressPublishAdvertisement to true when --publish-quiet is specified', async function () {
       const cwd = await buildTestWorkingDirectory()
       const argv = baseArgv.concat(['--publish-quiet'])
-      const configuration = await ConfigurationBuilder.build({ argv, cwd })
+      const configuration = await ConfigurationBuilder.build({ argv, cwd, env })
 
       expect(configuration.suppressPublishAdvertisement).to.eq(true)
     })
@@ -220,7 +221,7 @@ describe('Configuration', () => {
       ])
 
       // Act
-      const { formats } = await ConfigurationBuilder.build({ argv, cwd })
+      const { formats } = await ConfigurationBuilder.build({ argv, cwd, env })
 
       // Assert
       expect(formats).to.eql([
@@ -238,7 +239,7 @@ describe('Configuration', () => {
       ])
 
       // Act
-      const { formats } = await ConfigurationBuilder.build({ argv, cwd })
+      const { formats } = await ConfigurationBuilder.build({ argv, cwd, env })
 
       // Assert
       expect(formats).to.eql([
@@ -256,7 +257,7 @@ describe('Configuration', () => {
       ])
 
       // Act
-      const { formats } = await ConfigurationBuilder.build({ argv, cwd })
+      const { formats } = await ConfigurationBuilder.build({ argv, cwd, env })
 
       // Assert
       expect(formats).to.eql([
@@ -274,7 +275,7 @@ describe('Configuration', () => {
       const argv = baseArgv.concat(['-f', 'C:\\custom\\formatter'])
 
       // Act
-      const { formats } = await ConfigurationBuilder.build({ argv, cwd })
+      const { formats } = await ConfigurationBuilder.build({ argv, cwd, env })
 
       // Assert
       expect(formats).to.eql([{ outputTo: '', type: 'C:\\custom\\formatter' }])
@@ -293,7 +294,11 @@ describe('Configuration', () => {
       ])
 
       // Act
-      const { formatOptions } = await ConfigurationBuilder.build({ argv, cwd })
+      const { formatOptions } = await ConfigurationBuilder.build({
+        argv,
+        cwd,
+        env,
+      })
 
       // Assert
       expect(formatOptions).to.eql({

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -54,19 +54,23 @@ interface IGetSupportCodeLibraryRequest {
 export default class Cli {
   private readonly argv: string[]
   private readonly cwd: string
+  private readonly env: Record<string, string | undefined>
   private readonly stdout: IFormatterStream
 
   constructor({
     argv,
     cwd,
+    env,
     stdout,
   }: {
     argv: string[]
     cwd: string
+    env: Record<string, string | undefined>
     stdout: IFormatterStream
   }) {
     this.argv = argv
     this.cwd = cwd
+    this.env = env
     this.stdout = stdout
   }
 
@@ -78,6 +82,7 @@ export default class Cli {
     return await ConfigurationBuilder.build({
       argv: fullArgv,
       cwd: this.cwd,
+      env: this.env,
     })
   }
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -16,6 +16,7 @@ export default async function run(): Promise<void> {
   const cli = new Cli({
     argv: process.argv,
     cwd,
+    env: process.env,
     stdout: process.stdout,
   })
 


### PR DESCRIPTION
This is necessary in order to make tests behave independently of the value of environment variables such as `CUCUMBER_PUBLISH_TOKEN`.