### PR TITLE
bringing back v6/5 props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 * Prevent duplicate scenario execution where the same feature is targeted in multiple line expressions ([#1706](https://github.com/cucumber/cucumber-js/issues/1706))
 * Fixed reports banner to point to [new docs](https://cucumber.io/docs/cucumber/environment-variables/) about environment variables 
-* errorMessage and errorStack functions are not found [1582](https://github.com/cucumber/cucumber-js/issues/1582)
+* Re-add color functions for use with custom formatters [1582](https://github.com/cucumber/cucumber-js/issues/1582)
 
 ## [7.3.0] (2021-06-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 * Prevent duplicate scenario execution where the same feature is targeted in multiple line expressions ([#1706](https://github.com/cucumber/cucumber-js/issues/1706))
 * Fixed reports banner to point to [new docs](https://cucumber.io/docs/cucumber/environment-variables/) about environment variables 
+* errorMessage and errorStack functions are not found [1582](https://github.com/cucumber/cucumber-js/issues/1582)
 
 ## [7.3.0] (2021-06-17)
 

--- a/src/formatter/get_color_fns.ts
+++ b/src/formatter/get_color_fns.ts
@@ -9,6 +9,10 @@ export interface IColorFns {
   forStatus: (status: TestStepResultStatus) => IColorFn
   location: IColorFn
   tag: IColorFn
+  diffAdded: IColorFn
+  diffRemoved: IColorFn
+  errorMessage: IColorFn
+  errorStack: IColorFn
 }
 
 export default function getColorFns(enabled: boolean): IColorFns {
@@ -27,6 +31,10 @@ export default function getColorFns(enabled: boolean): IColorFns {
       },
       location: colors.gray.bind(colors),
       tag: colors.cyan.bind(colors),
+      diffAdded: colors.green.bind(colors),
+      diffRemoved: colors.red.bind(colors),
+      errorMessage: colors.red.bind(colors),
+      errorStack: colors.grey.bind(colors),
     }
   } else {
     return {
@@ -35,6 +43,10 @@ export default function getColorFns(enabled: boolean): IColorFns {
       },
       location: (x) => x,
       tag: (x) => x,
+      diffAdded: (x) => x,
+      diffRemoved: (x) => x,
+      errorMessage: (x) => x,
+      errorStack: (x) => x,
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

bringing back v6/5 `get_color_fns` props

# Motivation & context

Fixes #1582

## Type of change

<!--- Delete any options that are not relevant -->

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
