### PR TITLE
fix: ensure durations are integers in json formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -8,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Ensure durations are integers in JSON formatter ([#2094](https://github.com/cucumber/cucumber-js/pull/2094))
 
 ## [8.5.0] - 2022-07-19
 ### Changed

--- a/src/formatter/helpers/duration_helpers.ts
+++ b/src/formatter/helpers/duration_helpers.ts
@@ -1,0 +1,7 @@
+import { Duration } from '@cucumber/messages'
+
+const NANOS_IN_SECOND = 1_000_000_000
+
+export function durationToNanoseconds(duration: Duration): number {
+  return Math.floor(duration.seconds * NANOS_IN_SECOND + duration.nanos)
+}

--- a/src/formatter/helpers/duration_helpers_spec.ts
+++ b/src/formatter/helpers/duration_helpers_spec.ts
@@ -1,0 +1,18 @@
+import { expect } from 'chai'
+import { durationToNanoseconds } from './duration_helpers'
+
+describe('duration helpers', () => {
+  describe('durationToNanoseconds', () => {
+    it('should convert under a second', () => {
+      expect(durationToNanoseconds({ seconds: 0, nanos: 257344166 })).to.eq(
+        257344166
+      )
+    })
+
+    it('should convert over a second', () => {
+      expect(durationToNanoseconds({ seconds: 2, nanos: 1043459 })).to.eq(
+        2001043459
+      )
+    })
+  })
+})

--- a/src/formatter/json_formatter.ts
+++ b/src/formatter/json_formatter.ts
@@ -8,6 +8,7 @@ import {
 import { ITestCaseAttempt } from './helpers/event_data_collector'
 import { doesHaveValue, doesNotHaveValue } from '../value_checker'
 import { parseStepArgument } from '../step_arguments'
+import { durationToNanoseconds } from './helpers/duration_helpers'
 
 const { getGherkinStepMap, getGherkinScenarioMap } = GherkinDocumentParser
 
@@ -280,10 +281,7 @@ export default class JsonFormatter extends Formatter {
       status: messages.TestStepResultStatus[status].toLowerCase(),
     }
     if (doesHaveValue(testStepResult.duration)) {
-      data.result.duration =
-        messages.TimeConversion.durationToMilliseconds(
-          testStepResult.duration
-        ) * 1000000
+      data.result.duration = durationToNanoseconds(testStepResult.duration)
     }
     if (
       status === messages.TestStepResultStatus.FAILED &&


### PR DESCRIPTION
### 🤔 What's changed?

Ensure the nanoseconds duration in the JSON formatter is an integer.

The way we derived a single nanoseconds number from a duration object was prone to rounding errors:

```js
(1043459 / 1000000) * 1000000
// 1043458.9999999999
```

We now do it a slightly different way and `Math.floor` the result to be sure. This is consistent with what some of the helpers from messages do (and why the message formatter was not affected even though we were providing higher resolution timestamps since 8.0.0).

### ⚡️ What's your motivation? 

Fixes #2086.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
