### PR TITLE
remove generator snippet interface

### DIFF
--- a/features/step_definition_snippets_interfaces.feature
+++ b/features/step_definition_snippets_interfaces.feature
@@ -25,7 +25,6 @@ Feature: step definition snippets custom syntax
     Examples:
       | INTERFACE   | SNIPPET_FUNCTION_KEYWORD_AND_PARAMETERS | SNIPPET_IMPLEMENTATION            |
       | callback    | function (callback)                     | callback(null, 'pending')         |
-      | generator   | function *()                            | return 'pending'                  |
       | promise     | function ()                             | return Promise.resolve('pending') |
       | async-await | async function ()                       | return 'pending'                  |
       | synchronous | function ()                             | return 'pending'                  |

--- a/src/formatter/step_definition_snippet_builder/javascript_snippet_syntax.ts
+++ b/src/formatter/step_definition_snippet_builder/javascript_snippet_syntax.ts
@@ -23,8 +23,6 @@ export default class JavaScriptSnippetSyntax implements ISnippetSnytax {
     let functionKeyword = 'function '
     if (this.snippetInterface === SnippetInterface.AsyncAwait) {
       functionKeyword = 'async ' + functionKeyword
-    } else if (this.snippetInterface === SnippetInterface.Generator) {
-      functionKeyword += '*'
     }
 
     let implementation: string

--- a/src/formatter/step_definition_snippet_builder/javascript_snippet_syntax_spec.ts
+++ b/src/formatter/step_definition_snippet_builder/javascript_snippet_syntax_spec.ts
@@ -45,31 +45,6 @@ describe('JavascriptSnippetSyntax', () => {
       })
     })
 
-    describe('generator interface', () => {
-      it('returns the proper snippet', function () {
-        // Arrange
-        const syntax = new JavascriptSnippetSyntax(SnippetInterface.Generator)
-        const buildOptions: ISnippetSyntaxBuildOptions = {
-          comment: 'comment',
-          functionName: 'functionName',
-          generatedExpressions: generateExpressions('"abc" def "ghi"'),
-          stepParameterNames: [],
-        }
-
-        // Act
-        const result = syntax.build(buildOptions)
-
-        // Assert
-        expect(result).to.eql(
-          reindent(`
-            functionName('{string} def {string}', function *(string, string2) {
-              // comment
-              return 'pending';
-            });`)
-        )
-      })
-    })
-
     describe('promise interface', () => {
       it('returns the proper snippet', function () {
         // Arrange

--- a/src/formatter/step_definition_snippet_builder/snippet_syntax.ts
+++ b/src/formatter/step_definition_snippet_builder/snippet_syntax.ts
@@ -3,7 +3,6 @@ import { GeneratedExpression } from '@cucumber/cucumber-expressions'
 export enum SnippetInterface {
   AsyncAwait = 'async-await',
   Callback = 'callback',
-  Generator = 'generator',
   Promise = 'promise',
   Synchronous = 'synchronous',
 }


### PR DESCRIPTION
### 🤔 What's changed?

Remove the "generator" snippet interface.

### ⚡️ What's your motivation? 

We [removed support](https://github.com/cucumber/cucumber-js/pull/1725) for generators in steps some time ago.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :boom: Breaking change (incompatible changes to the API)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
