### PR TITLE
snippets: correctly escape backslashes in generated expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Correctly escape backslashes in generated expressions for snippets ([#1324](https://github.com/cucumber/cucumber-js/issues/1324) [#1995](https://github.com/cucumber/cucumber-js/pull/1995))
 
 ## [8.0.0] - 2022-04-06
 ### Changed

--- a/features/step_definition_snippets.feature
+++ b/features/step_definition_snippets.feature
@@ -70,3 +70,20 @@ Feature: step definition snippets
         return 'pending';
       });
       """
+
+  Scenario: a step resulting in special characters in the expression
+    Given a file named "features/number.feature" with:
+      """
+      Feature: a feature
+        Scenario: a scenario
+          Given a person's (secret) desires
+      """
+    When I run cucumber-js
+    Then it fails
+    And the output contains the text:
+      """
+      Given('a person\'s \\(secret) desires', function () {
+        // Write code here that turns the phrase above into concrete actions
+        return 'pending';
+      });
+      """

--- a/src/formatter/step_definition_snippet_builder/javascript_snippet_syntax.ts
+++ b/src/formatter/step_definition_snippet_builder/javascript_snippet_syntax.ts
@@ -1,3 +1,4 @@
+import { GeneratedExpression } from '@cucumber/cucumber-expressions'
 import {
   ISnippetSnytax,
   ISnippetSyntaxBuildOptions,
@@ -43,9 +44,8 @@ export default class JavaScriptSnippetSyntax implements ISnippetSnytax {
         if (this.snippetInterface === SnippetInterface.Callback) {
           allParameterNames.push(CALLBACK_NAME)
         }
-        return `${prefix + functionName}('${generatedExpression.source.replace(
-          /'/g,
-          "\\'"
+        return `${prefix + functionName}('${this.escapeSpecialCharacters(
+          generatedExpression
         )}', ${functionKeyword}(${allParameterNames.join(', ')}) {\n`
       }
     )
@@ -55,5 +55,14 @@ export default class JavaScriptSnippetSyntax implements ISnippetSnytax {
       `  ${implementation}\n` +
       '});'
     )
+  }
+
+  private escapeSpecialCharacters(generatedExpression: GeneratedExpression) {
+    let source = generatedExpression.source
+    // double up any backslashes because we're in a javascript string
+    source = source.replace(/\\/g, '\\\\')
+    // escape any single quotes because that's our quote delimiter
+    source = source.replace(/'/g, "\\'")
+    return source
   }
 }

--- a/src/formatter/step_definition_snippet_builder/javascript_snippet_syntax_spec.ts
+++ b/src/formatter/step_definition_snippet_builder/javascript_snippet_syntax_spec.ts
@@ -145,6 +145,33 @@ describe('JavascriptSnippetSyntax', () => {
       })
     })
 
+    describe('pattern contains escapes', () => {
+      it('returns the proper snippet', () => {
+        // Arrange
+        const syntax = new JavascriptSnippetSyntax(SnippetInterface.Synchronous)
+        const buildOptions: ISnippetSyntaxBuildOptions = {
+          comment: 'comment',
+          functionName: 'functionName',
+          generatedExpressions: generateExpressions(
+            'the user (with permissions) executes the action'
+          ),
+          stepParameterNames: [],
+        }
+
+        // Act
+        const result = syntax.build(buildOptions)
+
+        // Assert
+        expect(result).to.eql(
+          reindent(`
+            functionName('the user \\\\(with permissions) executes the action', function () {
+              // comment
+              return 'pending';
+            });`)
+        )
+      })
+    })
+
     describe('multiple patterns', () => {
       it('returns the snippet with the other choices commented out', function () {
         // Arrange


### PR DESCRIPTION
### 🤔 What's changed?

When a generated cucumber expression contained a backslash (in order to escape, say, a parenthesis) the backslash would previously be treated as a noop escape in the context of a JavaScript string. Now we add another backslash to correctly escape it.

### ⚡️ What's your motivation? 

Fixes #1324.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
