### PR TITLE
chore: ensure typescript will see all types correctly

### DIFF
--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -1,0 +1,6 @@
+/*
+allows TypeScript to see `@cucumber/cucumber/api` where it doesn't yet support
+subpath exports, see <https://github.com/microsoft/TypeScript/issues/33079>
+ */
+
+export * from '../lib/api'

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
         "typescript": "4.6.2"
       },
       "engines": {
-        "node": "12 || 14 || 16 || 17"
+        "node": "12 || 14 || >=16"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -173,11 +173,13 @@
   "exports": {
     ".": {
       "import": "./lib/wrapper.mjs",
-      "require": "./lib/index.js"
+      "require": "./lib/index.js",
+      "types": "./lib/index.d.ts"
     },
     "./api": {
       "import": "./lib/api/wrapper.mjs",
-      "require": "./lib/api/index.js"
+      "require": "./lib/api/index.js",
+      "types": "./lib/api/index.d.ts"
     },
     "./lib/*": {
       "require": "./lib/*.js"
@@ -309,6 +311,7 @@
   },
   "license": "MIT",
   "files": [
+    "api/",
     "bin/",
     "lib/"
   ]

--- a/test-d/api.ts
+++ b/test-d/api.ts
@@ -1,0 +1,5 @@
+import { loadConfiguration, runCucumber } from '../api'
+
+// should allow api usage from /api subpath
+const { runConfiguration } = await loadConfiguration()
+const { success } = await runCucumber(runConfiguration)


### PR DESCRIPTION
### 🤔 What's changed?

TypeScript hasn't yet released support for subpath exports. When it does (should be soon-ish), [it will look for the "type" field on each export](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#packagejson-exports-imports-and-self-referencing) to see where the types are, so we want those values to be there ready.

At the same time, _because_ TypeScript [hasn't yet released](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#beta-delta) support for subpath exports, it can't see `@cucumber/cucumber/api`, so we just need to add a physical file that points it to the type declarations in `lib`. This is just needed for the TypeScript compiler - Node.js itself will handle the resultant `require('@cucumber/cucumber/api')` fine because it understands the subpath exports. Includes a tsd test which failed without this change.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, docuemntation etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

<!-- 
Edit this template here: 

https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md
-->
