### PR TITLE
export parallelCanAssignHelpers on main entry point

### DIFF
--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -46,9 +46,9 @@ setParallelCanAssign(function(pickleInQuestion, picklesInProgress) {
 For convenience, the following helpers exist to build a `canAssignFn`:
 
 ```javascript
-import { setParallelCanAssign } from '@cucumber/cucumber'
-import { atMostOnePicklePerTag } from '@cucumber/cucumber/lib/support_code_library_builder/parallel_can_assign_helpers'
+import { setParallelCanAssign, parallelCanAssignHelpers } from '@cucumber/cucumber'
 
+const { atMostOnePicklePerTag } = parallelCanAssignHelpers
 const myTagRule = atMostOnePicklePerTag(["@tag1", "@tag2"]);
 
 // Only one pickle with @tag1 can run at a time

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as formatterHelpers from './formatter/helpers'
+import * as parallelCanAssignHelpers from './support_code_library_builder/parallel_can_assign_helpers'
 import supportCodeLibraryBuilder from './support_code_library_builder'
 import * as messages from '@cucumber/messages'
 
@@ -50,6 +51,7 @@ export {
   IWorld,
   IWorldOptions,
 } from './support_code_library_builder/world'
+export { parallelCanAssignHelpers }
 
 export {
   ITestCaseHookParameter,

--- a/src/wrapper.mjs
+++ b/src/wrapper.mjs
@@ -35,8 +35,8 @@ export const setDefinitionFunctionWrapper = cucumber.setDefinitionFunctionWrappe
 export const setWorldConstructor = cucumber.setWorldConstructor
 export const Then = cucumber.Then
 export const When = cucumber.When
-
 export const World = cucumber.World
+export const parallelCanAssignHelpers = cucumber.parallelCanAssignHelpers
 
 export const wrapPromiseWithTimeout = cucumber.wrapPromiseWithTimeout
 

--- a/test-d/parallel.ts
+++ b/test-d/parallel.ts
@@ -1,0 +1,5 @@
+import { parallelCanAssignHelpers, setParallelCanAssign } from '../'
+
+const { atMostOnePicklePerTag } = parallelCanAssignHelpers
+
+setParallelCanAssign(atMostOnePicklePerTag(['@tag1', '@tag2']))


### PR DESCRIPTION

### 🤔 What's changed?

Adds `parallelCanAssignHelpers` to main entry point.

### ⚡️ What's your motivation? 

Deep requires are not going to work forever, if we want things to be usable by consumers we should explicitly export them (and then the rest is free for us to refactor).

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

<!-- 
Edit this template here: 

https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md
-->

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
