### PR TITLE
docs: add info about testing custom formatters

### DIFF
--- a/docs/custom_formatters.md
+++ b/docs/custom_formatters.md
@@ -24,6 +24,12 @@ The base `Formatter` does very little aside from saving some of the options on t
 
 If there is any other formatter functionality you would like access to, please create an [issue](https://github.com/cucumber/cucumber-js).
 
+## Testing
+
+To test your formatter with a good degree of confidence, you probably want to run Cucumber with a predefined set of features and support code, and then assert that the output from your formatter is what you'd expect.
+
+We take this approach with the official [`@cucumber/pretty-formatter`](https://github.com/cucumber/cucumber-js-pretty-formatter), using the [JavaScript API](./javascript_api.md) to run Cucumber in-process and grabbing the result from its `stdout` to compare against a fixture file. Take a look at [the `run`  helper function](https://github.com/cucumber/cucumber-js-pretty-formatter/blob/main/test/exec.ts#L19) for some hints on how to go about this.
+
 ## Distribution
 
 If you want to share your formatter with other users, [publish it as an npm package](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry) and make sure your formatter class is the default export of the entry point defined in `package.json` - that way users will be able to just reference it by the package name when running cucumber-js, once they've added it as a dependency.


### PR DESCRIPTION
### 🤔 What's changed?

Add documentation about testing custom formatters, and link to the pretty formatter as a good example.

### ⚡️ What's your motivation? 

Fixes #1545.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
