### PR TITLE
fix(junit-formatter): add file name on testcase tag

### DIFF
--- a/src/formatter/junit_formatter.ts
+++ b/src/formatter/junit_formatter.ts
@@ -34,6 +34,7 @@ interface IJUnitTestCase {
   result: IJUnitTestCaseResult
   systemOutput: string
   steps: IJUnitTestStep[]
+  file: string
 }
 
 interface IJUnitTestCaseResult {
@@ -221,6 +222,7 @@ export default class JunitFormatter extends Formatter {
           result: this.getTestCaseResult(steps),
           systemOutput: this.formatTestSteps(steps),
           steps,
+          file: pickle.uri,
         }
       }
     )
@@ -257,6 +259,7 @@ export default class JunitFormatter extends Formatter {
         classname: test.classname,
         name: test.name,
         time: test.time,
+        file: test.file,
       })
       if (test.result.status === TestStepResultStatus.SKIPPED) {
         xmlTestCase.ele('skipped')

--- a/src/formatter/junit_formatter_spec.ts
+++ b/src/formatter/junit_formatter_spec.ts
@@ -104,7 +104,7 @@ describe('JunitFormatter', () => {
         expect(output).xml.to.deep.equal(
           '<?xml version="1.0"?>\n' +
             '<testsuite failures="0" skipped="0" name="cucumber-js" time="0.001" tests="1">\n' +
-            '  <testcase classname="my feature" name="my scenario" time="0.001">\n' +
+            '  <testcase classname="my feature" name="my scenario" time="0.001" file="a.feature">\n' +
             '    <system-out><![CDATA[Given a passing step......................................................passed]]></system-out>\n' +
             '  </testcase>\n' +
             '</testsuite>'
@@ -139,7 +139,7 @@ describe('JunitFormatter', () => {
         expect(output).xml.to.deep.equal(
           '<?xml version="1.0"?>\n' +
             '<testsuite failures="1" skipped="0" name="cucumber-js" time="0.001" tests="1">\n' +
-            '  <testcase classname="my feature" name="my scenario" time="0.001">\n' +
+            '  <testcase classname="my feature" name="my scenario" time="0.001" file="a.feature">\n' +
             '    <failure type="FAILED" message="A hook or step failed"><![CDATA[error]]></failure>\n' +
             '    <system-out><![CDATA[Given a failing step......................................................failed]]></system-out>\n' +
             '  </testcase>\n' +
@@ -176,7 +176,7 @@ describe('JunitFormatter', () => {
         expect(output).xml.to.deep.equal(
           '<?xml version="1.0"?>\n' +
             '<testsuite failures="0" skipped="0" name="cucumber-js" time="0.001" tests="1">\n' +
-            '  <testcase classname="my feature" name="my scenario" time="0.001">\n' +
+            '  <testcase classname="my feature" name="my scenario" time="0.001" file="a.feature">\n' +
             '    <system-out><![CDATA[Given a flaky step........................................................passed]]></system-out>\n' +
             '  </testcase>\n' +
             '</testsuite>'
@@ -210,7 +210,7 @@ describe('JunitFormatter', () => {
         expect(output).xml.to.deep.equal(
           '<?xml version="1.0"?>\n' +
             '<testsuite failures="1" skipped="0" name="cucumber-js" time="0.001" tests="1">\n' +
-            '  <testcase classname="my feature" name="my scenario" time="0.001">\n' +
+            '  <testcase classname="my feature" name="my scenario" time="0.001" file="a.feature">\n' +
             '    <failure type="PENDING" message="A step in the test case is not yet implemented"/>\n' +
             '    <system-out><![CDATA[Given a pending step.....................................................pending]]></system-out>\n' +
             '  </testcase>\n' +
@@ -247,7 +247,7 @@ describe('JunitFormatter', () => {
         expect(output).xml.to.deep.equal(
           '<?xml version="1.0"?>\n' +
             '<testsuite failures="0" skipped="1" name="cucumber-js" time="0.001" tests="1">\n' +
-            '  <testcase classname="my feature" name="my scenario" time="0.001">\n' +
+            '  <testcase classname="my feature" name="my scenario" time="0.001" file="a.feature">\n' +
             '    <skipped/>\n' +
             '    <system-out><![CDATA[Given a passing step......................................................passed\n' +
             'And a skipped step.......................................................skipped\n' +
@@ -282,7 +282,7 @@ describe('JunitFormatter', () => {
         expect(output).xml.to.deep.equal(
           '<?xml version="1.0"?>\n' +
             '<testsuite failures="1" skipped="0" name="cucumber-js" time="0" tests="1">\n' +
-            '  <testcase classname="my feature" name="my scenario" time="0">\n' +
+            '  <testcase classname="my feature" name="my scenario" time="0" file="a.feature">\n' +
             '    <failure type="UNDEFINED" message="A step in the test case is not defined"/>\n' +
             '    <system-out><![CDATA[Given a passing step...................................................undefined]]></system-out>\n' +
             '  </testcase>\n' +
@@ -324,7 +324,7 @@ describe('JunitFormatter', () => {
       expect(output).xml.to.deep.equal(
         '<?xml version="1.0"?>\n' +
           '<testsuite failures="0" skipped="0" name="cucumber-js" time="0.002" tests="1">\n' +
-          '  <testcase classname="my feature" name="my scenario" time="0.002">\n' +
+          '  <testcase classname="my feature" name="my scenario" time="0.002" file="a.feature">\n' +
           '    <system-out><![CDATA[Given a passing step......................................................passed\n' +
           'When a passing step.......................................................passed]]></system-out>\n' +
           '  </testcase>\n' +
@@ -366,10 +366,10 @@ describe('JunitFormatter', () => {
       expect(output).xml.to.deep.equal(
         '<?xml version="1.0"?>\n' +
           '<testsuite failures="1" skipped="0" name="cucumber-js" time="0.002" tests="2">\n' +
-          '  <testcase classname="my feature" name="my templated scenario" time="0.001">\n' +
+          '  <testcase classname="my feature" name="my templated scenario" time="0.001" file="a.feature">\n' +
           '    <system-out><![CDATA[Given a passing step......................................................passed]]></system-out>\n' +
           '  </testcase>\n' +
-          '  <testcase classname="my feature" name="my templated scenario [1]" time="0.001">\n' +
+          '  <testcase classname="my feature" name="my templated scenario [1]" time="0.001" file="a.feature">\n' +
           '    <failure type="FAILED" message="A hook or step failed"><![CDATA[error]]></failure>\n' +
           '    <system-out><![CDATA[Given a failing step......................................................failed]]></system-out>\n' +
           '  </testcase>\n' +
@@ -418,10 +418,10 @@ describe('JunitFormatter', () => {
         expect(output).xml.to.deep.equal(
           '<?xml version="1.0"?>\n' +
             '<testsuite failures="0" skipped="0" name="cucumber-js" time="0.002" tests="2">\n' +
-            '  <testcase classname="my feature" name="my rule: first example" time="0.001">\n' +
+            '  <testcase classname="my feature" name="my rule: first example" time="0.001" file="a.feature">\n' +
             '    <system-out><![CDATA[Given a passing step......................................................passed]]></system-out>\n' +
             '  </testcase>\n' +
-            '  <testcase classname="my feature" name="my rule: second example" time="0.001">\n' +
+            '  <testcase classname="my feature" name="my rule: second example" time="0.001" file="a.feature">\n' +
             '    <system-out><![CDATA[Given a passing step......................................................passed]]></system-out>\n' +
             '  </testcase>\n' +
             '</testsuite>'
@@ -469,10 +469,10 @@ describe('JunitFormatter', () => {
       expect(output).xml.to.deep.equal(
         '<?xml version="1.0"?>\n' +
           '<testsuite failures="0" skipped="0" name="cucumber-js" time="0.002" tests="2">\n' +
-          '  <testcase classname="(unnamed feature)" name="(unnamed rule): (unnamed scenario)" time="0.001">\n' +
+          '  <testcase classname="(unnamed feature)" name="(unnamed rule): (unnamed scenario)" time="0.001" file="a.feature">\n' +
           '    <system-out><![CDATA[Given a passing step......................................................passed]]></system-out>\n' +
           '  </testcase>\n' +
-          '  <testcase classname="(unnamed feature)" name="(unnamed rule): (unnamed scenario) [1]" time="0.001">\n' +
+          '  <testcase classname="(unnamed feature)" name="(unnamed rule): (unnamed scenario) [1]" time="0.001" file="a.feature">\n' +
           '    <system-out><![CDATA[Given a passing step......................................................passed]]></system-out>\n' +
           '  </testcase>\n' +
           '</testsuite>'


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

Added `file` attribute on each `testcase` tag of XML-based JUnit report

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

In CircleCI, in order to optimize Cucumber tests across a set of parallel executors, CircleCI requires test results to be uploaded as JUnit XML format reports with executed timing data. Based on needed well-formed JUnit XML reports, CircleCI parses and uses data for the following test splitting based on timing data taken to execute tests of a specific `test name`, `class name`, or `file name`. [CircleCI required JUnit XML report format as below:](https://circleci.com/docs/use-the-circleci-cli-to-split-tests/#junit-xml-reports)

- The `file` attribute, either on the `<testsuite>` or `<testcase>` tag
- The `time` attribute, on the `<testcase>` tag

``` XML
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="Mocha Tests" tests="3" failures="1">
  <testsuite tests="3">
    <testcase classname="foo1" name="ASuccessfulTest" time="10" file="src/__tests__/App.test.js" />
    <testcase classname="foo2" name="AnotherSuccessfulTest" time="5" file="src/__tests__/App.test.js" />
    <testcase classname="foo3" name="AFailingTest" time="1.1050" file="src/__tests__/App.test.js">
        <failure type="NotEnoughFoo"> details about failure </failure>
    </testcase>
  </testsuite>
</testsuites>
```

The `time` attribute is already on the `<testcase>` tag of the XML-based JUnit report, this PR just adds the `file` attribute on the `<testcase>` tag

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

Feel free to suggest any change or possible improvement.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
