### PR TITLE
CI: Add a dead link checker in order to detect if some link are dead

### DIFF
--- a/.404-links.yml
+++ b/.404-links.yml
@@ -1,0 +1,2 @@
+delay:
+    'https://github.com': 500

--- a/.github/workflows/404-links.yaml
+++ b/.github/workflows/404-links.yaml
@@ -1,0 +1,14 @@
+name: Dead link checker
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check links
+      uses: restqa/404-links@2.2.0


### PR DESCRIPTION

### 🤔 What's changed?

Propose a new github action that would detect if some links referenced on the markdown are dead. 

### ⚡️ What's your motivation? 

While looking at the excellent documentation i realized that such a long term support project might still reference link that are not longer exists.

### 🏷️ What kind of change is this?


- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)


### ♻️ Anything particular you want feedback on?

❤️

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
