### PR TITLE
docs: officially deprecate setDefinitionFunctionWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Deprecated
 
+* Deprecate `setDefinitionFunctionWrapper` and step definition option `wrapperOptions`
+
 ### Removed
 
 ### Fixed

--- a/src/support_code_library_builder/index.ts
+++ b/src/support_code_library_builder/index.ts
@@ -108,6 +108,9 @@ export class SupportCodeLibraryBuilder {
         this.defaultTimeout = milliseconds
       },
       setDefinitionFunctionWrapper: (fn) => {
+        console.log(
+          `setDefinitionFunctionWrapper is deprecated and will be removed in version 8.0.0 of cucumber-js. If this was used to wrap generator functions, please transition to using async / await. If this was used to wrap step definitions, please use BeforeStep / AfterStep hooks instead. If you had other use cases, please create an issue.`
+        )
         this.definitionFunctionWrapper = fn
       },
       setWorldConstructor: (fn) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Emit a warning when you call `setDefinitionFunctionWrapper`, using same wording as the removal notice in #1725.

# Motivation & context

Give users a bit of warning about the removal in 8.0.0.

Then going to release as 7.3.1 (we had another couple fixes ready anyway on 7.x).