### PR TITLE
List formatters in help command

### DIFF
--- a/src/formatter/builder.ts
+++ b/src/formatter/builder.ts
@@ -61,30 +61,22 @@ const FormatterBuilder = {
   },
 
   getConstructorByType(type: string, cwd: string): typeof Formatter {
-    switch (type) {
-      case 'json':
-        return JsonFormatter
-      case 'message':
-        return MessageFormatter
-      case 'html':
-        return HtmlFormatter
-      case 'progress':
-        return ProgressFormatter
-      case 'progress-bar':
-        return ProgressBarFormatter
-      case 'rerun':
-        return RerunFormatter
-      case 'snippets':
-        return SnippetsFormatter
-      case 'summary':
-        return SummaryFormatter
-      case 'usage':
-        return UsageFormatter
-      case 'usage-json':
-        return UsageJsonFormatter
-      default:
-        return FormatterBuilder.loadCustomFormatter(type, cwd)
+    
+    const formatters: Record<string, typeof Formatter> = {
+      'json': JsonFormatter,
+      'message': MessageFormatter,
+      'html': HtmlFormatter,
+      'progress': ProgressFormatter,
+      'progress-bar': ProgressBarFormatter,
+      'rerun': RerunFormatter,
+      'snippets': SnippetsFormatter,
+      'summary': SummaryFormatter,
+      'usage': UsageFormatter,
+      'usage-json': UsageJsonFormatter,
+      'default': FormatterBuilder.loadCustomFormatter(type, cwd)
     }
+
+    return formatters.type
   },
 
   getStepDefinitionSnippetBuilder({

--- a/src/formatter/index.ts
+++ b/src/formatter/index.ts
@@ -39,6 +39,7 @@ export default class Formatter {
   protected stream: WritableStream
   protected supportCodeLibrary: ISupportCodeLibrary
   private readonly cleanup: IFormatterCleanupFn
+  protected readonly documentation: string
 
   constructor(options: IFormatterOptions) {
     this.colorFns = options.colorFns


### PR DESCRIPTION
# Description
As it currently stands, when running the command  cucumber.js --help, the formatters do not show up.
To remedy this situation, it was suggested to do the following:

- Refactor getConstructorByType method to hold a Record<string, typeof Formatter>
- Add a documentation field to Formatter class to hold the static string
- Use the Record in argv_parser.ts to print out all the formatters

# Motivation & context
Fixes #1700 

## Type of change
- Refactoring/debt (improvement to code design or tooling without changing behaviour)
- Bug fix (non-breaking change which fixes an issue)

## Note to other contributors


## Update required of cucumber.io/docs
No update needed

# Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
