### PR TITLE
lint: error on unused vars

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,4 +21,4 @@ rules:
   '@typescript-eslint/no-inferrable-types': off
   '@typescript-eslint/no-empty-function': off
   '@typescript-eslint/ban-types': off
-  '@typescript-eslint/no-unused-vars': off
+  '@typescript-eslint/no-unused-vars': [error, { "argsIgnorePattern": "^_" }]

--- a/compatibility/features/parameter-types/parameter-types.ts
+++ b/compatibility/features/parameter-types/parameter-types.ts
@@ -18,5 +18,6 @@ Given(
   function (flight: Flight, delay: number) {
     expect(flight.from).to.eq('LHR')
     expect(flight.to).to.eq('CDG')
+    expect(delay).to.eq(45)
   }
 )

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -39,7 +39,6 @@ export async function getExpandedArgv({
 }
 
 interface IParseGherkinMessageStreamRequest {
-  cwd: string
   eventBroadcaster: EventEmitter
   eventDataCollector: EventDataCollector
   gherkinMessageStream: Readable
@@ -50,7 +49,6 @@ interface IParseGherkinMessageStreamRequest {
 export type PickleOrder = 'defined' | 'random'
 
 export async function parseGherkinMessageStream({
-  cwd,
   eventBroadcaster,
   eventDataCollector,
   gherkinMessageStream,

--- a/src/cli/helpers_spec.ts
+++ b/src/cli/helpers_spec.ts
@@ -30,7 +30,6 @@ const noopFunction = (): void => {
 }
 
 interface ITestParseGherkinMessageStreamRequest {
-  cwd: string
   gherkinMessageStream: Readable
   order: PickleOrder
   pickleFilter: PickleFilter
@@ -49,7 +48,6 @@ async function testParseGherkinMessageStream(
   eventBroadcaster.on('envelope', (e) => envelopes.push(e))
   const eventDataCollector = new EventDataCollector(eventBroadcaster)
   const result = await parseGherkinMessageStream({
-    cwd: options.cwd,
     eventBroadcaster,
     eventDataCollector,
     gherkinMessageStream: options.gherkinMessageStream,
@@ -384,7 +382,6 @@ describe('helpers', () => {
 
         // Act
         const { envelopes, result } = await testParseGherkinMessageStream({
-          cwd,
           gherkinMessageStream,
           order,
           pickleFilter,
@@ -426,7 +423,6 @@ describe('helpers', () => {
 
         // Act
         const { envelopes, result } = await testParseGherkinMessageStream({
-          cwd,
           gherkinMessageStream,
           order,
           pickleFilter,
@@ -470,7 +466,6 @@ describe('helpers', () => {
 
         // Act
         const { envelopes, result } = await testParseGherkinMessageStream({
-          cwd,
           gherkinMessageStream,
           order,
           pickleFilter,

--- a/src/formatter/get_color_fns.ts
+++ b/src/formatter/get_color_fns.ts
@@ -36,7 +36,7 @@ export default function getColorFns(enabled: boolean): IColorFns {
     }
   } else {
     return {
-      forStatus(status: TestStepResultStatus) {
+      forStatus(_status: TestStepResultStatus) {
         return (x) => x
       },
       location: (x) => x,

--- a/src/formatter/helpers/issue_helpers.ts
+++ b/src/formatter/helpers/issue_helpers.ts
@@ -32,7 +32,6 @@ export function isIssue(result: messages.TestStepResult): boolean {
 
 export interface IFormatIssueRequest {
   colorFns: IColorFns
-  cwd: string
   number: number
   snippetBuilder: StepDefinitionSnippetBuilder
   testCaseAttempt: ITestCaseAttempt
@@ -42,7 +41,6 @@ export interface IFormatIssueRequest {
 
 export function formatIssue({
   colorFns,
-  cwd,
   number,
   snippetBuilder,
   testCaseAttempt,
@@ -52,7 +50,6 @@ export function formatIssue({
   const prefix = `${number.toString()}) `
   const formattedTestCaseAttempt = formatTestCaseAttempt({
     colorFns,
-    cwd,
     snippetBuilder,
     testCaseAttempt,
     supportCodeLibrary,

--- a/src/formatter/helpers/issue_helpers_spec.ts
+++ b/src/formatter/helpers/issue_helpers_spec.ts
@@ -24,7 +24,6 @@ async function testFormatIssue(
     supportCodeLibrary,
   })
   return formatIssue({
-    cwd: 'project/',
     colorFns: getColorFns(false),
     number: 1,
     snippetBuilder: await FormatterBuilder.getStepDefinitionSnippetBuilder({

--- a/src/formatter/helpers/summary_helpers_spec.ts
+++ b/src/formatter/helpers/summary_helpers_spec.ts
@@ -238,13 +238,11 @@ describe('SummaryHelpers', () => {
           'Scenario: b',
           'Given a passing step',
         ].join('\n')
-        const supportCodeLibrary = buildSupportCodeLibrary(
-          ({ Given, Before }) => {
-            Given('a passing step', () => {
-              clock.tick(123)
-            })
-          }
-        )
+        const supportCodeLibrary = buildSupportCodeLibrary(({ Given }) => {
+          Given('a passing step', () => {
+            clock.tick(123)
+          })
+        })
 
         // Act
         const output = await testFormatSummary({
@@ -282,13 +280,11 @@ describe('SummaryHelpers', () => {
           'Scenario: b',
           'Given a passing step',
         ].join('\n')
-        const supportCodeLibrary = buildSupportCodeLibrary(
-          ({ Given, Before }) => {
-            Given('a passing step', () => {
-              clock.tick(12.3 * 1000)
-            })
-          }
-        )
+        const supportCodeLibrary = buildSupportCodeLibrary(({ Given }) => {
+          Given('a passing step', () => {
+            clock.tick(12.3 * 1000)
+          })
+        })
 
         // Act
         const output = await testFormatSummary({
@@ -320,13 +316,11 @@ describe('SummaryHelpers', () => {
           'Scenario: b',
           'Given a passing step',
         ].join('\n')
-        const supportCodeLibrary = buildSupportCodeLibrary(
-          ({ Given, Before }) => {
-            Given('a passing step', () => {
-              clock.tick(123 * 1000)
-            })
-          }
-        )
+        const supportCodeLibrary = buildSupportCodeLibrary(({ Given }) => {
+          Given('a passing step', () => {
+            clock.tick(123 * 1000)
+          })
+        })
 
         // Act
         const output = await testFormatSummary({

--- a/src/formatter/helpers/test_case_attempt_formatter.ts
+++ b/src/formatter/helpers/test_case_attempt_formatter.ts
@@ -79,7 +79,6 @@ function formatStep({
 
 export interface IFormatTestCaseAttemptRequest {
   colorFns: IColorFns
-  cwd: string
   testCaseAttempt: ITestCaseAttempt
   snippetBuilder: StepDefinitionSnippetBuilder
   supportCodeLibrary: ISupportCodeLibrary
@@ -88,14 +87,12 @@ export interface IFormatTestCaseAttemptRequest {
 
 export function formatTestCaseAttempt({
   colorFns,
-  cwd,
   snippetBuilder,
   supportCodeLibrary,
   testCaseAttempt,
   printAttachments,
 }: IFormatTestCaseAttemptRequest): string {
   const parsed = parseTestCaseAttempt({
-    cwd,
     snippetBuilder,
     testCaseAttempt,
     supportCodeLibrary,

--- a/src/formatter/helpers/test_case_attempt_parser.ts
+++ b/src/formatter/helpers/test_case_attempt_parser.ts
@@ -117,7 +117,6 @@ function parseStep({
 }
 
 export interface IParseTestCaseAttemptRequest {
-  cwd: string
   testCaseAttempt: ITestCaseAttempt
   snippetBuilder: StepDefinitionSnippetBuilder
   supportCodeLibrary: ISupportCodeLibrary
@@ -126,7 +125,6 @@ export interface IParseTestCaseAttemptRequest {
 // Converts a testCaseAttempt into a json object with all data needed for
 // displaying it in a pretty format
 export function parseTestCaseAttempt({
-  cwd,
   testCaseAttempt,
   snippetBuilder,
   supportCodeLibrary,

--- a/src/formatter/helpers/test_case_attempt_parser_spec.ts
+++ b/src/formatter/helpers/test_case_attempt_parser_spec.ts
@@ -10,7 +10,6 @@ import { getTestCaseAttempts } from '../../../test/formatter_helpers'
 
 describe('TestCaseAttemptParser', () => {
   describe('parseTestCaseAttempt', () => {
-    const cwd = ''
     const supportCodeLibrary = getBaseSupportCodeLibrary()
     const snippetSyntax = {
       build: () => 'snippet',
@@ -42,7 +41,6 @@ describe('TestCaseAttemptParser', () => {
 
         // Act
         const output = parseTestCaseAttempt({
-          cwd,
           testCaseAttempt,
           snippetBuilder,
           supportCodeLibrary,
@@ -65,7 +63,6 @@ describe('TestCaseAttemptParser', () => {
 
         // Act
         const output = parseTestCaseAttempt({
-          cwd,
           testCaseAttempt,
           snippetBuilder,
           supportCodeLibrary,

--- a/src/formatter/helpers/usage_helpers/index.ts
+++ b/src/formatter/helpers/usage_helpers/index.ts
@@ -23,7 +23,6 @@ export interface IUsage {
 }
 
 export interface IGetUsageRequest {
-  cwd: string
   eventDataCollector: EventDataCollector
   stepDefinitions: StepDefinition[]
 }
@@ -52,7 +51,6 @@ const unexecutedStatuses: readonly messages.TestStepResultStatus[] = [
 ]
 
 function buildMapping({
-  cwd,
   stepDefinitions,
   eventDataCollector,
 }: IGetUsageRequest): Record<string, IUsage> {
@@ -125,10 +123,9 @@ function buildResult(mapping: Record<string, IUsage>): IUsage[] {
 }
 
 export function getUsage({
-  cwd,
   stepDefinitions,
   eventDataCollector,
 }: IGetUsageRequest): IUsage[] {
-  const mapping = buildMapping({ cwd, stepDefinitions, eventDataCollector })
+  const mapping = buildMapping({ stepDefinitions, eventDataCollector })
   return buildResult(mapping)
 }

--- a/src/formatter/helpers/usage_helpers/index_spec.ts
+++ b/src/formatter/helpers/usage_helpers/index_spec.ts
@@ -21,7 +21,6 @@ describe('Usage Helpers', () => {
 
           // Act
           const output = getUsage({
-            cwd: '/project',
             eventDataCollector,
             stepDefinitions: supportCodeLibrary.stepDefinitions,
           })
@@ -41,15 +40,12 @@ describe('Usage Helpers', () => {
           const supportCodeLibrary = buildSupportCodeLibrary(
             ({ Given, setDefinitionFunctionWrapper }) => {
               Given('a step', code)
-              setDefinitionFunctionWrapper(
-                (fn: Function) =>
-                  function (fn: Function) {
-                    if (fn.length === 1) {
-                      return fn
-                    }
-                    return fn
-                  }
-              )
+              setDefinitionFunctionWrapper((fn: Function) => {
+                if (fn.length === 1) {
+                  return fn
+                }
+                return fn
+              })
             }
           )
           const { eventDataCollector } =
@@ -57,7 +53,6 @@ describe('Usage Helpers', () => {
 
           // Act
           const output = getUsage({
-            cwd: '/project',
             eventDataCollector,
             stepDefinitions: supportCodeLibrary.stepDefinitions,
           })

--- a/src/formatter/progress_bar_formatter.ts
+++ b/src/formatter/progress_bar_formatter.ts
@@ -75,7 +75,6 @@ export default class ProgressBarFormatter extends Formatter {
       this.progressBar.interrupt(
         formatIssue({
           colorFns: this.colorFns,
-          cwd: this.cwd,
           number: this.issueCount,
           snippetBuilder: this.snippetBuilder,
           supportCodeLibrary: this.supportCodeLibrary,

--- a/src/formatter/progress_bar_formatter_spec.ts
+++ b/src/formatter/progress_bar_formatter_spec.ts
@@ -212,7 +212,7 @@ describe('ProgressBarFormatter', () => {
 
         // Act
         const { progressBarFormatter } = await testProgressBarFormatter({
-          shouldStopFn: (envelope) => false,
+          shouldStopFn: () => false,
           sources,
           supportCodeLibrary,
         })
@@ -376,7 +376,7 @@ describe('ProgressBarFormatter', () => {
         // Act
         const { progressBarFormatter } = await testProgressBarFormatter({
           runtimeOptions: { retry: 1 },
-          shouldStopFn: (envelope) => false,
+          shouldStopFn: () => false,
           sources,
           supportCodeLibrary,
         })
@@ -414,7 +414,7 @@ describe('ProgressBarFormatter', () => {
 
       // Act
       const { output } = await testProgressBarFormatter({
-        shouldStopFn: (envelope) => false,
+        shouldStopFn: () => false,
         sources,
         supportCodeLibrary,
       })
@@ -441,7 +441,7 @@ describe('ProgressBarFormatter', () => {
 
       // Act
       const { output } = await testProgressBarFormatter({
-        shouldStopFn: (envelope) => false,
+        shouldStopFn: () => false,
         sources,
         supportCodeLibrary,
       })
@@ -473,7 +473,7 @@ describe('ProgressBarFormatter', () => {
 
       // Act
       const { output } = await testProgressBarFormatter({
-        shouldStopFn: (envelope) => false,
+        shouldStopFn: () => false,
         sources,
         supportCodeLibrary,
       })

--- a/src/formatter/snippets_formatter.ts
+++ b/src/formatter/snippets_formatter.ts
@@ -21,7 +21,6 @@ export default class SnippetsFormatter extends Formatter {
     const snippets: string[] = []
     this.eventDataCollector.getTestCaseAttempts().forEach((testCaseAttempt) => {
       const parsed = parseTestCaseAttempt({
-        cwd: this.cwd,
         snippetBuilder: this.snippetBuilder,
         supportCodeLibrary: this.supportCodeLibrary,
         testCaseAttempt,

--- a/src/formatter/summary_formatter.ts
+++ b/src/formatter/summary_formatter.ts
@@ -83,7 +83,6 @@ export default class SummaryFormatter extends Formatter {
       this.log(
         formatIssue({
           colorFns: this.colorFns,
-          cwd: this.cwd,
           number: index + 1,
           snippetBuilder: this.snippetBuilder,
           supportCodeLibrary: this.supportCodeLibrary,

--- a/src/formatter/usage_formatter.ts
+++ b/src/formatter/usage_formatter.ts
@@ -20,7 +20,6 @@ export default class UsageFormatter extends Formatter {
 
   logUsage(): void {
     const usage = getUsage({
-      cwd: this.cwd,
       stepDefinitions: this.supportCodeLibrary.stepDefinitions,
       eventDataCollector: this.eventDataCollector,
     })

--- a/src/formatter/usage_json_formatter.ts
+++ b/src/formatter/usage_json_formatter.ts
@@ -19,7 +19,6 @@ export default class UsageJsonFormatter extends Formatter {
 
   logUsage(): void {
     const usage = getUsage({
-      cwd: this.cwd,
       stepDefinitions: this.supportCodeLibrary.stepDefinitions,
       eventDataCollector: this.eventDataCollector,
     })

--- a/src/run/runCucumber.ts
+++ b/src/run/runCucumber.ts
@@ -58,7 +58,6 @@ export async function runCucumber(
 
   if (featurePaths.length > 0) {
     pickleIds = await parseGherkinMessageStream({
-      cwd,
       eventBroadcaster,
       eventDataCollector,
       gherkinMessageStream,

--- a/src/runtime/parallel/coordinator.ts
+++ b/src/runtime/parallel/coordinator.ts
@@ -119,13 +119,10 @@ export default class Coordinator implements IRuntime {
       return worker.state !== WorkerState.idle
     })
 
-    let wip: Boolean = false
-    for (const p in this.inProgressPickles) {
-      wip = true
-      break
-    }
-
-    if (!wip && this.pickleIds.length > 0) {
+    if (
+      Object.keys(this.inProgressPickles).length == 0 &&
+      this.pickleIds.length > 0
+    ) {
       this.giveWork(triggeringWorker, true)
       this.idleInterventions++
     }


### PR DESCRIPTION
This rule got turned off during a lint upgrade and think its useful to have on