### PR TITLE
export IConfiguration interface for API users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Export `IConfiguration` type on API entry point ([#2064](https://github.com/cucumber/cucumber-js/pull/2064))
 
 ## [8.3.0] - 2022-06-11
 ### Added

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,6 +5,7 @@
  * @packageDocumentation
  */
 
+export { IConfiguration } from '../configuration'
 export * from './load_configuration'
 export * from './load_sources'
 export * from './load_support'

--- a/test-d/api.ts
+++ b/test-d/api.ts
@@ -1,5 +1,8 @@
-import { loadConfiguration, runCucumber } from '../api'
+import { IConfiguration, loadConfiguration, runCucumber } from '../api'
 
 // should allow api usage from /api subpath
-const { runConfiguration } = await loadConfiguration()
+const provided: Partial<IConfiguration> = {
+  paths: ['features/foo.feature'],
+}
+const { runConfiguration } = await loadConfiguration({ provided })
 const { success } = await runCucumber(runConfiguration)


### PR DESCRIPTION
### 🤔 What's changed?

Export `IConfiguration` on the API entry point.

### ⚡️ What's your motivation? 

So API users can type the configuration objects they compose and pass in to the `loadConfiguration` function. I'm doing this now and it's painful without the typing.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
