### PR TITLE
reports: add handler for published url

### DIFF
--- a/features/publish.feature
+++ b/features/publish.feature
@@ -73,6 +73,22 @@ Feature: Publish reports
     And the server should receive an "Authorization" header with value "Bearer f318d9ec-5a3d-4727-adec-bd7b69e2edd3"
 
   @spawn
+  Scenario: users can supply a custom handler for the published url
+    Given a file named "features/step_definitions/publish.js" with:
+      """
+      const {setPublishedHandler} = require('@cucumber/cucumber')
+
+      setPublishedHandler(({url}) => {
+        console.error(`Our handler worked: ${url}`)
+      })
+      """
+    When I run cucumber-js with arguments `--publish` and env ``
+    Then the error output contains the text:
+      """
+      Our handler worked: https://reports.cucumber.io/reports/f318d9ec-5a3d-4727-adec-bd7b69e2edd3
+      """
+
+  @spawn
   Scenario: a banner is displayed after publication
     When I run cucumber-js with arguments `--publish` and env ``
     Then the error output contains the text:
@@ -124,11 +140,11 @@ Feature: Publish reports
       Share your Cucumber Report with your team at https://reports.cucumber.io
       """
 
-  Examples:
-    | args      | env                                                         |
-    | --publish |                                                             |
-    |           | CUCUMBER_PUBLISH_ENABLED=true                               |
-    |           | CUCUMBER_PUBLISH_TOKEN=f318d9ec-5a3d-4727-adec-bd7b69e2edd3 |
+    Examples:
+      | args      | env                                                         |
+      | --publish |                                                             |
+      |           | CUCUMBER_PUBLISH_ENABLED=true                               |
+      |           | CUCUMBER_PUBLISH_TOKEN=f318d9ec-5a3d-4727-adec-bd7b69e2edd3 |
 
   @spawn
   Scenario: the publication banner is not shown when publication is disabled
@@ -138,7 +154,7 @@ Feature: Publish reports
       Share your Cucumber Report with your team at https://reports.cucumber.io
       """
 
-  Examples:
-    | args            | env                         |
-    | --publish-quiet |                             |
-    |                 | CUCUMBER_PUBLISH_QUIET=true |
+    Examples:
+      | args            | env                         |
+      | --publish-quiet |                             |
+      |                 | CUCUMBER_PUBLISH_QUIET=true |

