### PR TITLE
drop support for node 12/17

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         # these versions must be kept in sync with enginesTested.node in package.json
-        node-version: [12.x, 14.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
       fail-fast: false
 
     steps:

--- a/package.json
+++ b/package.json
@@ -190,10 +190,10 @@
   },
   "types": "./lib/index.d.ts",
   "engines": {
-    "node": "12 || 14 || >=16"
+    "node": "14 || 16 || >=18"
   },
   "enginesTested": {
-    "node": "12 || 14 || 16 || 17 || 18 || 19"
+    "node": "14 || 16 || 18 || 19"
   },
   "dependencies": {
     "@cucumber/ci-environment": "9.1.0",


### PR DESCRIPTION
12 and 17 are no longer officially supported: https://github.com/nodejs/release#release-schedule

Will need to a major release for this change. Any other incoming breaking changes planned?