### PR TITLE
default stderr if not provided to Cli ctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Default `stderr` if not provided to `Cli` constructor ([#2138](https://github.com/cucumber/cucumber-js/pull/2138))
 
 ## [8.5.2] - 2022-08-24
 ### Added

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,13 +21,13 @@ export default class Cli {
     argv,
     cwd,
     stdout,
-    stderr,
+    stderr = process.stderr,
     env,
   }: {
     argv: string[]
     cwd: string
     stdout: IFormatterStream
-    stderr: IFormatterStream
+    stderr?: IFormatterStream
     env: NodeJS.ProcessEnv
   }) {
     this.argv = argv


### PR DESCRIPTION
### 🤔 What's changed?

In `Cli`, default the `stderr` property of the constructor object to `process.stderr` if it's not defined - making the property effectively optional for consumers.

### ⚡️ What's your motivation? 

We introduced this property in https://github.com/cucumber/cucumber-js/pull/2137 which was effectively a breaking change for people who use the `Cli` class for framework integrations. It managed to fly under the radar until https://github.com/cucumber/cucumber-js/pull/2092/files#diff-7f71b0d311e14868f853f726912b222ac5e2aee58d985f1758d6b8f5e19c4c5c (8.5.2) where there'll be an error if it's missing. This affects `nightwatch` for example (see #2137).

This class will shortly be deprecated in favour of `runCucumber` et al, but in the meantime it should be stable.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
