### PR TITLE
Extract prettier config from eslintrc

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,26 +1,24 @@
 extends:
-  - "eslint:recommended"
-  - "plugin:import/typescript"
-  - "plugin:@typescript-eslint/eslint-recommended"
-  - "plugin:@typescript-eslint/recommended"
-  - "plugin:prettier/recommended"
-parser: "@typescript-eslint/parser"
+  - 'eslint:recommended'
+  - 'plugin:import/typescript'
+  - 'plugin:@typescript-eslint/eslint-recommended'
+  - 'plugin:@typescript-eslint/recommended'
+  - 'plugin:prettier/recommended'
+  - prettier
+parser: '@typescript-eslint/parser'
 parserOptions:
   project: './tsconfig.json'
 plugins:
   - import
   - node
-  - "@typescript-eslint"
+  - '@typescript-eslint'
+  - prettier
 rules:
-  prettier/prettier:
-    - error
-    - trailingComma: es5
-      singleQuote: true
-      semi: false
+  'prettier/prettier': 2
   # requires strictNullChecks compiler option, produces many errors with messages objects
-  "@typescript-eslint/strict-boolean-expressions": off
-  "@typescript-eslint/no-explicit-any": off
-  "@typescript-eslint/no-inferrable-types": off
-  "@typescript-eslint/no-empty-function": off
-  "@typescript-eslint/ban-types": off
-  "@typescript-eslint/no-unused-vars": off
+  '@typescript-eslint/strict-boolean-expressions': off
+  '@typescript-eslint/no-explicit-any': off
+  '@typescript-eslint/no-inferrable-types': off
+  '@typescript-eslint/no-empty-function': off
+  '@typescript-eslint/ban-types': off
+  '@typescript-eslint/no-unused-vars': off

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+	"trailingComma": "es5",
+	"singleQuote": true,
+	"semi": false
+}


### PR DESCRIPTION
# Description

Use a more conventional place to store prettier config

# Motivation & context

So that VSCode's prettier plugin can automatically find it.

Currently, VSCode doesn't understand our prettier config, so the code formatter from the prettier plugin reformats the code using defaults (e.g. adding semi-colons), which then breaks the eslint rules!

## Type of change

- Refactoring/debt (improvement to code design or tooling without changing behaviour)
