### PR TITLE
fix: add IMethods interface for use in time module functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 ## [Unreleased]
 ### Added
 - `IMethods` interface for use in `getTimestamp`, `durationBetweenTimestamps`, and `wrapPromiseWithTimeout` functions and `methods` in `time` module instead of explicit `any` ([#2111](https://github.com/cucumber/cucumber-js/pull/2111))
-
-### Added
 - `IPublishConfig` interface for use in return type of `makePublishConfig` instead of explicit `any` ([#2106](https://github.com/cucumber/cucumber-js/pull/2106))
 
 ## [8.5.1] - 2022-07-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ## [Unreleased]
 ### Added
-- `IPublishConfig` interface for use in return type of `makePublishConfig` instead of explicit `any` ([#1648](https://github.com/cucumber/cucumber-js/pull/2106))
+- `IMethods` interface for use in `getTimestamp`, `durationBetweenTimestamps`, and `wrapPromiseWithTimeout` functions and `methods` in `time` module instead of explicit `any` ([#2111](https://github.com/cucumber/cucumber-js/pull/2111))
+
+### Added
+- `IPublishConfig` interface for use in return type of `makePublishConfig` instead of explicit `any` ([#2106](https://github.com/cucumber/cucumber-js/pull/2106))
 
 ## [8.5.1] - 2022-07-28
 ### Fixed

--- a/src/time.ts
+++ b/src/time.ts
@@ -1,9 +1,16 @@
 import { performance } from 'perf_hooks'
 import * as messages from '@cucumber/messages'
+import { FakeClock, GlobalTimers, TimerId } from '@sinonjs/fake-timers'
 
 let previousTimestamp: number
 
-const methods: any = {
+interface IMethods extends GlobalTimers<TimerId> {
+  beginTiming: () => void
+  endTiming: () => number
+  performance: FakeClock<TimerId>['performance']
+}
+
+const methods: Partial<IMethods> = {
   beginTiming() {
     previousTimestamp = getTimestamp()
   },
@@ -44,7 +51,7 @@ export async function wrapPromiseWithTimeout<T>(
   timeoutInMilliseconds: number,
   timeoutMessage: string = ''
 ): Promise<T> {
-  let timeoutId: NodeJS.Timeout
+  let timeoutId: TimerId
   if (timeoutMessage === '') {
     timeoutMessage = `Action did not complete within ${timeoutInMilliseconds} milliseconds`
   }


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

This PR does the following,
- defines a new interface `IMethods` in `time.ts` extending from `GlobalTimers`
- explicitly defines the possible return values to `beginTiming` and `endTiming` in `src/time.ts`
  - `void` for `beginTiming`
  - `number` for `endTiming`
- updates the `methods` object to make use of `IMethods` interface 
- updates `timeoutId` to use `TimerId` instead of `NodeJS.Timeout`
- a minor fix on link from a previous related PR

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

The motivation for this update/change is the incremental completion of #1648 in small manageable PRs.
I imagine this will be one of multiple PRs to replace explicit `any` with a type.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

- I would love feedback on this approach to removing `any` and defining an interface for `strictly typing`, is this the recommended approach for this project?
- - I based this approach on looking at how other return types were defined and where those definitions were placed
- - Additionally,

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.


----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
