### PR TITLE
fix: update mocha config to avoid test timeouts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - fix/flaky-api-tests
   pull_request:
     branches:
       - main
@@ -18,6 +17,7 @@ jobs:
     strategy:
       matrix:
         os:
+          - ubuntu-latest
           - windows-latest
         # these versions must be kept in sync with enginesTested.node in package.json
         node-version: [12.x, 14.x, 16.x, 17.x, 18.x, 19.x]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - fix/flaky-api-tests
   pull_request:
     branches:
       - main
@@ -17,7 +18,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
           - windows-latest
         # these versions must be kept in sync with enginesTested.node in package.json
         node-version: [12.x, 14.x, 16.x, 17.x, 18.x, 19.x]

--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -7,3 +7,4 @@ forbid-pending: true
 recursive: true
 reporter: dot
 require: 'ts-node/register'
+timeout: 5000


### PR DESCRIPTION
### 🤔 What's changed?

Increase mocha timeout from 2s to 5s. We don't routinely have tests timeout so this should not make the build any slower in general.

### ⚡️ What's your motivation? 

Fixes #2234. One or two API tests are doing multiple test runs and that's taking them over the 2s timeout on Windows sometimes. I expect we'll do more of this kind of test (i.e. using the `runCucumber` API) so don't want to just do it on a test by test basis.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
