### PR TITLE
Version banner warning on docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,10 @@
+_**You are reading the documentation in the `main` development branch, which might contain some unreleased features. See documentation for [older versions](https://github.com/cucumber/cucumber-js/blob/main/docs/older_versions.md) if you need it.**_
+
+----
+
 # Configuration
 
-# Files
+## Files
 
 You can keep your configuration in a file. Cucumber will look for one of these files in the root of your project, and use the first one it finds:
 


### PR DESCRIPTION
### 🤔 What's changed?

* Added a warning banner at the top of the config docs

<img width="1625" alt="Screenshot 2022-04-07 at 7 52 10 AM" src="https://user-images.githubusercontent.com/19260/162228035-98274a61-8545-4fc6-aea9-2809d61ca1c1.png">

### ⚡️ What's your motivation? 

Help avoid confusion like https://github.com/cucumber/cucumber-js/issues/1986

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Is this useful? Should we roll this out across every page?

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
