### PR TITLE
fix: readd old bin alias for backwards compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 ### Added
 - Explicit support for Node.js 18 ([#2007](https://github.com/cucumber/cucumber-js/pull/2007))
 
+### Fixed
+- Re-add `cucumber-js` bin file for backwards compatibility ([#2008](https://github.com/cucumber/cucumber-js/pull/2008))
+
 ## [8.1.1] - 2022-04-20
 ### Fixed
 - Capture dependency on `@cucumber/message-streams` to satisfy peer requirement from `@cucumber/gherkin-streams` ([#2006](https://github.com/cucumber/cucumber-js/pull/2006))

--- a/bin/cucumber-js
+++ b/bin/cucumber-js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../lib/cli/run.js').default();


### PR DESCRIPTION
### 🤔 What's changed?

Re-add the original `cucumber-js` bin file alongside the `cucumber.js` one (which was renamed from the former in https://github.com/cucumber/cucumber-js/pull/1993).

### ⚡️ What's your motivation? 

Backwards compatibility - these files should not be referenced directly, but it happens in the wild anyway.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
