### PR TITLE
Do not exit in Cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Changed
 
+* Change the behaviour of `Cli` so that the process does not exit when bad command line options are used.
+  It will still exit when `--help`, `--version` or `-v` is passed.
 * All `testCase` messages now emitted upfront at the start of the run (relevant for formatter authors) ([#1408](https://github.com/cucumber/cucumber-js/issues/1408)
   [#1669](https://github.com/cucumber/cucumber-js/pull/1669))
 * Clarify that the JSON formatter will not be removed any time soon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Changed
 
+* Change the behaviour of `Cli` so that the process does not exit when bad command line options are used.
+  It will still exit when `--help`, `--version` or `-v` is passed.
+  ([#1695](https://github.com/cucumber/cucumber-js/pull/1695)
+   [aslakhellesoy])
+
 ### Deprecated
 
 ### Removed
@@ -28,10 +33,6 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Changed
 
-* Change the behaviour of `Cli` so that the process does not exit when bad command line options are used.
-  It will still exit when `--help`, `--version` or `-v` is passed.
-  ([#1695](https://github.com/cucumber/cucumber-js/pull/1695)
-   [aslakhellesoy])
 * All `testCase` messages now emitted upfront at the start of the run (relevant for formatter authors) ([#1408](https://github.com/cucumber/cucumber-js/issues/1408)
   [#1669](https://github.com/cucumber/cucumber-js/pull/1669))
 * Clarify that the JSON formatter will not be removed any time soon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 * Change the behaviour of `Cli` so that the process does not exit when bad command line options are used.
   It will still exit when `--help`, `--version` or `-v` is passed.
+  ([#1695](https://github.com/cucumber/cucumber-js/pull/1695)
+   [aslakhellesoy])
 * All `testCase` messages now emitted upfront at the start of the run (relevant for formatter authors) ([#1408](https://github.com/cucumber/cucumber-js/issues/1408)
   [#1669](https://github.com/cucumber/cucumber-js/pull/1669))
 * Clarify that the JSON formatter will not be removed any time soon

--- a/src/cli/argv_parser.ts
+++ b/src/cli/argv_parser.ts
@@ -235,9 +235,8 @@ const ArgvParser = {
 
     try {
       program.parse(argv)
-    } catch (err) {
-      // An error is always thrown when program.exitOverride() is set.
-      const commanderError: CommanderError = err
+      // @ts-expect-error
+    } catch (commanderError: CommanderError) {
       if (commanderError.exitCode !== 0) {
         throw commanderError
       }


### PR DESCRIPTION
This prevents the process from calling `process.exit` when an error occurs during command line parsing.

This is needed to make it easier to control when the process exits from tools that use Cucumber as a library (like https://github.com/cucumber/cucumber-electron).

I tried to prevent exit for `--help` and `--version`, but this was harder. We parse the command line twice (once to extract the `--profile`, and once again after reading the profile options), and this caused double rendering when `--version` was used.

Circumventing this would mean one of the following:
* Don't use commander to extract profiles
* Set a custom [output handler](https://github.com/tj/commander.js/#override-exit-and-output-handling)

This seemed too cumbersome, so I went with this compromise.