### PR TITLE
rework time interfaces to avoid using sinon types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 ### Added
 - Debug logging capability to help diagnose configuration issues (see [documentation](./docs/debugging.md)) ([#2120](https://github.com/cucumber/cucumber-js/pull/2120))
 
+### Fixed
+- Rework time interfaces to avoid using sinon types ([#2142](https://github.com/cucumber/cucumber-js/pull/2142))
+
 ## [8.5.3] - 2022-09-10
 ### Fixed
 - Default `stderr` if not provided to `Cli` constructor ([#2138](https://github.com/cucumber/cucumber-js/pull/2138))

--- a/src/time.ts
+++ b/src/time.ts
@@ -1,16 +1,25 @@
 import { performance } from 'perf_hooks'
 import * as messages from '@cucumber/messages'
-import { FakeClock, GlobalTimers, TimerId } from '@sinonjs/fake-timers'
 
 let previousTimestamp: number
 
-interface IMethods extends GlobalTimers<TimerId> {
-  beginTiming: () => void
-  endTiming: () => number
-  performance: FakeClock<TimerId>['performance']
+interface ProtectedTimingBuiltins {
+  clearImmediate: typeof clearImmediate
+  clearInterval: typeof clearInterval
+  clearTimeout: typeof clearTimeout
+  Date: typeof Date
+  setImmediate: typeof setImmediate
+  setInterval: typeof setInterval
+  setTimeout: typeof setTimeout
+  performance: typeof performance
 }
 
-const methods: Partial<IMethods> = {
+interface CustomTimingFunctions {
+  beginTiming: () => void
+  endTiming: () => number
+}
+
+const methods: Partial<ProtectedTimingBuiltins & CustomTimingFunctions> = {
   beginTiming() {
     previousTimestamp = getTimestamp()
   },
@@ -51,7 +60,7 @@ export async function wrapPromiseWithTimeout<T>(
   timeoutInMilliseconds: number,
   timeoutMessage: string = ''
 ): Promise<T> {
-  let timeoutId: TimerId
+  let timeoutId: ReturnType<typeof setTimeout>
   if (timeoutMessage === '') {
     timeoutMessage = `Action did not complete within ${timeoutInMilliseconds} milliseconds`
   }


### PR DESCRIPTION
### 🤔 What's changed?

Rework time interfaces to avoid using sinon types in production code.

### ⚡️ What's your motivation? 

Fixes #2141. We shouldn't have a non-dev dependency, explicit or otherwise, on a test library's types.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
