### PR TITLE
Replace uses of `any` type

### DIFF
--- a/compatibility/cck_spec.ts
+++ b/compatibility/cck_spec.ts
@@ -58,6 +58,7 @@ describe('Cucumber Compatibility Kit', () => {
       stdout.end()
 
       const rawOutput = await toString(stdout)
+      // TODO: consider validating (at run-time) the parsed message is really an Envelope
       const actualMessages = normalize(
         rawOutput
           .split('\n')
@@ -85,7 +86,7 @@ describe('Cucumber Compatibility Kit', () => {
   })
 })
 
-function normalize(messages: any[]): any[] {
+function normalize(messages: messages.Envelope[]): messages.Envelope[] {
   messages = normalizeMessageOutput(
     messages,
     path.join(PROJECT_PATH, 'compatibility')

--- a/compatibility/features/data-tables/data-tables.ts
+++ b/compatibility/features/data-tables/data-tables.ts
@@ -1,13 +1,17 @@
 import { When, Then, DataTable } from '../../../src'
 import { expect } from 'chai'
 
+type World = {
+  transposed: DataTable
+}
+
 When(
   'the following table is transposed:',
-  function (this: any, table: DataTable) {
+  function (this: World, table: DataTable) {
     this.transposed = table.transpose()
   }
 )
 
-Then('it should be:', function (this: any, expected: DataTable) {
+Then('it should be:', function (this: World, expected: DataTable) {
   expect(this.transposed.raw()).to.deep.eq(expected.raw())
 })

--- a/compatibility/features/examples-tables/examples-tables.ts
+++ b/compatibility/features/examples-tables/examples-tables.ts
@@ -1,17 +1,24 @@
 import assert from 'assert'
 import { Given, When, Then } from '../../../src'
 
-Given('there are {int} cucumbers', function (this: any, initialCount: number) {
-  this.count = initialCount
-})
+type World = {
+  count: number
+}
 
-When('I eat {int} cucumbers', function (this: any, eatCount: number) {
+Given(
+  'there are {int} cucumbers',
+  function (this: World, initialCount: number) {
+    this.count = initialCount
+  }
+)
+
+When('I eat {int} cucumbers', function (this: World, eatCount: number) {
   this.count -= eatCount
 })
 
 Then(
   'I should have {int} cucumbers',
-  function (this: any, expectedCount: number) {
+  function (this: World, expectedCount: number) {
     assert.strictEqual(this.count, expectedCount)
   }
 )

--- a/compatibility/features/unknown-parameter-type/unknown-parameter-type.ts
+++ b/compatibility/features/unknown-parameter-type/unknown-parameter-type.ts
@@ -1,6 +1,6 @@
 import { Given } from '../../../src'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-Given('{airport} is closed because of a strike', function (airport: any) {
+Given('{airport} is closed because of a strike', function (airport: unknown) {
   throw new Error('Should not be called because airport type not defined')
 })


### PR DESCRIPTION
# Description

Change uses of `any` type to use specific types.

# Motivation & context

See #1648

## Type of change

- Refactoring/debt (improvement to code design or tooling without changing behaviour)

# Checklist:

- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
