### PR TITLE
fix: end html formatter stream at appropriate time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Exit correctly when there's a Gherkin parse failure [#2233](https://github.com/cucumber/cucumber-js/pull/2233)
 
 ## [8.11.0] - 2023-02-10
 ### Added

--- a/features/gherkin_parse_failure.feature
+++ b/features/gherkin_parse_failure.feature
@@ -43,3 +43,13 @@ Feature: Gherkin parse failure
       | pickle          | 1     |
       | parseError      | 2     |
 
+  Scenario: Formatters handle the truncated test run
+    Given a file named "features/a.feature" with:
+      """
+      Feature: a feature name
+        Scenario: a scenario name
+          Given a step
+          Parse Error
+      """
+    When I run cucumber-js with all formatters
+    Then it fails

--- a/src/formatter/html_formatter.ts
+++ b/src/formatter/html_formatter.ts
@@ -2,34 +2,30 @@ import Formatter, { IFormatterOptions } from '.'
 import * as messages from '@cucumber/messages'
 import resolvePkg from 'resolve-pkg'
 import CucumberHtmlStream from '@cucumber/html-formatter'
-import { doesHaveValue } from '../value_checker'
 import { finished } from 'stream'
 import { promisify } from 'util'
 
 export default class HtmlFormatter extends Formatter {
-  private readonly _finished: Promise<void>
+  private readonly _htmlStream: CucumberHtmlStream
   public static readonly documentation: string = 'Outputs HTML report'
 
   constructor(options: IFormatterOptions) {
     super(options)
-    const cucumberHtmlStream = new CucumberHtmlStream(
+    this._htmlStream = new CucumberHtmlStream(
       resolvePkg('@cucumber/html-formatter', { cwd: __dirname }) +
         '/dist/main.css',
       resolvePkg('@cucumber/html-formatter', { cwd: __dirname }) +
         '/dist/main.js'
     )
     options.eventBroadcaster.on('envelope', (envelope: messages.Envelope) => {
-      cucumberHtmlStream.write(envelope)
-      if (doesHaveValue(envelope.testRunFinished)) {
-        cucumberHtmlStream.end()
-      }
+      this._htmlStream.write(envelope)
     })
-    cucumberHtmlStream.on('data', (chunk) => this.log(chunk))
-    this._finished = promisify(finished)(cucumberHtmlStream)
+    this._htmlStream.on('data', (chunk) => this.log(chunk))
   }
 
   async finished(): Promise<void> {
-    await this._finished
+    this._htmlStream.end()
+    await promisify(finished)(this._htmlStream)
     await super.finished()
   }
 }


### PR DESCRIPTION
### 🤔 What's changed?

In the `html` formatter, change when we end the `CucumberHtmlStream` that pipes to the output stream.

Previously we did this when we saw a `testRunFinished` message, which sort of makes sense. However there are other ways for a test run to end e.g. Gherkin parse failure as in the linked issue. This meant we were awaiting a stream to finish that was never going to, and this caused the process to just exit (I'm a little hazy as to exactly why, but I could reproduce it).

Now we only end the stream in the cleanup step after the test run has finished (or an error has caused us to bail out of it) and it works for both cases - covered by existing scenarios for the happy path and a new one covering the parse failure.

### ⚡️ What's your motivation? 

Fixes #2225.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
