### PR TITLE
fix: ensure feature paths are properly deduplicated

### DIFF
--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -73,7 +73,8 @@ async function expandPaths(
       return expanded.flat()
     })
   )
-  return expandedPaths.flat().map((x) => path.normalize(x))
+  const normalized = expandedPaths.flat().map((x) => path.normalize(x));
+  return [...new Set(normalized)]
 }
 
 async function getUnexpandedFeaturePaths(
@@ -126,7 +127,6 @@ async function expandFeaturePaths(
   featurePaths: string[]
 ): Promise<string[]> {
   featurePaths = featurePaths.map((p) => p.replace(/(:\d+)*$/g, '')) // Strip line numbers
-  featurePaths = [...new Set(featurePaths)] // Deduplicate the feature files
   return await expandPaths(cwd, featurePaths, '.feature')
 }
 

--- a/src/api/paths_spec.ts
+++ b/src/api/paths_spec.ts
@@ -55,7 +55,31 @@ describe('resolvePaths', () => {
       expect(importPaths).to.eql([esmSupportCodePath])
     })
 
-    it('deduplicates the .feature files before returning', async function () {
+    it('deduplicates features based on overlapping expressions', async function () {
+      // Arrange
+      const cwd = await buildTestWorkingDirectory()
+      const relativeFeaturePath = path.join('features', 'a.feature')
+      const featurePath = path.join(cwd, relativeFeaturePath)
+      await fsExtra.outputFile(featurePath, '')
+      // Act
+      const { featurePaths } = await resolvePaths(
+        new FakeLogger(),
+        cwd,
+        {
+          paths: ['features/*.feature', 'features/a.feature'],
+        },
+        {
+          requireModules: [],
+          requirePaths: [],
+          importPaths: [],
+        }
+      )
+
+      // Assert
+      expect(featurePaths).to.eql([featurePath])
+    })
+
+    it('deduplicates features based on multiple targets of same path', async function () {
       // Arrange
       const cwd = await buildTestWorkingDirectory()
       const relativeFeaturePath = path.join('features', 'a.feature')


### PR DESCRIPTION
### 🤔 What's changed?

Deduplicate feature paths a bit later in the process of expanding and normalizing them. This ensures that e.g. two overlapping glob expressions, or a mixture of a glob and a specific path, won't cause the same feature to be loaded multiple times.

### ⚡️ What's your motivation? 

Fixes #2226

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
