### PR TITLE
remove my work e-mail from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "RolandArgos <roland.ormrod@argos.co.uk>",
     "Ronald Chen (https://github.com/Pyrolistical)",
     "Sam Saccone <sam@samx.it>",
+    "Scott Deakin (https://github.com/GeekyDeaks)",
     "seantdg <sm.davis@gmx.com>",
     "Seb Rose <seb@claysnow.co.uk>",
     "Sérgio Junior <sergioamjr91@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "RolandArgos <roland.ormrod@argos.co.uk>",
     "Ronald Chen (https://github.com/Pyrolistical)",
     "Sam Saccone <sam@samx.it>",
-    "Scott Deakin <scott.deakin@kantar.com>",
     "seantdg <sm.davis@gmx.com>",
     "Seb Rose <seb@claysnow.co.uk>",
     "Sérgio Junior <sergioamjr91@gmail.com>",


### PR DESCRIPTION
Hi, sorry but I have been asked by my company to remove my work e-mail address from all public repos and this is one of them.

This was my mistake as I was accidentally using the wrong account when contributing to the project.

Cheers,
Scott
