### PR TITLE
deprecation updates ahead of 9.0.0

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -22,14 +22,6 @@ The `Cli` class is used internally to represent an instance of the command-line 
 
 To adapt, pivot to the `runCucumber` function from the [JavaScript API](./javascript_api.md), or raise an issue if you feel your use case isn't catered for.
 
-### `defineStep`
-
-Deprecated in `8.3.0`, will be removed in `10.0.0` or later.
-
-`defineStep` is a way to generically define a step without tying it to any of the `Given`, `When` or `Then` keywords. This leads to ambiguity in the business language and is considered an antipattern; steps should be clearly applicable to one of those keywords, being a context, action or outcome respectively.
-
-To adapt, review your steps and define them with the appropriate keyword, or just switch to `Given` as a starting point. We're working on adding [an opt-in "strict mode" for keywords](https://github.com/cucumber/cucumber-js/issues/2043) which will yield an error when the keyword in the Gherkin text doesn't match that of the step definition, and could be used to pinpoint such issues in your project.
-
 ### `parseGherkinMessageStream`
 
 Deprecated in `8.0.0`, will be removed in `10.0.0` or later.

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -22,14 +22,6 @@ The `Cli` class is used internally to represent an instance of the command-line 
 
 To adapt, pivot to the `runCucumber` function from the [JavaScript API](./javascript_api.md), or raise an issue if you feel your use case isn't catered for.
 
-### `JsonFormatter`
-
-Deprecated in `8.12.0`, will be removed in `10.0.0` or later.
-
-This formatter is going to be rewritten and the existing class removed. If you're implementing your own formatter, consider extending `Formatter` or `SummaryFormatter` instead.
-
-Note that using the `json` formatter with the `format` option is unaffected; this is just about the implementation class being exposed.
-
 ### `parseGherkinMessageStream`
 
 Deprecated in `8.0.0`, will be removed in `10.0.0` or later.

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -10,11 +10,13 @@ Assuming a current major version of `N`:
 2. Later, a major version (e.g. `N+1.0.0`) is released; the deprecation is highlighted in the release notes
 3. Later still, another major version (e.g. `N+2.0.0`) is released with the deprecated functionality removed
 
+In some cases, we might wait longer than `N+2.0.0` before removing functionality if the ecosystem needs more time to adapt.
+
 ## Current deprecations
 
 ### `Cli`
 
-Deprecated in `8.7.0`, will be removed in `10.0.0`.
+Deprecated in `8.7.0`, will be removed in `10.0.0` or later.
 
 The `Cli` class is used internally to represent an instance of the command-line program invoked via `cucumber-js`. It can be used to run Cucumber programmatically, but is poorly suited for this.
 
