### PR TITLE
fix(cli): allow targetting same file multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Fixed
 
+* Prevent duplicate scenario execution where the same feature is targeted in multiple line expressions ([#1706](https://github.com/cucumber/cucumber-js/issues/1706))
 * Fixed reports banner to point to [new docs](https://cucumber.io/docs/cucumber/environment-variables/) about environment variables 
 
 ## [7.3.0] (2021-06-17)

--- a/features/target_specific_scenarios_by_line.feature
+++ b/features/target_specific_scenarios_by_line.feature
@@ -37,10 +37,15 @@ Feature: Target specific scenarios
     Then it fails
     And it runs the scenario "second scenario - X"
 
-  Scenario: run multiple scenarios
-    When I run cucumber-js with `features/a.feature:2:10`
+  Scenario Outline: run multiple scenarios
+    When I run cucumber-js with `<args>`
     Then it fails
     And it runs the scenarios:
       | NAME                |
       | first scenario      |
       | second scenario - X |
+
+    Examples:
+      | args                                       |
+      | features/a.feature:2:10                    |
+      | features/a.feature:2 features/a.feature:10 |

--- a/src/cli/configuration_builder.ts
+++ b/src/cli/configuration_builder.ts
@@ -143,6 +143,7 @@ export default class ConfigurationBuilder {
 
   async expandFeaturePaths(featurePaths: string[]): Promise<string[]> {
     featurePaths = featurePaths.map((p) => p.replace(/(:\d+)*$/g, '')) // Strip line numbers
+    featurePaths = [...new Set(featurePaths)] // Deduplicate the feature files; // Deduplicate the feature files
     return this.expandPaths(featurePaths, '.feature')
   }
 

--- a/src/cli/configuration_builder.ts
+++ b/src/cli/configuration_builder.ts
@@ -143,7 +143,7 @@ export default class ConfigurationBuilder {
 
   async expandFeaturePaths(featurePaths: string[]): Promise<string[]> {
     featurePaths = featurePaths.map((p) => p.replace(/(:\d+)*$/g, '')) // Strip line numbers
-    featurePaths = [...new Set(featurePaths)] // Deduplicate the feature files; // Deduplicate the feature files
+    featurePaths = [...new Set(featurePaths)] // Deduplicate the feature files
     return this.expandPaths(featurePaths, '.feature')
   }
 

--- a/src/cli/configuration_builder_spec.ts
+++ b/src/cli/configuration_builder_spec.ts
@@ -85,6 +85,24 @@ describe('Configuration', () => {
       expect(supportCodePaths).to.eql([supportCodePath])
     })
 
+    it('deduplicates the .feature files before returning', async function () {
+      // Arrange
+      const cwd = await buildTestWorkingDirectory()
+      const relativeFeaturePath = path.join('features', 'a.feature')
+      const featurePath = path.join(cwd, relativeFeaturePath)
+      await fsExtra.outputFile(featurePath, '')
+      const argv = baseArgv.concat([
+        `${relativeFeaturePath}:3`,
+        `${relativeFeaturePath}:4`,
+      ])
+
+      // Act
+      const { featurePaths } = await ConfigurationBuilder.build({ argv, cwd })
+
+      // Assert
+      expect(featurePaths).to.eql([featurePath])
+    })
+
     it('returns the appropriate .md and support code paths', async function () {
       // Arrange
       const cwd = await buildTestWorkingDirectory()


### PR DESCRIPTION
Fix the issue where the same scenarios are executed multiple times when the feature file is targeted multiple times.

Example:

```shell
$ npx cucumber-js features/simple_math.feature:19 features/simple_math.feature:20
```

Will now result in:

```
...
2 scenario (2 passed)
6 steps (6 passed)
```

Fixes #1706