### PR TITLE
Export version number of cucumber-js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ usage.txt
 yarn-error.log
 .vscode
 .DS_Store
+src/version.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 - Allows for parentheses in paths for developers working on cucumber's own code ([[#1735](https://github.com/cucumber/cucumber-js/issues/1735)])
 - Smoother onboarding for Windows developers ([#1863](https://github.com/cucumber/cucumber-js/pull/1863))
 
+### Added
+- Export cucumber version number. It is now possible to retrieve the current version
+  of cucumber using `import { version } from '@cucumber/cucumber'`.
+  ([PR#1866](https://github.com/cucumber/cucumber-js/pull/1866)
+   [Issue#1853](https://github.com/cucumber/cucumber-js/issues/1853))
+
 ## [8.0.0-rc.1] - 2021-10-19
 ### Added
 - Add `wrapPromiseWithTimeout` to public API ([#1566](https://github.com/cucumber/cucumber-js/pull/1566))

--- a/features/step_definitions/cli_steps.ts
+++ b/features/step_definitions/cli_steps.ts
@@ -9,8 +9,7 @@ import {
   valueOrDefault,
 } from '../../src/value_checker'
 import { World } from '../support/world'
-
-const { version } = require('../../package.json') // eslint-disable-line @typescript-eslint/no-var-requires
+import { version } from '../../src/version'
 
 When('my env includes {string}', function (this: World, envString: string) {
   this.sharedEnv = this.parseEnvString(envString)

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "eslint-plugin-standard": "4.1.0",
         "express": "4.17.1",
         "fs-extra": "10.0.0",
+        "genversion": "^3.0.2",
         "mocha": "9.1.3",
         "mustache": "4.2.0",
         "nyc": "15.1.0",
@@ -3323,6 +3324,15 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
+    "node_modules/find-package": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-package/-/find-package-1.0.0.tgz",
+      "integrity": "sha1-13ONpn48XwVcJNPhmqGu7QY8PoM=",
+      "dev": true,
+      "dependencies": {
+        "parents": "^1.0.1"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3503,6 +3513,28 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/genversion": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/genversion/-/genversion-3.0.2.tgz",
+      "integrity": "sha512-hto4m/V3DQOJbIH2nVNPhkScqwAzpYnmTLDOs+2AYxqGWVKsUW6Qxcz2FXRQlbAXgWpJxbxgnWqb1/s17lK2yg==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^7.2.0",
+        "find-package": "^1.0.0"
+      },
+      "bin": {
+        "genversion": "bin/genversion.js"
+      }
+    },
+    "node_modules/genversion/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/get-caller-file": {
@@ -5296,6 +5328,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/parents": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+      "dev": true,
+      "dependencies": {
+        "path-platform": "~0.11.15"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -5353,6 +5394,15 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-platform": {
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
@@ -9498,6 +9548,15 @@
         "pkg-dir": "^4.1.0"
       }
     },
+    "find-package": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-package/-/find-package-1.0.0.tgz",
+      "integrity": "sha1-13ONpn48XwVcJNPhmqGu7QY8PoM=",
+      "dev": true,
+      "requires": {
+        "parents": "^1.0.1"
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -9631,6 +9690,24 @@
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
+    },
+    "genversion": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/genversion/-/genversion-3.0.2.tgz",
+      "integrity": "sha512-hto4m/V3DQOJbIH2nVNPhkScqwAzpYnmTLDOs+2AYxqGWVKsUW6Qxcz2FXRQlbAXgWpJxbxgnWqb1/s17lK2yg==",
+      "dev": true,
+      "requires": {
+        "commander": "^7.2.0",
+        "find-package": "^1.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+          "dev": true
+        }
+      }
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -10983,6 +11060,15 @@
         "callsites": "^3.0.0"
       }
     },
+    "parents": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+      "dev": true,
+      "requires": {
+        "path-platform": "~0.11.15"
+      }
+    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -11022,6 +11108,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "path-platform": {
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
     "eslint-plugin-standard": "4.1.0",
     "express": "4.17.1",
     "fs-extra": "10.0.0",
+    "genversion": "^3.0.2",
     "mocha": "9.1.3",
     "mustache": "4.2.0",
     "nyc": "15.1.0",
@@ -266,7 +267,7 @@
     "typescript": "4.5.2"
   },
   "scripts": {
-    "build-local": "tsc --build tsconfig.node.json && cp src/importer.js lib/ && cp src/wrapper.mjs lib/",
+    "build-local": "genversion --es6 src/version.ts && tsc --build tsconfig.node.json && cp src/importer.js lib/ && cp src/wrapper.mjs lib/",
     "cck-test": "mocha 'compatibility/**/*_spec.ts'",
     "feature-test": "node ./bin/cucumber-js",
     "html-formatter": "node ./bin/cucumber-js --profile htmlFormatter",

--- a/src/cli/argv_parser.ts
+++ b/src/cli/argv_parser.ts
@@ -3,9 +3,7 @@ import path from 'path'
 import { dialects } from '@cucumber/gherkin'
 import { SnippetInterface } from '../formatter/step_definition_snippet_builder/snippet_syntax'
 import Formatters from '../formatter/helpers/formatters'
-
-// Using require instead of import so compiled typescript will have the desired folder structure
-const { version } = require('../../package.json') // eslint-disable-line @typescript-eslint/no-var-requires
+import { version } from '../version'
 
 export interface IParsedArgvFormatRerunOptions {
   separator?: string

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -14,6 +14,7 @@ import { ISupportCodeLibrary } from '../support_code_library_builder/types'
 import TestCaseHookDefinition from '../models/test_case_hook_definition'
 import TestRunHookDefinition from '../models/test_run_hook_definition'
 import { builtinParameterTypes } from '../support_code_library_builder'
+import { version } from '../version'
 
 export interface IGetExpandedArgvRequest {
   argv: string[]
@@ -114,8 +115,6 @@ export function isJavaScript(filePath: string): boolean {
 export async function emitMetaMessage(
   eventBroadcaster: EventEmitter
 ): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { version } = require('../../package.json')
   eventBroadcaster.emit('envelope', {
     meta: createMeta('cucumber-js', version, process.env),
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
 } from './runtime'
 export { default as supportCodeLibraryBuilder } from './support_code_library_builder'
 export { default as DataTable } from './models/data_table'
+export { version } from './version'
 
 // Formatters
 export { default as Formatter, IFormatterOptions } from './formatter'


### PR DESCRIPTION
# Description

Fixes. #1853 
With ESM support, the version number of cucumber-js is not as exposed as it was due to package.json not exported.
It seems more reliable with ESM to have version defined in a source file then exported by the libraries.

To keep the version sync with the one defined in package.json, the npm package [genversion](https://www.npmjs.com/package/genversion) has been used.

# Motivation & context

Pretty sure it may be useful with the incoming API too :)

## Type of change

<!--- Delete any options that are not relevant -->

I think we could consider this a breaking change: the way to find the version of cucumber programmatically has changed

- Breaking change (will cause existing functionality to not
  work as expected)

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
