### PR TITLE
make typing for attach and log functions correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 ## [Unreleased]
 ### Fixed
 - Exit correctly when there's a Gherkin parse failure [#2233](https://github.com/cucumber/cucumber-js/pull/2233)
-- Refer to correct example line in JSON formatter ([#2236](https://github.com/cucumber/cucumber-js/pull/2236)) 
+- Refer to correct example line in JSON formatter ([#2236](https://github.com/cucumber/cucumber-js/pull/2236))
+- Expose correct overload types for `this.attach` function ([#2238](https://github.com/cucumber/cucumber-js/pull/2238))
 
 ## [8.11.0] - 2023-02-10
 ### Added

--- a/src/runtime/attachment_manager/index.ts
+++ b/src/runtime/attachment_manager/index.ts
@@ -14,12 +14,23 @@ export interface IAttachment {
 }
 
 export type IAttachFunction = (attachment: IAttachment) => void
-export type ICreateAttachment = (
-  data: Buffer | Readable | string,
-  mediaType?: string,
-  callback?: () => void
-) => void | Promise<void>
-export type ICreateLog = (text: string) => void | Promise<void>
+
+export type ICreateStringAttachment = (data: string, mediaType?: string) => void
+export type ICreateBufferAttachment = (data: Buffer, mediaType: string) => void
+export type ICreateStreamAttachment = (
+  data: Readable,
+  mediaType: string
+) => Promise<void>
+export type ICreateStreamAttachmentWithCallback = (
+  data: Readable,
+  mediaType: string,
+  callback: () => void
+) => void
+export type ICreateAttachment = ICreateStringAttachment &
+  ICreateBufferAttachment &
+  ICreateStreamAttachment &
+  ICreateStreamAttachmentWithCallback
+export type ICreateLog = (text: string) => void
 
 export default class AttachmentManager {
   private readonly onAttachment: IAttachFunction

--- a/test-d/attachments.ts
+++ b/test-d/attachments.ts
@@ -1,0 +1,21 @@
+import { After } from '../'
+import { expectError, expectType } from 'tsd'
+import { PassThrough } from 'stream'
+
+After(async function () {
+  // log
+  expectType<void>(this.log('things'))
+  // string
+  expectType<void>(this.attach('stuff'))
+  expectType<void>(this.attach('{}', 'application/json'))
+  // buffer
+  expectType<void>(this.attach(Buffer.from('{}'), 'application/json'))
+  // stream
+  expectType<Promise<void>>(this.attach(new PassThrough(), 'application/json'))
+  expectType<void>(
+    this.attach(new PassThrough(), 'application/json', () => undefined)
+  )
+  // buffer and stream flavours must specify media type
+  expectError(this.attach(Buffer.from('{}')))
+  expectError(this.attach(new PassThrough()))
+})


### PR DESCRIPTION
### 🤔 What's changed?

Make the typings for `this.attach` more accurate by providing overload definitions. Also correct the `this.log` type as it can never yield a promise.

Included `tsd` test that would fail without these changes.

### ⚡️ What's your motivation? 

Fixes #2143 re the ambiguity of whether or not to expect a promise for stream attachments (depends on whether you pass in a callback), but it also improves the type safety around `mediaType` which is really only optional for string attachments.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
