### PR TITLE
support YAML for config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Added
+- Add support for YAML as a configuration file format ([#2199](https://github.com/cucumber/cucumber-js/pull/2199))
 
 ## [8.9.1] - 2022-12-16
 ### Fixed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,8 @@ You can keep your configuration in a file. Cucumber will look for one of these f
 - `cucumber.cjs`
 - `cucumber.mjs`
 - `cucumber.json`
+- `cucumber.yaml`
+- `cucumber.yml`
 
 You can also put your file somewhere else and tell Cucumber via the `--config` CLI option:
 
@@ -45,9 +47,18 @@ And the same in JSON format:
 {
   "default": {
     "parallel": 2,
-      "format": ["html:cucumber-report.html"]
+    "format": ["html:cucumber-report.html"]
   }
 }
+```
+
+And the same in YAML format:
+
+```yaml
+default:
+  parallel: 2
+  format:
+    - "html:cucumber-report.html"
 ```
 
 Cucumber also supports the configuration being a string of options in the style of the CLI, though this isn't recommended:

--- a/features/profiles.feature
+++ b/features/profiles.feature
@@ -117,3 +117,19 @@ Feature: default command line arguments
       1 step (1 skipped)
       <duration-stat>
       """
+
+  Scenario: using a YAML file
+    Given a file named ".cucumber-rc.yaml" with:
+      """
+      default:
+        dryRun: true
+      """
+    When I run cucumber-js with `--config .cucumber-rc.yaml`
+    Then it outputs the text:
+      """
+      -
+
+      1 scenario (1 skipped)
+      1 step (1 skipped)
+      <duration-stat>
+      """

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "util-arity": "^1.1.0",
         "verror": "^1.10.0",
         "xmlbuilder": "^15.1.1",
-        "yaml": "^2.1.3",
+        "yaml": "1.10.2",
         "yup": "^0.32.11"
       },
       "bin": {
@@ -7911,11 +7911,11 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
-      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6"
       }
     },
     "node_modules/yargs": {
@@ -14075,9 +14075,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
-      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "util-arity": "^1.1.0",
         "verror": "^1.10.0",
         "xmlbuilder": "^15.1.1",
+        "yaml": "^2.1.3",
         "yup": "^0.32.11"
       },
       "bin": {
@@ -7909,6 +7910,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "node_modules/yaml": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
+      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -14064,6 +14073,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yaml": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
+      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "util-arity": "^1.1.0",
     "verror": "^1.10.0",
     "xmlbuilder": "^15.1.1",
+    "yaml": "^2.1.3",
     "yup": "^0.32.11"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
     "util-arity": "^1.1.0",
     "verror": "^1.10.0",
     "xmlbuilder": "^15.1.1",
-    "yaml": "^2.1.3",
+    "yaml": "1.10.2",
     "yup": "^0.32.11"
   },
   "devDependencies": {

--- a/src/configuration/from_file.ts
+++ b/src/configuration/from_file.ts
@@ -1,14 +1,14 @@
-import stringArgv from "string-argv";
-import fs from "fs";
-import path from "path";
-import YAML from "yaml";
-import { promisify } from "util";
-import { pathToFileURL } from "url";
-import { IConfiguration } from "./types";
-import { mergeConfigurations } from "./merge_configurations";
-import ArgvParser from "./argv_parser";
-import { checkSchema } from "./check_schema";
-import { ILogger } from "../logger";
+import stringArgv from 'string-argv'
+import fs from 'fs'
+import path from 'path'
+import YAML from 'yaml'
+import { promisify } from 'util'
+import { pathToFileURL } from 'url'
+import { IConfiguration } from './types'
+import { mergeConfigurations } from './merge_configurations'
+import ArgvParser from './argv_parser'
+import { checkSchema } from './check_schema'
+import { ILogger } from '../logger'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { importer } = require('../importer')
@@ -51,11 +51,15 @@ async function loadFile(
   let definitions
   switch (extension) {
     case '.json':
-      definitions = JSON.parse(await promisify(fs.readFile)(filePath, { encoding: 'utf-8' }))
+      definitions = JSON.parse(
+        await promisify(fs.readFile)(filePath, { encoding: 'utf-8' })
+      )
       break
     case '.yaml':
     case '.yml':
-      definitions = YAML.parse(await promisify(fs.readFile)(filePath, { encoding: 'utf-8' }))
+      definitions = YAML.parse(
+        await promisify(fs.readFile)(filePath, { encoding: 'utf-8' })
+      )
       break
     default:
       try {

--- a/src/configuration/from_file.ts
+++ b/src/configuration/from_file.ts
@@ -1,6 +1,7 @@
 import stringArgv from 'string-argv'
 import fs from 'fs'
 import path from 'path'
+import YAML from 'yaml'
 import { promisify } from 'util'
 import { pathToFileURL } from 'url'
 import { IConfiguration } from './types'
@@ -48,9 +49,9 @@ async function loadFile(
   const filePath: string = path.join(cwd, file)
   const extension = path.extname(filePath)
   let definitions
-  if (extension === 'json') {
-    const json = await promisify(fs.readFile)(filePath, { encoding: 'utf-8' })
-    definitions = JSON.parse(json)
+  if (extension === '.json' || extension === '.yaml' || extension === '.yml') {
+    const raw = await promisify(fs.readFile)(filePath, { encoding: 'utf-8' })
+    definitions = YAML.parse(raw)
   } else {
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/src/configuration/from_file.ts
+++ b/src/configuration/from_file.ts
@@ -1,14 +1,14 @@
-import stringArgv from 'string-argv'
-import fs from 'fs'
-import path from 'path'
-import YAML from 'yaml'
-import { promisify } from 'util'
-import { pathToFileURL } from 'url'
-import { IConfiguration } from './types'
-import { mergeConfigurations } from './merge_configurations'
-import ArgvParser from './argv_parser'
-import { checkSchema } from './check_schema'
-import { ILogger } from '../logger'
+import stringArgv from "string-argv";
+import fs from "fs";
+import path from "path";
+import YAML from "yaml";
+import { promisify } from "util";
+import { pathToFileURL } from "url";
+import { IConfiguration } from "./types";
+import { mergeConfigurations } from "./merge_configurations";
+import ArgvParser from "./argv_parser";
+import { checkSchema } from "./check_schema";
+import { ILogger } from "../logger";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { importer } = require('../importer')
@@ -49,20 +49,25 @@ async function loadFile(
   const filePath: string = path.join(cwd, file)
   const extension = path.extname(filePath)
   let definitions
-  if (extension === '.json' || extension === '.yaml' || extension === '.yml') {
-    const raw = await promisify(fs.readFile)(filePath, { encoding: 'utf-8' })
-    definitions = YAML.parse(raw)
-  } else {
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      definitions = require(filePath)
-    } catch (error) {
-      if (error.code === 'ERR_REQUIRE_ESM') {
-        definitions = await importer(pathToFileURL(filePath))
-      } else {
-        throw error
+  switch (extension) {
+    case '.json':
+      definitions = JSON.parse(await promisify(fs.readFile)(filePath, { encoding: 'utf-8' }))
+      break
+    case '.yaml':
+    case '.yml':
+      definitions = YAML.parse(await promisify(fs.readFile)(filePath, { encoding: 'utf-8' }))
+      break
+    default:
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        definitions = require(filePath)
+      } catch (error) {
+        if (error.code === 'ERR_REQUIRE_ESM') {
+          definitions = await importer(pathToFileURL(filePath))
+        } else {
+          throw error
+        }
       }
-    }
   }
   if (typeof definitions !== 'object') {
     throw new Error(`Configuration file ${filePath} does not export an object`)

--- a/src/configuration/from_file_spec.ts
+++ b/src/configuration/from_file_spec.ts
@@ -99,5 +99,20 @@ describe('fromFile', () => {
       const result = await fromFile(logger, cwd, 'cucumber.json', ['p1'])
       expect(result).to.deep.eq({ paths: ['other/path/*.feature'] })
     })
+
+    it('should work with yaml', async () => {
+      const { logger, cwd } = await setup(
+        'cucumber.yaml',
+        `default:
+
+p1:
+  paths:
+    - "other/path/*.feature"
+`
+      )
+
+      const result = await fromFile(logger, cwd, 'cucumber.yaml', ['p1'])
+      expect(result).to.deep.eq({ paths: ['other/path/*.feature'] })
+    })
   })
 })

--- a/src/configuration/locate_file.ts
+++ b/src/configuration/locate_file.ts
@@ -6,6 +6,8 @@ const DEFAULT_FILENAMES = [
   'cucumber.cjs',
   'cucumber.mjs',
   'cucumber.json',
+  'cucumber.yaml',
+  'cucumber.yml',
 ]
 
 export function locateFile(cwd: string): string | undefined {


### PR DESCRIPTION
### 🤔 What's changed?

Add support for YAML as a configuration file format.

### ⚡️ What's your motivation? 

We support JS and JSON; YAML is the obvious missing option.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

Also as part of this, JSON configuration files are loaded with `fs.readFile` rather than `require` - this is a small non-breaking step towards moving away from `require` for everything.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
