### PR TITLE
run: handle parse errors better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Fixed
 - Warn users who are on an unsupported node version ([#1922](https://github.com/cucumber/cucumber-js/pull/1922))
+- Allow formatters to finish when a Gherkin parse error is encountered ([#1404](https://github.com/cucumber/cucumber-js/issues/1404) [#1951](https://github.com/cucumber/cucumber-js/pull/1951))
 
 ### Changed
 - Switch from `colors` to `chalk` for terminal coloring ([#1895](https://github.com/cucumber/cucumber-js/pull/1895))

--- a/features/gherkin_parse_failure.feature
+++ b/features/gherkin_parse_failure.feature
@@ -4,17 +4,42 @@ Feature: Gherkin parse failure
   I want an error message that points me to the file
   So that I can quickly fix the issue and move on
 
-  Scenario:
+  Scenario: URI, line and column are called out in output
     Given a file named "features/a.feature" with:
       """
-      Feature: a feature name
-        Scenario: a scenario name
+      Feature: a feature name a
+        Scenario: a scenario name b
           Given a step
           Parse Error
       """
-    When I run cucumber-js
+    When I run cucumber-js with `--format message`
     Then it fails
     And the error output contains the text:
       """
       Parse error in "features/a.feature" (4:5)
       """
+
+  Scenario: All parseable sources and all parse errors are emitted
+    Given a file named "features/a.feature" with:
+      """
+      Parse Error
+      """
+    Given a file named "features/b.feature" with:
+      """
+      Feature: a feature name b
+        Scenario: a scenario name b
+          Given a step
+      """
+    Given a file named "features/c.feature" with:
+      """
+      Parse Error
+      """
+    When I run cucumber-js with `--format message`
+    Then it fails
+    And the output contains these messages:
+      | TYPE            | COUNT |
+      | source          | 3     |
+      | gherkinDocument | 1     |
+      | pickle          | 1     |
+      | parseError      | 2     |
+

--- a/features/gherkin_parse_failure.feature
+++ b/features/gherkin_parse_failure.feature
@@ -12,7 +12,7 @@ Feature: Gherkin parse failure
           Given a step
           Parse Error
       """
-    When I run cucumber-js with `--format message`
+    When I run cucumber-js
     Then it fails
     And the error output contains the text:
       """

--- a/features/gherkin_parse_failure.feature
+++ b/features/gherkin_parse_failure.feature
@@ -16,5 +16,5 @@ Feature: Gherkin parse failure
     Then it fails
     And the error output contains the text:
       """
-      Parse error in 'features/a.feature'
+      Parse error in "features/a.feature" (4:5)
       """

--- a/features/gherkin_parse_failure.feature
+++ b/features/gherkin_parse_failure.feature
@@ -7,8 +7,8 @@ Feature: Gherkin parse failure
   Scenario: URI, line and column are called out in output
     Given a file named "features/a.feature" with:
       """
-      Feature: a feature name a
-        Scenario: a scenario name b
+      Feature: a feature name
+        Scenario: a scenario name
           Given a step
           Parse Error
       """
@@ -26,8 +26,8 @@ Feature: Gherkin parse failure
       """
     Given a file named "features/b.feature" with:
       """
-      Feature: a feature name b
-        Scenario: a scenario name b
+      Feature: a feature name
+        Scenario: a scenario name
           Given a step
       """
     Given a file named "features/c.feature" with:

--- a/features/gherkin_parse_failure.feature
+++ b/features/gherkin_parse_failure.feature
@@ -36,7 +36,7 @@ Feature: Gherkin parse failure
       """
     When I run cucumber-js with `--format message`
     Then it fails
-    And the output contains these messages:
+    And the output contains these types and quantities of message:
       | TYPE            | COUNT |
       | source          | 3     |
       | gherkinDocument | 1     |

--- a/features/step_definitions/cli_steps.ts
+++ b/features/step_definitions/cli_steps.ts
@@ -119,7 +119,7 @@ Then('the output contains the text:', function (this: World, text: string) {
 })
 
 Then(
-  'the output contains these messages:',
+  'the output contains these types and quantities of message:',
   function (this: World, expectedMessages: DataTable) {
     const envelopes = this.lastRun.output
       .split('\n')

--- a/features/step_definitions/cli_steps.ts
+++ b/features/step_definitions/cli_steps.ts
@@ -119,6 +119,22 @@ Then('the output contains the text:', function (this: World, text: string) {
 })
 
 Then(
+  'the output contains these messages:',
+  function (this: World, expectedMessages: DataTable) {
+    const envelopes = this.lastRun.output
+      .split('\n')
+      .filter((line) => !!line)
+      .map((line) => JSON.parse(line))
+    expectedMessages.rows().forEach(([type, count]) => {
+      expect(envelopes.filter((envelope) => !!envelope[type])).to.have.length(
+        Number(count),
+        `Didn't find expected number of ${type} messages`
+      )
+    })
+  }
+)
+
+Then(
   'the output does not contain the text:',
   function (this: World, text: string) {
     const actualOutput = normalizeText(this.lastRun.output)

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -71,13 +71,6 @@ export async function parseGherkinMessageStream({
           result.push(pickleId)
         }
       }
-      if (doesHaveValue(envelope.parseError)) {
-        reject(
-          new Error(
-            `Parse error in '${envelope.parseError.source.uri}': ${envelope.parseError.message}`
-          )
-        )
-      }
     })
     gherkinMessageStream.on('end', () => {
       orderPickleIds(result, order, logger)


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would probide useful context. 👏🏻
-->

### 🤔 What's changed?

Don't throw immediately when a parse error is encountered by gherkin - instead ensure all the errors (as well as any valid sources) are emitted and do a normal cleanup and exit.

Avoided making this part of `parseGherkinMessageStream` because that's on the public API (for now) and I didn't want to make a breaking change to its signature unnecessarily.

### ⚡️ What's your motivation? 

Fixes #1404.

Previously we'd throw on the first parse error and formatters wouldn't have a chance to do anything with it before the process exited.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Go over all the following points, and put an `x` in all the boxes that apply.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
