### PR TITLE
fix(junit): could not generate xml if error message has invalid character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Handle invalid characters when generating XML for JUnit formatter [#2228](https://github.com/cucumber/cucumber-js/pull/2228)
 
 ## [8.10.0] - 2022-12-27
 ### Added

--- a/src/formatter/junit_formatter.ts
+++ b/src/formatter/junit_formatter.ts
@@ -246,7 +246,7 @@ export default class JunitFormatter extends Formatter {
 
   private buildXmlReport(testSuite: IJUnitTestSuite): string {
     const xmlReport = xmlbuilder
-      .create('testsuite')
+      .create('testsuite', { invalidCharReplacement: '' })
       .att('failures', testSuite.failures)
       .att('skipped', testSuite.skipped)
       .att('name', testSuite.name)

--- a/src/formatter/junit_formatter_spec.ts
+++ b/src/formatter/junit_formatter_spec.ts
@@ -35,6 +35,11 @@ function getJUnitFormatterSupportCodeLibrary(
       throw 'error' // eslint-disable-line @typescript-eslint/no-throw-literal
     })
 
+    Given('a failing step with invalid character', function () {
+      clock.tick(1)
+      throw 'Error: include \x08invalid character' // eslint-disable-line @typescript-eslint/no-throw-literal
+    })
+
     Given('a pending step', function () {
       clock.tick(1)
       return 'pending'
@@ -142,6 +147,40 @@ describe('JunitFormatter', () => {
             '  <testcase classname="my feature" name="my scenario" time="0.001">\n' +
             '    <failure type="FAILED" message="A hook or step failed"><![CDATA[error]]></failure>\n' +
             '    <system-out><![CDATA[Given a failing step......................................................failed]]></system-out>\n' +
+            '  </testcase>\n' +
+            '</testsuite>'
+        )
+      })
+
+      it('failed with invalid character', async () => {
+        // Arrange
+        const sources = [
+          {
+            data: [
+              'Feature: my feature',
+              '  Scenario: my scenario',
+              '    Given a failing step with invalid character',
+            ].join('\n'),
+            uri: 'a.feature',
+          },
+        ]
+
+        const supportCodeLibrary = getJUnitFormatterSupportCodeLibrary(clock)
+
+        // Act
+        const output = await testFormatter({
+          sources,
+          supportCodeLibrary,
+          type: 'junit',
+        })
+
+        // Assert
+        expect(output).xml.to.deep.equal(
+          '<?xml version="1.0"?>\n' +
+            '<testsuite failures="1" skipped="0" name="cucumber-js" time="0.001" tests="1">\n' +
+            '  <testcase classname="my feature" name="my scenario" time="0.001">\n' +
+            '    <failure type="FAILED" message="A hook or step failed"><![CDATA[Error: include invalid character]]></failure>\n' +
+            '    <system-out><![CDATA[Given a failing step with invalid character...............................failed]]></system-out>\n' +
             '  </testcase>\n' +
             '</testsuite>'
         )


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

Added `invalidCharReplacement` option in XML Builder in XML formatter

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

I could not generate an XML report file via the JUnit formatter setting if the message of a failed test case contains any invalid character (Eg: `\x08`). So, in order to prevent these cases I added `invalidCharReplacement` option for XML builder as [this documentation](https://github.com/oozcitak/xmlbuilder-js/wiki/Builder-Options#settings-related-to-value-conversions).

<img width="1048" alt="Screen Shot 2023-02-02 at 16 42 28" src="https://user-images.githubusercontent.com/13638569/216265584-bb2a012c-4af8-4f6a-b0e0-14af31b580cf.png">


### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

Feel free to suggest any change or possible improvement.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
