### PR TITLE
Update links to cucumber expressions documentation

### DIFF
--- a/docs/custom_snippet_syntaxes.md
+++ b/docs/custom_snippet_syntaxes.md
@@ -7,7 +7,7 @@
     * An object with the following keys:
       * `comment`: a comment to be placed at the top of the function
       * `functionName`: the function name to use for the snippet
-      * `generatedExpressions`: from [cucumber-expressions](https://github.com/cucumber/cucumber-expressions-javascript). In most cases will be an array of length 1. But there may be multiple. If multiple, please follow the behavior of the javascript syntax in presenting each of them. See the "multiple patterns" test in this [file](/src/formatter/step_definition_snippet_builder/javascript_snippet_syntax_spec.ts).
+      * `generatedExpressions`: from [cucumber-expressions](https://github.com/cucumber/cucumber-expressions#readme). In most cases will be an array of length 1. But there may be multiple. If multiple, please follow the behavior of the javascript syntax in presenting each of them. See the "multiple patterns" test in this [file](/src/formatter/step_definition_snippet_builder/javascript_snippet_syntax_spec.ts).
       * `stepParameterNames`: names for the doc string or data table parameter when applicable. Theses should be appended to the parameter names of each generated expressions.
 * Please add the keywords `cucumber` and `snippets` to your package, so it can easily be found by searching [npm](https://www.npmjs.com/search?q=cucumber+snippets).
 * Please open an issue if you would like more information.

--- a/docs/support_files/step_definitions.md
+++ b/docs/support_files/step_definitions.md
@@ -9,7 +9,7 @@ Cucumber supports two types of expressions:
 
 ## Cucumber expressions
 
-[Full docs.](https://cucumber.io/docs/cucumber/cucumber-expressions/)
+[Full docs.](https://github.com/cucumber/cucumber-expressions#readme)
 
 Gherkin:
 ```gherkin


### PR DESCRIPTION
One link points to https://cucumber.io/docs/cucumber/cucumber-expressions/ which says:

> The [Cucumber Expressions Docs](https://github.com/cucumber/cucumber-expressions#readme) have been moved to GitHub. 

So I thought we could go straight to the correct link. The other link was simply 404'ing.