### PR TITLE
fix: include original coordinates in support code library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Include original coordinates in `loadSupport` result ([#2197](https://github.com/cucumber/cucumber-js/pull/2197))
 
 ## [8.9.0] - 2022-11-24
 ### Added

--- a/src/api/load_support_spec.ts
+++ b/src/api/load_support_spec.ts
@@ -1,43 +1,9 @@
-import { IdGenerator } from '@cucumber/messages'
 import { IRunEnvironment } from './types'
 import path from 'path'
-import fs from 'mz/fs'
-import { reindent } from 'reindent-template-literals'
-import { PassThrough } from 'stream'
 import { loadSupport } from './load_support'
 import { loadConfiguration } from './load_configuration'
 import { expect } from 'chai'
-
-const newId = IdGenerator.uuid()
-
-async function setupEnvironment(): Promise<Partial<IRunEnvironment>> {
-  const cwd = path.join(__dirname, '..', '..', 'tmp', `loadSupport_${newId()}`)
-  await fs.mkdir(path.join(cwd, 'features'), { recursive: true })
-  await fs.writeFile(
-    path.join(cwd, 'features', 'test.feature'),
-    reindent(`Feature: test fixture
-      Scenario: one
-        Given a step
-        Then another step`)
-  )
-  await fs.writeFile(
-    path.join(cwd, 'features', 'steps.ts'),
-    reindent(`import { Given, Then } from '../../../src'
-    Given('a step', function () {})
-    Then('another step', function () {})`)
-  )
-  await fs.writeFile(
-    path.join(cwd, 'cucumber.mjs'),
-    `export default {paths: ['features/test.feature'], requireModule: ['ts-node/register'], require: ['features/steps.ts']}`
-  )
-  const stdout = new PassThrough()
-  return { cwd, stdout }
-}
-
-async function teardownEnvironment(environment: IRunEnvironment) {
-  await fs.rmdir(environment.cwd, { recursive: true })
-  environment.stdout.end()
-}
+import { setupEnvironment, teardownEnvironment } from './test_helpers'
 
 describe('loadSupport', () => {
   let environment: IRunEnvironment

--- a/src/api/load_support_spec.ts
+++ b/src/api/load_support_spec.ts
@@ -1,0 +1,63 @@
+import { IdGenerator } from "@cucumber/messages";
+import { IRunEnvironment  } from "./types";
+import path from "path";
+import fs from "mz/fs";
+import { reindent } from "reindent-template-literals";
+import { PassThrough } from "stream";
+import { loadSupport } from "./load_support";
+import { loadConfiguration } from "./load_configuration";
+import { expect } from "chai";
+
+const newId = IdGenerator.uuid()
+
+async function setupEnvironment(): Promise<Partial<IRunEnvironment>> {
+  const cwd = path.join(__dirname, '..', '..', 'tmp', `loadSupport_${newId()}`)
+  await fs.mkdir(path.join(cwd, 'features'), { recursive: true })
+  await fs.writeFile(
+    path.join(cwd, 'features', 'test.feature'),
+    reindent(`Feature: test fixture
+      Scenario: one
+        Given a step
+        Then another step`)
+  )
+  await fs.writeFile(
+    path.join(cwd, 'features', 'steps.ts'),
+    reindent(`import { Given, Then } from '../../../src'
+    Given('a step', function () {})
+    Then('another step', function () {})`)
+  )
+  await fs.writeFile(
+    path.join(cwd, 'cucumber.mjs'),
+    `export default {paths: ['features/test.feature'], requireModule: ['ts-node/register'], require: ['features/steps.ts']}`
+  )
+  const stdout = new PassThrough()
+  return { cwd, stdout }
+}
+
+async function teardownEnvironment(environment: IRunEnvironment) {
+  await fs.rmdir(environment.cwd, { recursive: true })
+  environment.stdout.end()
+}
+
+describe('loadSupport', () => {
+  let environment: IRunEnvironment
+  beforeEach(async () => {
+    environment = await setupEnvironment()
+  })
+  afterEach(async () => teardownEnvironment(environment))
+
+  it("should include original paths in the returned support code library", async () => {
+    const { runConfiguration } = await loadConfiguration({}, environment)
+    const support = await loadSupport(runConfiguration, environment)
+
+    expect(support.originalCoordinates).to.deep.eq({
+      requireModules: [
+        "ts-node/register"
+      ],
+      requirePaths: [
+        `${environment.cwd}/features/steps.ts`
+      ],
+      importPaths: []
+    })
+  });
+})

--- a/src/api/load_support_spec.ts
+++ b/src/api/load_support_spec.ts
@@ -52,7 +52,7 @@ describe('loadSupport', () => {
 
     expect(support.originalCoordinates).to.deep.eq({
       requireModules: ['ts-node/register'],
-      requirePaths: [`${environment.cwd}/features/steps.ts`],
+      requirePaths: [path.join(environment.cwd, 'features', 'steps.ts')],
       importPaths: [],
     })
   })

--- a/src/api/load_support_spec.ts
+++ b/src/api/load_support_spec.ts
@@ -1,12 +1,12 @@
-import { IdGenerator } from "@cucumber/messages";
-import { IRunEnvironment  } from "./types";
-import path from "path";
-import fs from "mz/fs";
-import { reindent } from "reindent-template-literals";
-import { PassThrough } from "stream";
-import { loadSupport } from "./load_support";
-import { loadConfiguration } from "./load_configuration";
-import { expect } from "chai";
+import { IdGenerator } from '@cucumber/messages'
+import { IRunEnvironment } from './types'
+import path from 'path'
+import fs from 'mz/fs'
+import { reindent } from 'reindent-template-literals'
+import { PassThrough } from 'stream'
+import { loadSupport } from './load_support'
+import { loadConfiguration } from './load_configuration'
+import { expect } from 'chai'
 
 const newId = IdGenerator.uuid()
 
@@ -46,18 +46,14 @@ describe('loadSupport', () => {
   })
   afterEach(async () => teardownEnvironment(environment))
 
-  it("should include original paths in the returned support code library", async () => {
+  it('should include original paths in the returned support code library', async () => {
     const { runConfiguration } = await loadConfiguration({}, environment)
     const support = await loadSupport(runConfiguration, environment)
 
     expect(support.originalCoordinates).to.deep.eq({
-      requireModules: [
-        "ts-node/register"
-      ],
-      requirePaths: [
-        `${environment.cwd}/features/steps.ts`
-      ],
-      importPaths: []
+      requireModules: ['ts-node/register'],
+      requirePaths: [`${environment.cwd}/features/steps.ts`],
+      importPaths: [],
     })
-  });
+  })
 })

--- a/src/api/run_cucumber_spec.ts
+++ b/src/api/run_cucumber_spec.ts
@@ -1,44 +1,10 @@
-import { Envelope, TestStepResultStatus, IdGenerator } from '@cucumber/messages'
-import fs from 'mz/fs'
-import path from 'path'
-import { reindent } from 'reindent-template-literals'
-import { PassThrough } from 'stream'
+import { Envelope, TestStepResultStatus } from '@cucumber/messages'
 import { expect } from 'chai'
 import { runCucumber } from './run_cucumber'
 import { IRunEnvironment } from './types'
 import { loadSupport } from './load_support'
 import { loadConfiguration } from './load_configuration'
-
-const newId = IdGenerator.uuid()
-
-async function setupEnvironment(): Promise<Partial<IRunEnvironment>> {
-  const cwd = path.join(__dirname, '..', '..', 'tmp', `runCucumber_${newId()}`)
-  await fs.mkdir(path.join(cwd, 'features'), { recursive: true })
-  await fs.writeFile(
-    path.join(cwd, 'features', 'test.feature'),
-    reindent(`Feature: test fixture
-      Scenario: one
-        Given a step
-        Then another step`)
-  )
-  await fs.writeFile(
-    path.join(cwd, 'features', 'steps.ts'),
-    reindent(`import { Given, Then } from '../../../src'
-    Given('a step', function () {})
-    Then('another step', function () {})`)
-  )
-  await fs.writeFile(
-    path.join(cwd, 'cucumber.mjs'),
-    `export default {paths: ['features/test.feature'], requireModule: ['ts-node/register'], require: ['features/steps.ts']}`
-  )
-  const stdout = new PassThrough()
-  return { cwd, stdout }
-}
-
-async function teardownEnvironment(environment: IRunEnvironment) {
-  await fs.rmdir(environment.cwd, { recursive: true })
-  environment.stdout.end()
-}
+import { setupEnvironment, teardownEnvironment } from './test_helpers'
 
 describe('runCucumber', () => {
   describe('preloading support code', () => {

--- a/src/api/support.ts
+++ b/src/api/support.ts
@@ -22,7 +22,7 @@ export async function getSupportCodeLibrary({
   supportCodeLibraryBuilder.reset(cwd, newId, {
     requireModules,
     requirePaths,
-    importPaths
+    importPaths,
   })
   requireModules.map((module) => require(module))
   requirePaths.map((path) => require(path))

--- a/src/api/support.ts
+++ b/src/api/support.ts
@@ -19,7 +19,11 @@ export async function getSupportCodeLibrary({
   requirePaths: string[]
   importPaths: string[]
 }): Promise<ISupportCodeLibrary> {
-  supportCodeLibraryBuilder.reset(cwd, newId)
+  supportCodeLibraryBuilder.reset(cwd, newId, {
+    requireModules,
+    requirePaths,
+    importPaths
+  })
   requireModules.map((module) => require(module))
   requirePaths.map((path) => require(path))
   for (const path of importPaths) {

--- a/src/api/test_helpers.ts
+++ b/src/api/test_helpers.ts
@@ -1,9 +1,9 @@
-import { IRunEnvironment } from "./types";
-import path from "path";
-import fs from "mz/fs";
-import { reindent } from "reindent-template-literals";
-import { PassThrough } from "stream";
-import { IdGenerator } from "@cucumber/messages";
+import { IRunEnvironment } from './types'
+import path from 'path'
+import fs from 'mz/fs'
+import { reindent } from 'reindent-template-literals'
+import { PassThrough } from 'stream'
+import { IdGenerator } from '@cucumber/messages'
 
 const newId = IdGenerator.uuid()
 

--- a/src/api/test_helpers.ts
+++ b/src/api/test_helpers.ts
@@ -1,0 +1,37 @@
+import { IRunEnvironment } from "./types";
+import path from "path";
+import fs from "mz/fs";
+import { reindent } from "reindent-template-literals";
+import { PassThrough } from "stream";
+import { IdGenerator } from "@cucumber/messages";
+
+const newId = IdGenerator.uuid()
+
+export async function setupEnvironment(): Promise<Partial<IRunEnvironment>> {
+  const cwd = path.join(__dirname, '..', '..', 'tmp', `api_${newId()}`)
+  await fs.mkdir(path.join(cwd, 'features'), { recursive: true })
+  await fs.writeFile(
+    path.join(cwd, 'features', 'test.feature'),
+    reindent(`Feature: test fixture
+      Scenario: one
+        Given a step
+        Then another step`)
+  )
+  await fs.writeFile(
+    path.join(cwd, 'features', 'steps.ts'),
+    reindent(`import { Given, Then } from '../../../src'
+    Given('a step', function () {})
+    Then('another step', function () {})`)
+  )
+  await fs.writeFile(
+    path.join(cwd, 'cucumber.mjs'),
+    `export default {paths: ['features/test.feature'], requireModule: ['ts-node/register'], require: ['features/steps.ts']}`
+  )
+  const stdout = new PassThrough()
+  return { cwd, stdout }
+}
+
+export async function teardownEnvironment(environment: IRunEnvironment) {
+  await fs.rmdir(environment.cwd, { recursive: true })
+  environment.stdout.end()
+}

--- a/src/runtime/parallel/worker.ts
+++ b/src/runtime/parallel/worker.ts
@@ -70,7 +70,11 @@ export default class Worker {
     supportCodeIds,
     options,
   }: IWorkerCommandInitialize): Promise<void> {
-    supportCodeLibraryBuilder.reset(this.cwd, this.newId)
+    supportCodeLibraryBuilder.reset(this.cwd, this.newId, {
+      requireModules,
+      requirePaths,
+      importPaths
+    })
     requireModules.map((module) => require(module))
     requirePaths.map((module) => require(module))
     for (const path of importPaths) {

--- a/src/runtime/parallel/worker.ts
+++ b/src/runtime/parallel/worker.ts
@@ -73,7 +73,7 @@ export default class Worker {
     supportCodeLibraryBuilder.reset(this.cwd, this.newId, {
       requireModules,
       requirePaths,
-      importPaths
+      importPaths,
     })
     requireModules.map((module) => require(module))
     requirePaths.map((module) => require(module))


### PR DESCRIPTION
### 🤔 What's changed?

Always initialise the support code library with original coordinates so it can be loaded again in child processes.

Previously, when using the API, calling `loadSupport` and using the result in `runCucumber` with the parallel option would result in a state where:

- The parent (coordinator) process has the support code loaded
- It is happy for test cases to run since it can see they have matching step definitions
- The child processes don't have the coordinates, so they don't load the support code

And this would be followed by obscure errors as noted in the linked issue.

### ⚡️ What's your motivation? 

Fixes #2196.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
