### PR TITLE
cli: remove deprecated retryTagFilter option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 ### Breaking changes
 
 * Drop support for Node.js 10 and 15, add support for Node.js 16
+* Remove deprecated `--retryTagFilter` option (the correct option is `--retry-tag-filter`) 
 
 ### Added
 

--- a/features/retry.feature
+++ b/features/retry.feature
@@ -12,27 +12,6 @@ Feature: Retry flaky tests
       """
     And it fails
 
-  @spawn
-  Scenario: running Cucumber JS with --retryTagFilter in camel case will result in a warning
-    Given a file named "features/a.feature" with:
-      """
-      Feature:
-        Scenario:
-          Given a step
-      """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
-      """
-      const {Given} = require('@cucumber/cucumber')
-
-      Given(/^a step$/, function() {})
-      """
-    When I run cucumber-js with `--retry 1 --retryTagFilter @flaky`
-    Then the error output contains the text:
-      """
-      the argument --retryTagFilter is deprecated and will be removed in a future release; please use --retry-tag-filter
-      """
-    But it passes
-
   Scenario: running Cucumber JS with negative --retry will fail
     When I run cucumber-js with `--retry -1`
     Then the error output contains the text:

--- a/src/cli/argv_parser.ts
+++ b/src/cli/argv_parser.ts
@@ -200,7 +200,7 @@ const ArgvParser = {
         0
       )
       .option(
-        '--retryTagFilter, --retry-tag-filter <EXPRESSION>',
+        '--retry-tag-filter <EXPRESSION>',
         `only retries the features or scenarios with tags matching the expression (repeatable).
         This option requires '--retry' to be specified.`,
         ArgvParser.mergeTags,
@@ -234,14 +234,6 @@ const ArgvParser = {
     return {
       options,
       args: program.args,
-    }
-  },
-
-  lint(fullArgv: string[]): void {
-    if (fullArgv.includes('--retryTagFilter')) {
-      console.warn(
-        'the argument --retryTagFilter is deprecated and will be removed in a future release; please use --retry-tag-filter'
-      )
     }
   },
 }

--- a/src/cli/configuration_builder.ts
+++ b/src/cli/configuration_builder.ts
@@ -59,8 +59,6 @@ export default class ConfigurationBuilder {
 
   constructor({ argv, cwd }: INewConfigurationBuilderOptions) {
     this.cwd = cwd
-
-    ArgvParser.lint(argv)
     const parsedArgv = ArgvParser.parse(argv)
     this.args = parsedArgv.args
     this.options = parsedArgv.options


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Remove the camelCase version of this CLI option as deprecated in 7.0.0 via https://github.com/cucumber/cucumber-js/pull/1293.

## Type of change

<!--- Delete any options that are not relevant -->

- Breaking change (will cause existing functionality to not
  work as expected)

# Checklist:


- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
