### PR TITLE
fix: try require first for custom formatters so transpiled ones work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 ## [Unreleased]
 ### Fixed
 - Allow `file://` URLs to be used as formatter/snippet paths in options ([#1963](https://github.com/cucumber/cucumber-js/pull/1963) [#1920](https://github.com/cucumber/cucumber-js/issues/1920))
+- Allow custom formatters to rely on `--require-module` transpilers ([#1985](https://github.com/cucumber/cucumber-js/pull/1985))
 
 ### Changed
 - Emit a warning when using a Node.js version that's untested with Cucumber ([#1959](https://github.com/cucumber/cucumber-js/pull/1959))

--- a/features/custom_formatter.feature
+++ b/features/custom_formatter.feature
@@ -139,6 +139,7 @@ Feature: custom formatter
     Then it passes
     Examples:
       | EXT  | IMPORT_STATEMENT                                  | EXPORT_STATEMENT                  |
+      | .ts  | import {Formatter} from '@cucumber/cucumber'      | export default CustomFormatter    |
       | .mjs | import {Formatter} from '@cucumber/cucumber'      | export default CustomFormatter    |
       | .js  | const {Formatter} = require('@cucumber/cucumber') | module.exports = CustomFormatter  |
       | .js  | const {Formatter} = require('@cucumber/cucumber') | exports.default = CustomFormatter |

--- a/src/formatter/builder.ts
+++ b/src/formatter/builder.ts
@@ -142,11 +142,6 @@ const FormatterBuilder = {
       typeof ImportedCode.default === 'function'
     ) {
       return ImportedCode.default
-    } else if (
-      typeof ImportedCode.default === 'object' &&
-      typeof ImportedCode.default.default === 'function'
-    ) {
-      return ImportedCode.default.default
     }
     return null
   },

--- a/src/formatter/builder.ts
+++ b/src/formatter/builder.ts
@@ -13,7 +13,7 @@ import { EventEmitter } from 'events'
 import EventDataCollector from './helpers/event_data_collector'
 import { Writable as WritableStream } from 'stream'
 import { SnippetInterface } from './step_definition_snippet_builder/snippet_syntax'
-import { pathToFileURL } from 'url'
+import { fileURLToPath, pathToFileURL } from 'url'
 import Formatters from './helpers/formatters'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { importer } = require('../importer')
@@ -97,9 +97,13 @@ const FormatterBuilder = {
     descriptor: string,
     cwd: string
   ) {
-    let CustomClass = descriptor.startsWith(`.`)
-      ? await importer(pathToFileURL(path.resolve(cwd, descriptor)))
-      : await importer(descriptor)
+    let normalised: URL | string = descriptor
+    if (descriptor.startsWith('.')) {
+      normalised = pathToFileURL(path.resolve(cwd, descriptor))
+    } else if (descriptor.startsWith('file://')) {
+      normalised = new URL(descriptor)
+    }
+    let CustomClass = await FormatterBuilder.loadFile(normalised)
     CustomClass = FormatterBuilder.resolveConstructor(CustomClass)
     if (doesHaveValue(CustomClass)) {
       return CustomClass
@@ -108,6 +112,23 @@ const FormatterBuilder = {
         `Custom ${type} (${descriptor}) does not export a function/class`
       )
     }
+  },
+
+  async loadFile(urlOrName: URL | string) {
+    let result
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      result = require(typeof urlOrName === 'string'
+        ? urlOrName
+        : fileURLToPath(urlOrName))
+    } catch (error) {
+      if (error.code === 'ERR_REQUIRE_ESM') {
+        result = await importer(urlOrName)
+      } else {
+        throw error
+      }
+    }
+    return result
   },
 
   resolveConstructor(ImportedCode: any) {

--- a/src/formatter/builder_spec.ts
+++ b/src/formatter/builder_spec.ts
@@ -4,46 +4,32 @@ import { pathToFileURL } from 'url'
 import path from 'path'
 
 describe('custom class loading', () => {
-  it('should handle a file:// url', async () => {
-    const fileUrl = pathToFileURL(
-      path.resolve(__dirname, './fixtures/module_dot_exports.cjs')
-    ).toString()
-    const CustomClass = await FormatterBuilder.loadCustomClass(
-      'formatter',
-      fileUrl,
-      __dirname
-    )
+  ;['esm.mjs', 'exports_dot_default.cjs', 'module_dot_exports.cjs'].forEach(
+    (filename) => {
+      describe(filename, () => {
+        it('should handle a relative path', async () => {
+          const CustomClass = await FormatterBuilder.loadCustomClass(
+            'formatter',
+            `./fixtures/${filename}`,
+            __dirname
+          )
 
-    expect(typeof CustomClass).to.eq('function')
-  })
+          expect(typeof CustomClass).to.eq('function')
+        })
 
-  it('should handle cjs module.exports', async () => {
-    const CustomClass = await FormatterBuilder.loadCustomClass(
-      'formatter',
-      './fixtures/module_dot_exports.cjs',
-      __dirname
-    )
+        it('should handle a file:// url', async () => {
+          const fileUrl = pathToFileURL(
+            path.resolve(__dirname, `./fixtures/${filename}`)
+          ).toString()
+          const CustomClass = await FormatterBuilder.loadCustomClass(
+            'formatter',
+            fileUrl,
+            __dirname
+          )
 
-    expect(typeof CustomClass).to.eq('function')
-  })
-
-  it('should handle cjs exports.default', async () => {
-    const CustomClass = await FormatterBuilder.loadCustomClass(
-      'formatter',
-      './fixtures/exports_dot_default.cjs',
-      __dirname
-    )
-
-    expect(typeof CustomClass).to.eq('function')
-  })
-
-  it('should handle esm default export', async () => {
-    const CustomClass = await FormatterBuilder.loadCustomClass(
-      'formatter',
-      './fixtures/esm.mjs',
-      __dirname
-    )
-
-    expect(typeof CustomClass).to.eq('function')
-  })
+          expect(typeof CustomClass).to.eq('function')
+        })
+      })
+    }
+  )
 })

--- a/src/formatter/builder_spec.ts
+++ b/src/formatter/builder_spec.ts
@@ -4,32 +4,36 @@ import { pathToFileURL } from 'url'
 import path from 'path'
 
 describe('custom class loading', () => {
-  ;['esm.mjs', 'exports_dot_default.cjs', 'module_dot_exports.cjs'].forEach(
-    (filename) => {
-      describe(filename, () => {
-        it('should handle a relative path', async () => {
-          const CustomClass = await FormatterBuilder.loadCustomClass(
-            'formatter',
-            `./fixtures/${filename}`,
-            __dirname
-          )
+  const varieties = [
+    'esm.mjs',
+    'exports_dot_default.cjs',
+    'module_dot_exports.cjs',
+    'typescript.ts',
+  ]
+  varieties.forEach((filename) => {
+    describe(filename, () => {
+      it('should handle a relative path', async () => {
+        const CustomClass = await FormatterBuilder.loadCustomClass(
+          'formatter',
+          `./fixtures/${filename}`,
+          __dirname
+        )
 
-          expect(typeof CustomClass).to.eq('function')
-        })
-
-        it('should handle a file:// url', async () => {
-          const fileUrl = pathToFileURL(
-            path.resolve(__dirname, `./fixtures/${filename}`)
-          ).toString()
-          const CustomClass = await FormatterBuilder.loadCustomClass(
-            'formatter',
-            fileUrl,
-            __dirname
-          )
-
-          expect(typeof CustomClass).to.eq('function')
-        })
+        expect(typeof CustomClass).to.eq('function')
       })
-    }
-  )
+
+      it('should handle a file:// url', async () => {
+        const fileUrl = pathToFileURL(
+          path.resolve(__dirname, `./fixtures/${filename}`)
+        ).toString()
+        const CustomClass = await FormatterBuilder.loadCustomClass(
+          'formatter',
+          fileUrl,
+          __dirname
+        )
+
+        expect(typeof CustomClass).to.eq('function')
+      })
+    })
+  })
 })

--- a/src/formatter/fixtures/typescript.ts
+++ b/src/formatter/fixtures/typescript.ts
@@ -1,0 +1,1 @@
+export default class Formatter {}


### PR DESCRIPTION

### 🤔 What's changed?

Tweak the loading of custom formatters and snippet syntaxes so we try `require()` first and then try `import()` if it turns out the target file is a module (ESM).

This mirrors how we are also now loading the configuration file.



### ⚡️ What's your motivation? 

https://cucumberbdd.slack.com/archives/C6QJ6N695/p1649071066867509

An edge case arguably, but some users in the wild have formatters in their project written in TypeScript (or something else that transpiles) and take advantage of the fact that `--require-module` means their transpiler has registered by the time the formatter is loaded.

This is quite cool and something we should avoid breaking if possible. We broke it with earlier RCs because we switched to exclusively using `import()` to load custom formatters, which doesn't yet account for just-in-time transpiled code.

In 1 or 2 major releases (when loader hooks are a solved problem) we'll ditch the `require()` bit and just use `import()` which will simplify things a lot but for now this works reliably and is well covered by tests.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
