### PR TITLE
Issue 2262 ES imports in parallel

### DIFF
--- a/src/api/support.ts
+++ b/src/api/support.ts
@@ -24,10 +24,13 @@ export async function getSupportCodeLibrary({
     requirePaths,
     importPaths,
   })
+  const importPromises:Array<Promise<void>> = []
+
   requireModules.map((module) => require(module))
   requirePaths.map((path) => require(path))
-  for (const path of importPaths) {
-    await importer(pathToFileURL(path))
-  }
+  importPaths.map((path) => importPromises.push(importer(pathToFileURL(path))))
+
+  await Promise.all(importPromises)
+
   return supportCodeLibraryBuilder.finalize()
 }

--- a/src/api/support.ts
+++ b/src/api/support.ts
@@ -19,12 +19,13 @@ export async function getSupportCodeLibrary({
   requirePaths: string[]
   importPaths: string[]
 }): Promise<ISupportCodeLibrary> {
+  const importPromises: Array<Promise<void>> = []
+
   supportCodeLibraryBuilder.reset(cwd, newId, {
     requireModules,
     requirePaths,
     importPaths,
   })
-  const importPromises:Array<Promise<void>> = []
 
   requireModules.map((module) => require(module))
   requirePaths.map((path) => require(path))


### PR DESCRIPTION


### 🤔 What's changed?

Optimization in the support.ts file to gather the dynamic import Promises into an array and then resolve them with a single Promise.all() call.

### ⚡️ What's your motivation? 

This should yield a noticeable speedup on Cucumber installs with very large ES step definition libraries. Other Cucumber installs will be unaffected.

### 🏷️ What kind of change is this?

- 🐎 Optimization - A change meant to make the code more performant.

### ♻️ Anything particular you want feedback on?

If there are other instances in the codebase where an await is inside a loop then this pattern should be applied there as well.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

