### PR TITLE
Update esm.md

### DIFF
--- a/docs/esm.md
+++ b/docs/esm.md
@@ -2,6 +2,8 @@
 
 You can optionally write your support code (steps, hooks, etc) with native ES modules syntax - i.e. using `import` and `export` statements without transpiling. This is enabled without any additional configuration, and you can use either of the `.js` or `.mjs` file extensions.
 
+**Important**: please note that your configuration file referenced for [Profiles](./profiles.md) - aka `cucumber.js` file - must remain a CommonJS file. In a project with `type=module`, you can name the file `cucumber.cjs`, since Node expects `.js` files to be in ESM syntax in such projects.
+
 Example (adapted from [our original example](./nodejs_example.md)):
 
 ```javascript
@@ -30,5 +32,3 @@ As well as support code, these things can also be in ES modules syntax:
 You can use ES modules selectively/incrementally - so you can have a mixture of CommonJS and ESM in the same project.
 
 When using a transpiler for e.g. TypeScript, ESM isn't supported - you'll need to configure your transpiler to output modules in CommonJS syntax (for now).
-
-The config file referenced for [Profiles](./profiles.md) can only be in CommonJS syntax. In a project with `type=module`, you can name the file `cucumber.cjs`, since Node expects `.js` files to be in ESM syntax in such projects.


### PR DESCRIPTION
# Description

Move the chapter about configuration file at the top of the doc to give it more visibility

# Motivation & context

The fact that the cucumber configuration file must remain a commonJs file is very important as without that, we may think the esm support is actually broken.

Moving the chapter back on top should give it more visibility.
