### PR TITLE
build: tag as next when publishing release candidates

### DIFF
--- a/.github/workflows/release-npm-latest.yaml
+++ b/.github/workflows/release-npm-latest.yaml
@@ -1,0 +1,24 @@
+name: Release NPM (latest)
+
+on:
+  push:
+    branches: [release/*]
+    branches-ignore: [release/*-rc*]
+
+jobs:
+  publish-npm:
+    name: Publish NPM module
+    runs-on: ubuntu-latest
+    environment: Release
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - run: npm install-test
+      - uses: cucumber/action-publish-npm@v1.1.0
+        with:
+          npm-token: ${{ secrets.NPM_TOKEN }}
+          npm-tag: 'latest'

--- a/.github/workflows/release-npm-next.yaml
+++ b/.github/workflows/release-npm-next.yaml
@@ -1,8 +1,8 @@
-name: Release NPM
+name: Release NPM (next)
 
 on:
   push:
-    branches: [release/*]
+    branches: [release/*-rc*]
 
 jobs:
   publish-npm:
@@ -17,6 +17,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm install-test
-      - uses: cucumber/action-publish-npm@v1.0.0
+      - uses: cucumber/action-publish-npm@v1.1.0
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
+          npm-tag: 'next'


### PR DESCRIPTION
# Description

Creates two versions of the npm release workflow - one for stable releases, and one for release candidates, based on branch naming patterns. The former are tagged as `latest` and the latter as `next`.

# Motivation & context

Unless a tag is specified, npm packages default to `latest` on publication. This meant that, when a release candidate was out, in practise users would run `npm install @cucumber/cucumber` and get the release candidate when we would want them to get the latest stable version unless they opt in to the RC.

`next` is a loose convention in the npm ecosystem for tagging prereleases. So next time there is an RC, regular users will still get the latest stable version when they install, and enthusiasts can do `npm install @cucumber/cucumber@next` to get the RC.

## Type of change

<!--- Delete any options that are not relevant -->

- Refactoring/debt (improvement to code design or tooling without changing behaviour)

# Checklist:

<!--- 
Go over all the following points, and put an `x` in all the boxes that apply. 
-->

- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] My change needed additional tests
  - [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