@@ -22,7 +24,7 @@ To adapt, pivot to the `runCucumber` function from the [JavaScript API](./javasc
 
 ### `defineStep`
 
-Deprecated in `8.3.0`, will be removed in `10.0.0`.
+Deprecated in `8.3.0`, will be removed in `10.0.0` or later.
 
 `defineStep` is a way to generically define a step without tying it to any of the `Given`, `When` or `Then` keywords. This leads to ambiguity in the business language and is considered an antipattern; steps should be clearly applicable to one of those keywords, being a context, action or outcome respectively.
 
@@ -30,7 +32,7 @@ To adapt, review your steps and define them with the appropriate keyword, or jus
 
 ### `parseGherkinMessageStream`
 
-Deprecated in `8.0.0`, will be removed in `10.0.0`.
+Deprecated in `8.0.0`, will be removed in `10.0.0` or later.
 
 `parseGherkinMessageStream` is a way to process a stream of envelopes from Gherkin and resolve to an array of filtered, ordered pickle Ids. Its interface includes internal implementation details from Cucumber which are difficult to assemble.
 
@@ -38,7 +40,7 @@ To adapt, pivot to the `loadSources` function from the [JavaScript API](./javasc
 
 ### `PickleFilter`
 
-Deprecated in `8.7.0`, will be removed in `10.0.0`.
+Deprecated in `8.7.0`, will be removed in `10.0.0` or later.
 
 The `PickleFilter` class is used to provide a filter to the `parseGherkinMessageStream` function above.
 
@@ -46,7 +48,7 @@ To adapt, pivot to the `loadSources` function from the [JavaScript API](./javasc
 
 ### `Runtime`
 
-Deprecated in `8.7.0`, will be removed in `10.0.0`.
+Deprecated in `8.7.0`, will be removed in `10.0.0` or later.
 
 The `Runtime` class is used internally to represent an instance of the serial test case runner. Its interface includes internal implementation details from Cucumber which are difficult to assemble.
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -22,6 +22,14 @@ The `Cli` class is used internally to represent an instance of the command-line 
 
 To adapt, pivot to the `runCucumber` function from the [JavaScript API](./javascript_api.md), or raise an issue if you feel your use case isn't catered for.
 
+### `JsonFormatter`
+
+Deprecated in `8.12.0`, will be removed in `10.0.0` or later.
+
+This formatter is going to be rewritten and the existing class removed. If you're implementing your own formatter, consider extending `Formatter` or `SummaryFormatter` instead.
+
+Note that using the `json` formatter with the `format` option is unaffected; this is just about the implementation class being exposed.
+
 ### `parseGherkinMessageStream`
 
 Deprecated in `8.0.0`, will be removed in `10.0.0` or later.

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export const AfterStep = methods.AfterStep
 export const Before = methods.Before
 export const BeforeAll = methods.BeforeAll
 export const BeforeStep = methods.BeforeStep
+export const defineStep = methods.defineStep
 export const defineParameterType = methods.defineParameterType
 export const Given = methods.Given
 export const setDefaultTimeout = methods.setDefaultTimeout
@@ -65,13 +66,6 @@ export { wrapPromiseWithTimeout } from './time'
 export const Cli = deprecate(
   _Cli,
   '`Cli` is deprecated, use `runCucumber` instead; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
-)
-/**
- * @deprecated use `Given`, `When` or `Then` instead; see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
- */
-export const defineStep = deprecate(
-  methods.defineStep,
-  '`defineStep` is deprecated, use `Given`, `When` or `Then` instead; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
 )
 /**
  * @deprecated use `loadSources` instead; see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,6 @@
 import { default as _Cli } from './cli'
 import * as cliHelpers from './cli/helpers'
 import * as formatterHelpers from './formatter/helpers'
-import { default as _JsonFormatter } from './formatter/json_formatter'
-import { default as _ProgressFormatter } from './formatter/progress_formatter'
-import { default as _RerunFormatter } from './formatter/rerun_formatter'
-import { default as _SnippetsFormatter } from './formatter/snippets_formatter'
-import { default as _UsageFormatter } from './formatter/usage_formatter'
-import { default as _UsageJsonFormatter } from './formatter/usage_json_formatter'
 import { default as _PickleFilter } from './pickle_filter'
 import * as parallelCanAssignHelpers from './support_code_library_builder/parallel_can_assign_helpers'
 import { default as _Runtime } from './runtime'
@@ -23,7 +17,13 @@ export { version } from './version'
 // Formatters
 export { default as Formatter, IFormatterOptions } from './formatter'
 export { default as FormatterBuilder } from './formatter/builder'
+export { default as JsonFormatter } from './formatter/json_formatter'
+export { default as ProgressFormatter } from './formatter/progress_formatter'
+export { default as RerunFormatter } from './formatter/rerun_formatter'
+export { default as SnippetsFormatter } from './formatter/snippets_formatter'
 export { default as SummaryFormatter } from './formatter/summary_formatter'
+export { default as UsageFormatter } from './formatter/usage_formatter'
+export { default as UsageJsonFormatter } from './formatter/usage_json_formatter'
 export { formatterHelpers }
 
 // Support Code Functions
@@ -66,48 +66,6 @@ export { wrapPromiseWithTimeout } from './time'
 export const Cli = deprecate(
   _Cli,
   '`Cli` is deprecated, use `runCucumber` instead; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
-)
-/**
- * @deprecated see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
- */
-export const JsonFormatter = deprecate(
-  _JsonFormatter,
-  'Extending `JsonFormatter` is deprecated; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
-)
-/**
- * @deprecated see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
- */
-export const ProgressFormatter = deprecate(
-  _ProgressFormatter,
-  'Extending `ProgressFormatter` is deprecated; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
-)
-/**
- * @deprecated see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
- */
-export const RerunFormatter = deprecate(
-  _RerunFormatter,
-  'Extending `RerunFormatter` is deprecated; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
-)
-/**
- * @deprecated see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
- */
-export const SnippetsFormatter = deprecate(
-  _SnippetsFormatter,
-  'Extending `SnippetsFormatter` is deprecated; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
-)
-/**
- * @deprecated see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
- */
-export const UsageFormatter = deprecate(
-  _UsageFormatter,
-  'Extending `UsageFormatter` is deprecated; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
-)
-/**
- * @deprecated see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
- */
-export const UsageJsonFormatter = deprecate(
-  _UsageJsonFormatter,
-  'Extending `UsageJsonFormatter` is deprecated; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
 )
 /**
  * @deprecated use `loadSources` instead; see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,11 @@ import { default as _Cli } from './cli'
 import * as cliHelpers from './cli/helpers'
 import * as formatterHelpers from './formatter/helpers'
 import { default as _JsonFormatter } from './formatter/json_formatter'
+import { default as _ProgressFormatter } from './formatter/progress_formatter'
+import { default as _RerunFormatter } from './formatter/rerun_formatter'
+import { default as _SnippetsFormatter } from './formatter/snippets_formatter'
+import { default as _UsageFormatter } from './formatter/usage_formatter'
+import { default as _UsageJsonFormatter } from './formatter/usage_json_formatter'
 import { default as _PickleFilter } from './pickle_filter'
 import * as parallelCanAssignHelpers from './support_code_library_builder/parallel_can_assign_helpers'
 import { default as _Runtime } from './runtime'
@@ -18,12 +23,7 @@ export { version } from './version'
 // Formatters
 export { default as Formatter, IFormatterOptions } from './formatter'
 export { default as FormatterBuilder } from './formatter/builder'
-export { default as ProgressFormatter } from './formatter/progress_formatter'
-export { default as RerunFormatter } from './formatter/rerun_formatter'
-export { default as SnippetsFormatter } from './formatter/snippets_formatter'
 export { default as SummaryFormatter } from './formatter/summary_formatter'
-export { default as UsageFormatter } from './formatter/usage_formatter'
-export { default as UsageJsonFormatter } from './formatter/usage_json_formatter'
 export { formatterHelpers }
 
 // Support Code Functions
@@ -73,6 +73,41 @@ export const Cli = deprecate(
 export const JsonFormatter = deprecate(
   _JsonFormatter,
   'Extending `JsonFormatter` is deprecated; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
+)
+/**
+ * @deprecated see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
+ */
+export const ProgressFormatter = deprecate(
+  _ProgressFormatter,
+  'Extending `ProgressFormatter` is deprecated; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
+)
+/**
+ * @deprecated see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
+ */
+export const RerunFormatter = deprecate(
+  _RerunFormatter,
+  'Extending `RerunFormatter` is deprecated; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
+)
+/**
+ * @deprecated see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
+ */
+export const SnippetsFormatter = deprecate(
+  _SnippetsFormatter,
+  'Extending `SnippetsFormatter` is deprecated; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
+)
+/**
+ * @deprecated see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
+ */
+export const UsageFormatter = deprecate(
+  _UsageFormatter,
+  'Extending `UsageFormatter` is deprecated; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
+)
+/**
+ * @deprecated see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
+ */
+export const UsageJsonFormatter = deprecate(
+  _UsageJsonFormatter,
+  'Extending `UsageJsonFormatter` is deprecated; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
 )
 /**
  * @deprecated use `loadSources` instead; see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export const PickleFilter = deprecate(
   '`PickleFilter` is deprecated, use `loadSources` instead; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
 )
 /**
- * @deprecated use `loadSources` instead; see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
+ * @deprecated use `runCucumber` instead; see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
  */
 export const Runtime = deprecate(
   _Runtime,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { default as _Cli } from './cli'
 import * as cliHelpers from './cli/helpers'
 import * as formatterHelpers from './formatter/helpers'
+import { default as _JsonFormatter } from './formatter/json_formatter'
 import { default as _PickleFilter } from './pickle_filter'
 import * as parallelCanAssignHelpers from './support_code_library_builder/parallel_can_assign_helpers'
 import { default as _Runtime } from './runtime'
@@ -17,7 +18,6 @@ export { version } from './version'
 // Formatters
 export { default as Formatter, IFormatterOptions } from './formatter'
 export { default as FormatterBuilder } from './formatter/builder'
-export { default as JsonFormatter } from './formatter/json_formatter'
 export { default as ProgressFormatter } from './formatter/progress_formatter'
 export { default as RerunFormatter } from './formatter/rerun_formatter'
 export { default as SnippetsFormatter } from './formatter/snippets_formatter'
@@ -66,6 +66,13 @@ export { wrapPromiseWithTimeout } from './time'
 export const Cli = deprecate(
   _Cli,
   '`Cli` is deprecated, use `runCucumber` instead; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
+)
+/**
+ * @deprecated see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>
+ */
+export const JsonFormatter = deprecate(
+  _JsonFormatter,
+  'Extending `JsonFormatter` is deprecated; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
 )
 /**
  * @deprecated use `loadSources` instead; see <https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md>

--- a/src/wrapper.mjs
+++ b/src/wrapper.mjs
@@ -23,6 +23,7 @@ export const AfterStep = cucumber.AfterStep
 export const Before = cucumber.Before
 export const BeforeAll = cucumber.BeforeAll
 export const BeforeStep = cucumber.BeforeStep
+export const defineStep = cucumber.defineStep
 export const defineParameterType = cucumber.defineParameterType
 export const Given = cucumber.Given
 export const setDefaultTimeout = cucumber.setDefaultTimeout
@@ -37,7 +38,6 @@ export const wrapPromiseWithTimeout = cucumber.wrapPromiseWithTimeout
 
 // Deprecated
 export const Cli = cucumber.Cli
-export const defineStep = cucumber.defineStep
 export const parseGherkinMessageStream = cucumber.parseGherkinMessageStream
 export const PickleFilter = cucumber.PickleFilter
 export const Runtime = cucumber.Runtime

--- a/src/wrapper.mjs
+++ b/src/wrapper.mjs
@@ -8,12 +8,7 @@ export const version = cucumber.version
 
 export const Formatter = cucumber.Formatter
 export const FormatterBuilder = cucumber.FormatterBuilder
-export const ProgressFormatter = cucumber.ProgressFormatter
-export const RerunFormatter = cucumber.RerunFormatter
-export const SnippetsFormatter = cucumber.SnippetsFormatter
 export const SummaryFormatter = cucumber.SummaryFormatter
-export const UsageFormatter = cucumber.UsageFormatter
-export const UsageJsonFormatter = cucumber.UsageJsonFormatter
 export const formatterHelpers = cucumber.formatterHelpers
 
 export const After = cucumber.After
@@ -38,6 +33,11 @@ export const wrapPromiseWithTimeout = cucumber.wrapPromiseWithTimeout
 // Deprecated
 export const Cli = cucumber.Cli
 export const JsonFormatter = cucumber.JsonFormatter
+export const ProgressFormatter = cucumber.ProgressFormatter
+export const RerunFormatter = cucumber.RerunFormatter
+export const SnippetsFormatter = cucumber.SnippetsFormatter
+export const UsageFormatter = cucumber.UsageFormatter
+export const UsageJsonFormatter = cucumber.UsageJsonFormatter
 export const parseGherkinMessageStream = cucumber.parseGherkinMessageStream
 export const PickleFilter = cucumber.PickleFilter
 export const Runtime = cucumber.Runtime

--- a/src/wrapper.mjs
+++ b/src/wrapper.mjs
@@ -8,7 +8,13 @@ export const version = cucumber.version
 
 export const Formatter = cucumber.Formatter
 export const FormatterBuilder = cucumber.FormatterBuilder
+export const JsonFormatter = cucumber.JsonFormatter
+export const ProgressFormatter = cucumber.ProgressFormatter
+export const RerunFormatter = cucumber.RerunFormatter
+export const SnippetsFormatter = cucumber.SnippetsFormatter
 export const SummaryFormatter = cucumber.SummaryFormatter
+export const UsageFormatter = cucumber.UsageFormatter
+export const UsageJsonFormatter = cucumber.UsageJsonFormatter
 export const formatterHelpers = cucumber.formatterHelpers
 
 export const After = cucumber.After
@@ -32,12 +38,6 @@ export const wrapPromiseWithTimeout = cucumber.wrapPromiseWithTimeout
 
 // Deprecated
 export const Cli = cucumber.Cli
-export const JsonFormatter = cucumber.JsonFormatter
-export const ProgressFormatter = cucumber.ProgressFormatter
-export const RerunFormatter = cucumber.RerunFormatter
-export const SnippetsFormatter = cucumber.SnippetsFormatter
-export const UsageFormatter = cucumber.UsageFormatter
-export const UsageJsonFormatter = cucumber.UsageJsonFormatter
 export const parseGherkinMessageStream = cucumber.parseGherkinMessageStream
 export const PickleFilter = cucumber.PickleFilter
 export const Runtime = cucumber.Runtime

--- a/src/wrapper.mjs
+++ b/src/wrapper.mjs
@@ -8,7 +8,6 @@ export const version = cucumber.version
 
 export const Formatter = cucumber.Formatter
 export const FormatterBuilder = cucumber.FormatterBuilder
-export const JsonFormatter = cucumber.JsonFormatter
 export const ProgressFormatter = cucumber.ProgressFormatter
 export const RerunFormatter = cucumber.RerunFormatter
 export const SnippetsFormatter = cucumber.SnippetsFormatter
@@ -38,6 +37,7 @@ export const wrapPromiseWithTimeout = cucumber.wrapPromiseWithTimeout
 
 // Deprecated
 export const Cli = cucumber.Cli
+export const JsonFormatter = cucumber.JsonFormatter
 export const parseGherkinMessageStream = cucumber.parseGherkinMessageStream
 export const PickleFilter = cucumber.PickleFilter
 export const Runtime = cucumber.Runtime


### PR DESCRIPTION
### 🤔 What's changed?

- Some rewording and fixing around how we describe deprecations
- Undeprecate `defineStep` - at the time the direction seemed to be to eventually make [strict keywords](https://github.com/cucumber/common/issues/768) the only behaviour. However there is [not a consensus across platforms ](https://github.com/cucumber/cucumber-jvm/issues/2557#issuecomment-1137867515) for doing that, so on that basis it should only be an option. The `PickleStep` model [has an 'Unknown' value](https://github.com/cucumber/messages/blob/main/jsonschema/Pickle.json#L50) so we can use that for `defineStep` and just throw if you try to use it with strict keywords. Finally, a user raised [a separate concern](https://github.com/cucumber/cucumber-js/issues/2043#issuecomment-1267136955) in defense of `defineStep` from a linguistics perspective. So overall I think there's no longer a case to remove this.
- ~~Deprecate the export of `JsonFormatter` class - currently most of the built-in formatter classes are exported like this but I think they should mostly be considered implementation details. When we tackle https://github.com/cucumber/cucumber-js/issues/2239 we'll rewrite this formatter, probably in the new "plugin"-style format we've discussed, so we should get this off the entry point as soon as we can.~~
    - Whilst it would be good to move early on this, we can't reasonably deprecate something without pointing to the new thing that people should migrate to, which we don't have yet, so omitting this for now.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
