### PR TITLE
fix return type of step hook function to allow async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Fix return type of step hook function to allow async functions ([#2038](https://github.com/cucumber/cucumber-js/pull/2038))
 
 ## [8.2.0] - 2022-05-05
 ### Changed

--- a/features/support/hooks.ts
+++ b/features/support/hooks.ts
@@ -1,11 +1,10 @@
-import { After, Before, formatterHelpers } from '../../'
+import { After, Before, formatterHelpers, ITestCaseHookParameter } from '../../'
 import fs from 'fs'
 import fsExtra from 'fs-extra'
 import path from 'path'
 import tmp from 'tmp'
 import { doesHaveValue } from '../../src/value_checker'
 import { World } from './world'
-import { ITestCaseHookParameter } from '../../src/support_code_library_builder/types'
 import { warnUserAboutEnablingDeveloperMode } from './warn_user_about_enabling_developer_mode'
 
 const projectPath = path.join(__dirname, '..', '..')

--- a/src/support_code_library_builder/types.ts
+++ b/src/support_code_library_builder/types.ts
@@ -35,7 +35,7 @@ export type TestCaseHookFunction<WorldType> = (
 export type TestStepHookFunction<WorldType> = (
   this: WorldType,
   arg: ITestStepHookParameter
-) => void
+) => any | Promise<any>
 
 export type TestStepFunction<WorldType> = (
   this: WorldType,

--- a/test-d/hooks.ts
+++ b/test-d/hooks.ts
@@ -17,6 +17,14 @@ After(function () {})
 BeforeStep(function () {})
 AfterStep(function () {})
 
+// should allow hook functions to be async
+BeforeAll(async function () {})
+AfterAll(async function () {})
+Before(async function () {})
+After(async function () {})
+BeforeStep(async function () {})
+AfterStep(async function () {})
+
 // should allow typed arguments in hooks
 Before(function (param: ITestCaseHookParameter) {})
 After(function (param: ITestCaseHookParameter) {})


### PR DESCRIPTION
### 🤔 What's changed?

Fix return type of step hook function to allow async, to be more accurate and prevent compile/lint errors for users.

### ⚡️ What's your motivation? 

Fixes #2037.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