--- a/src/api/formatters.ts
+++ b/src/api/formatters.ts
@@ -93,7 +93,12 @@ export async function initializeFormatters({
     if (token !== undefined) {
       headers.Authorization = `Bearer ${token}`
     }
-    const stream = new HttpStream(url, 'GET', headers)
+    const stream = new HttpStream(
+      url,
+      'GET',
+      headers,
+      supportCodeLibrary.publishedHandler
+    )
     const readerStream = new Writable({
       objectMode: true,
       write: function (responseBody: string, encoding, writeCallback) {

--- a/src/cli/helpers_spec.ts
+++ b/src/cli/helpers_spec.ts
@@ -84,6 +84,7 @@ function testEmitSupportCodeMessages(
         undefinedParameterTypes: [],
         World: null,
         parallelCanAssign: () => true,
+        publishedHandler: () => undefined,
       },
       supportCode
     ),

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export const setDefaultTimeout = methods.setDefaultTimeout
 export const setDefinitionFunctionWrapper = methods.setDefinitionFunctionWrapper
 export const setWorldConstructor = methods.setWorldConstructor
 export const setParallelCanAssign = methods.setParallelCanAssign
+export const setPublishedHandler = methods.setPublishedHandler
 export const Then = methods.Then
 export const When = methods.When
 export {

--- a/src/support_code_library_builder/index.ts
+++ b/src/support_code_library_builder/index.ts
@@ -29,6 +29,7 @@ import {
   TestStepHookFunction,
   ParallelAssignmentValidator,
   ISupportCodeCoordinates,
+  IPublishedHandler,
 } from './types'
 import World from './world'
 import { ICanonicalSupportCodeIds } from '../runtime/parallel/command_types'
@@ -94,6 +95,7 @@ export class SupportCodeLibraryBuilder {
   private stepDefinitionConfigs: IStepDefinitionConfig[]
   private World: any
   private parallelCanAssign: ParallelAssignmentValidator
+  private publishedHandler: IPublishedHandler
 
   constructor() {
     const defineStep = this.defineStep.bind(this)
@@ -130,6 +132,9 @@ export class SupportCodeLibraryBuilder {
       },
       setParallelCanAssign: (fn: ParallelAssignmentValidator): void => {
         this.parallelCanAssign = fn
+      },
+      setPublishedHandler: (fn: IPublishedHandler): void => {
+        this.publishedHandler = fn
       },
       Then: defineStep,
       When: defineStep,
@@ -423,6 +428,7 @@ export class SupportCodeLibraryBuilder {
       stepDefinitions: stepDefinitionsResult.stepDefinitions,
       World: this.World,
       parallelCanAssign: this.parallelCanAssign,
+      publishedHandler: this.publishedHandler,
     }
   }
 
@@ -449,6 +455,7 @@ export class SupportCodeLibraryBuilder {
     this.parameterTypeRegistry = new ParameterTypeRegistry()
     this.stepDefinitionConfigs = []
     this.parallelCanAssign = () => true
+    this.publishedHandler = () => undefined
     this.World = World
   }
 }

--- a/src/support_code_library_builder/types.ts
+++ b/src/support_code_library_builder/types.ts
@@ -69,6 +69,8 @@ export interface IParameterTypeDefinition<T> {
   preferForRegexpMatch?: boolean
 }
 
+export type IPublishedHandler = (report: { url: string }) => void
+
 export interface IDefineSupportCodeMethods {
   defineParameterType: (options: IParameterTypeDefinition<any>) => void
   defineStep: (<WorldType = IWorld>(
@@ -83,6 +85,7 @@ export interface IDefineSupportCodeMethods {
   setDefaultTimeout: (milliseconds: number) => void
   setDefinitionFunctionWrapper: (fn: Function) => void
   setParallelCanAssign: (fn: ParallelAssignmentValidator) => void
+  setPublishedHandler: (fn: IPublishedHandler) => void
   setWorldConstructor: (fn: any) => void
   After: (<WorldType = IWorld>(code: TestCaseHookFunction<WorldType>) => void) &
     (<WorldType = IWorld>(
@@ -179,4 +182,5 @@ export interface ISupportCodeLibrary {
   readonly parameterTypeRegistry: ParameterTypeRegistry
   readonly World: any
   readonly parallelCanAssign: ParallelAssignmentValidator
+  readonly publishedHandler: IPublishedHandler
 }

--- a/src/wrapper.mjs
+++ b/src/wrapper.mjs
@@ -33,6 +33,7 @@ export const Given = cucumber.Given
 export const setDefaultTimeout = cucumber.setDefaultTimeout
 export const setDefinitionFunctionWrapper = cucumber.setDefinitionFunctionWrapper
 export const setWorldConstructor = cucumber.setWorldConstructor
+export const setPublishedHandler = cucumber.setPublishedHandler
 export const Then = cucumber.Then
 export const When = cucumber.When
 

--- a/test-d/publish.ts
+++ b/test-d/publish.ts
@@ -1,0 +1,5 @@
+import { setPublishedHandler } from '../'
+
+setPublishedHandler(async ({ url }) => {
+  return Promise.resolve(url)
+})

--- a/test/fake_report_server.ts
+++ b/test/fake_report_server.ts
@@ -7,6 +7,8 @@ import { doesHaveValue } from '../src/value_checker'
 
 type Callback = (err?: Error | null) => void
 
+export const FAKE_IDENTIFIER = 'f318d9ec-5a3d-4727-adec-bd7b69e2edd3'
+
 /**
  * Fake implementation of the same report server that backs Cucumber Reports
  * (https://messages.cucumber.io). Used for testing only.
@@ -20,7 +22,7 @@ export default class FakeReportServer {
   constructor(private port: number) {
     const app = express()
 
-    app.put('/s3', (req, res) => {
+    app.put(`/s3/${FAKE_IDENTIFIER}`, (req, res) => {
       this.receivedHeaders = { ...this.receivedHeaders, ...req.headers }
 
       const captureBodyStream = new Writable({
@@ -51,12 +53,15 @@ export default class FakeReportServer {
         return
       }
 
-      res.setHeader('Location', `http://localhost:${this.port}/s3`)
+      res.setHeader(
+        'Location',
+        `http://localhost:${this.port}/s3/${FAKE_IDENTIFIER}`
+      )
       res.status(202)
 
       res.end(`┌──────────────────────────────────────────────────────────────────────────┐
 │ View your Cucumber Report at:                                            │
-│ https://reports.cucumber.io/reports/f318d9ec-5a3d-4727-adec-bd7b69e2edd3 │
+│ https://reports.cucumber.io/reports/${FAKE_IDENTIFIER} │
 │                                                                          │
 │ This report will self-destruct in 24h unless it is claimed or deleted.   │
 └──────────────────────────────────────────────────────────────────────────┘


### PR DESCRIPTION
### 🤔 What's changed?

Added `setPublishedHandler` support code function so users can do something custom with the report URL once it's done.

The function name differs from what's suggested on the issue, but I went for consistency with existing stuff e.g. `setWorldConstructor`.

Very hacky implementation which shouldn't be merged until/unless we can do it a less hacky way (probably by changing the reports API a bit).

### ⚡️ What's your motivation? 

Fixes #1797.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Go over all the following points, and put an `x` in all the boxes that apply.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
