### PR TITLE
chore: add workflow for closing incomplete issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,20 @@
+name: 'Close stale issues'
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  incomplete-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v7
+        with:
+          stale-issue-label: ':hourglass: stale'
+          stale-issue-message: 'This issue is stale because it has been open for 3 weeks with no activity. Remove the stale label or comment or this will be closed in another 5 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          only-issue-labels: ':baby_bottle: incomplete'
+          days-before-stale: 21
+          days-before-close: 5
+          days-before-pr-stale: -1
+          days-before-pr-close: -1

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,5 +1,9 @@
 name: 'Close stale issues'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: '30 1 * * *'


### PR DESCRIPTION
### 🤔 What's changed?

Use GitHub's recommended action to auto stale and close issues.

To begin with, just focusing on this flow for issues that we've labelled as "incomplete" (i.e. the requester hasn't provided enough information):

- After 3 weeks, mark stale and comment
- After 5 more days, close

### ⚡️ What's your motivation? 

https://github.com/cucumber/common/issues/2140

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
