### PR TITLE
fix: ensure absolute paths (as file urls) can be loaded for formatters, snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ## [Unreleased]
 ### Fixed
-- Allow `file://` URLs to be used as formatter/snippet paths in options
+- Allow `file://` URLs to be used as formatter/snippet paths in options ([#1963](https://github.com/cucumber/cucumber-js/pull/1963) [#1920](https://github.com/cucumber/cucumber-js/issues/1920))
 
 ## [8.0.0-rc.3] - 2022-03-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Allow `file://` URLs to be used as formatter/snippet paths in options
 
 ## [8.0.0-rc.3] - 2022-03-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ See [docs/profiles.md](./docs/profiles.md#using-another-file-than-cucumberjs) fo
 
 ### Changed
 - Relative paths for custom snippet syntaxes must begin with `.` ([#1640](https://github.com/cucumber/cucumber-js/issues/1640))
+- Absolute paths for custom formatters and snippet syntaxes must be a valid `file://` URL
 - Use performance timers for test case duration measurement.
 [#1793](https://github.com/cucumber/cucumber-js/pull/1793)
 

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -14,6 +14,7 @@ For each value you provide, `TYPE` should be one of:
 * The name of one of the built-in formatters (below) e.g. `progress`
 * A module/package name e.g. `@cucumber/pretty-formatter`
 * A relative path to a local formatter implementation e.g. `./my-customer-formatter.js`
+* An absolute path to a local formatter implementation in the form of a `file://` URL
 
 If `PATH` is supplied, the formatter prints to the given file, otherwise it prints to `stdout`.
 

--- a/src/api/convert_configuration_spec.ts
+++ b/src/api/convert_configuration_spec.ts
@@ -63,4 +63,28 @@ describe('convertConfiguration', () => {
       options: {},
     })
   })
+
+  it('should map formatters correctly when file:// urls are involved', async () => {
+    const result = await convertConfiguration(
+      {
+        ...DEFAULT_CONFIGURATION,
+        format: [
+          'file:///my/fancy/formatter',
+          'json:./report.json',
+          'html:./report.html',
+        ],
+      },
+      {}
+    )
+
+    expect(result.formats).to.eql({
+      stdout: 'file:///my/fancy/formatter',
+      files: {
+        './report.html': 'html',
+        './report.json': 'json',
+      },
+      publish: false,
+      options: {},
+    })
+  })
 })

--- a/src/configuration/option_splitter.ts
+++ b/src/configuration/option_splitter.ts
@@ -2,7 +2,7 @@ export const OptionSplitter = {
   split(option: string): string[] {
     option = option.replace(/"/g, '')
 
-    const parts = option.split(/([^A-Z]):(?!\\)/)
+    const parts = option.split(/((?:file){0}):(?!\\|\/\/)/)
 
     const result = parts.reduce((memo: string[], part: string, i: number) => {
       if (partNeedsRecombined(i)) {

--- a/src/configuration/option_splitter_spec.ts
+++ b/src/configuration/option_splitter_spec.ts
@@ -16,8 +16,8 @@ describe('OptionSplitter', () => {
     },
     {
       description: 'splits absolute unix paths',
-      input: '/custom/formatter:/formatter/output.txt',
-      output: ['/custom/formatter', '/formatter/output.txt'],
+      input: 'file:///custom/formatter:file:///formatter/output.txt',
+      output: ['file:///custom/formatter', 'file:///formatter/output.txt'],
     },
     {
       description: 'splits paths with quotes around them',
@@ -26,14 +26,17 @@ describe('OptionSplitter', () => {
     },
     {
       description: 'splits absolute windows paths',
-      input: 'C:\\custom\\formatter:C:\\formatter\\output.txt',
-      output: ['C:\\custom\\formatter', 'C:\\formatter\\output.txt'],
+      input: 'file://C:\\custom\\formatter:file://C:\\formatter\\output.txt',
+      output: [
+        'file://C:\\custom\\formatter',
+        'file://C:\\formatter\\output.txt',
+      ],
     },
     {
       description:
         'does not split a single absolute windows paths, adds empty string',
-      input: 'C:\\custom\\formatter',
-      output: ['C:\\custom\\formatter', ''],
+      input: 'file://C:\\custom\\formatter',
+      output: ['file://C:\\custom\\formatter', ''],
     },
   ]
 

--- a/src/formatter/builder_spec.ts
+++ b/src/formatter/builder_spec.ts
@@ -1,7 +1,22 @@
 import { expect } from 'chai'
 import FormatterBuilder from './builder'
+import { pathToFileURL } from 'url'
+import path from 'path'
 
 describe('custom class loading', () => {
+  it('should handle a file:// url', async () => {
+    const fileUrl = pathToFileURL(
+      path.resolve(__dirname, './fixtures/module_dot_exports.cjs')
+    ).toString()
+    const CustomClass = await FormatterBuilder.loadCustomClass(
+      'formatter',
+      fileUrl,
+      __dirname
+    )
+
+    expect(typeof CustomClass).to.eq('function')
+  })
+
   it('should handle cjs module.exports', async () => {
     const CustomClass = await FormatterBuilder.loadCustomClass(
       'formatter',


### PR DESCRIPTION
### 🤔 What's changed?

As part of the ESM support, we started loading formatters and snippet syntaxes with `await import()`. Unlike `require()`, paths you pass to `import()` have to be a valid URL, and for absolute paths that means using the `file://` scheme.

This PR:

- Adds a test to prove that classes can be successfully loaded based on a `file://` URL
- Fixes some code in the configuration module in order that `file://` URLs are correctly accounted for when parsing the `--format` option (which unfortunately uses `:` as the delimiter)
- Adds a note to the documentation on formatters.

This will also be called out in the migration guide via https://github.com/cucumber/cucumber-js/pull/1962

### ⚡️ What's your motivation? 

Fixes #1920.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

<!-- 
Edit this template here: 

https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md
-->
