### PR TITLE
Cucumber now creates whatever directories are necessary to make a report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
-
+- Reporters create sub-directory automatically instead of failing ([#2266](https://github.com/cucumber/cucumber-js/pull/2266))
 ## [9.0.1] - 2023-03-15
 ### Fixed
 - Ensure feature paths are properly deduplicated ([#2258](https://github.com/cucumber/cucumber-js/pull/2258))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Added
 - Formatters create sub-directory automatically instead of failing ([#2266](https://github.com/cucumber/cucumber-js/pull/2266))
+
 ## [9.0.1] - 2023-03-15
 ### Fixed
 - Ensure feature paths are properly deduplicated ([#2258](https://github.com/cucumber/cucumber-js/pull/2258))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
-- Reporters create sub-directory automatically instead of failing ([#2266](https://github.com/cucumber/cucumber-js/pull/2266))
+- Formatters create sub-directory automatically instead of failing ([#2266](https://github.com/cucumber/cucumber-js/pull/2266))
 ## [9.0.1] - 2023-03-15
 ### Fixed
 - Ensure feature paths are properly deduplicated ([#2258](https://github.com/cucumber/cucumber-js/pull/2258))

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -16,7 +16,7 @@ For each value you provide, `TYPE` should be one of:
 * A relative path to a local formatter implementation e.g. `./my-customer-formatter.js`
 * An absolute path to a local formatter implementation in the form of a `file://` URL
 
-If `PATH` is supplied, the formatter prints to the given file, otherwise it prints to `stdout`.
+If `PATH` is supplied, the formatter prints to the given file, otherwise it prints to `stdout`. If the path includes directories that do not yet exist they will be created.
 
 For example, this configuration would give you a progress bar as you run, plus JSON and HTML report files:
 
@@ -30,7 +30,7 @@ Some notes on specifying Formatters:
 
 ## Options
 
-Many formatters, including the built-in ones, support some configurability via options. You can provide this data as an object literal via the `formatOptions` configuration option, like this:
+Many formatters, including the built-in ones, support some configuration via options. You can provide this data as an object literal via the `formatOptions` configuration option, like this:
 
 - In a configuration file `{ formatOptions: { someOption: true } }`
 - On the CLI `$ cucumber-js --format-options '{"someOption":true}'`

--- a/features/formatter_paths.feature
+++ b/features/formatter_paths.feature
@@ -33,10 +33,12 @@ Feature: Formatter Paths
       <duration-stat>
       """
 
-  Scenario: Invalid path
-    When I run cucumber-js with `-f summary:invalid/summary.txt`
-    Then it fails
-    And the error output contains the text:
+  Scenario: Created relative path
+    When I run cucumber-js with `-f summary:some/long/path/for/reports/summary.txt`
+    Then the file "some/long/path/for/reports/summary.txt" has the text:
       """
-      ENOENT
+      1 scenario (1 passed)
+      1 step (1 passed)
+      <duration-stat>
       """
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
         "luxon": "3.2.1",
+        "mkdirp": "^2.1.5",
         "mz": "^2.7.0",
         "progress": "^2.0.3",
         "resolve-pkg": "^2.0.0",
@@ -5251,6 +5252,20 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.5.tgz",
+      "integrity": "sha512-jbjfql+shJtAPrFoKxHOXip4xS+kul9W3OzfzzrqueWK2QMGon2bFH2opl6W9EagBThjEz+iysyi/swOoVfB/w==",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha": {
@@ -11925,6 +11940,11 @@
         "is-plain-obj": "^1.1.0",
         "kind-of": "^6.0.3"
       }
+    },
+    "mkdirp": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.5.tgz",
+      "integrity": "sha512-jbjfql+shJtAPrFoKxHOXip4xS+kul9W3OzfzzrqueWK2QMGon2bFH2opl6W9EagBThjEz+iysyi/swOoVfB/w=="
     },
     "mocha": {
       "version": "10.2.0",

--- a/package.json
+++ b/package.json
@@ -232,6 +232,7 @@
     "lodash.merge": "^4.6.2",
     "lodash.mergewith": "^4.6.2",
     "luxon": "3.2.1",
+    "mkdirp": "^2.1.5",
     "mz": "^2.7.0",
     "progress": "^2.0.3",
     "resolve-pkg": "^2.0.0",

--- a/src/api/formatters.ts
+++ b/src/api/formatters.ts
@@ -9,6 +9,7 @@ import fs from 'mz/fs'
 import path from 'path'
 import { IRunOptionsFormats } from './types'
 import { ILogger } from '../logger'
+import { mkdirp } from 'mkdirp'
 
 export async function initializeFormatters({
   env,
@@ -70,12 +71,26 @@ export async function initializeFormatters({
     await initializeFormatter(stdout, 'stdout', configuration.stdout)
   )
 
-  for (const [target, type] of Object.entries(configuration.files)) {
-    const stream: IFormatterStream = fs.createWriteStream(null, {
-      fd: await fs.open(path.resolve(cwd, target), 'w'),
-    })
-    formatters.push(await initializeFormatter(stream, target, type))
-  }
+  const streamPromises: Promise<void>[] = []
+
+  Object.entries(configuration.files).forEach(([target, type]) => {
+    streamPromises.push(
+      (async (target, type) => {
+        const absoluteTarget = path.resolve(cwd, target)
+
+        if (!(await fs.exists(absoluteTarget))) {
+          await mkdirp(path.dirname(absoluteTarget))
+        }
+
+        const stream: IFormatterStream = fs.createWriteStream(null, {
+          fd: await fs.open(absoluteTarget, 'w'),
+        })
+        formatters.push(await initializeFormatter(stream, target, type))
+      })(target, type)
+    )
+  })
+
+  await Promise.all(streamPromises)
 
   return async function () {
     await Promise.all(formatters.map(async (f) => await f.finished()))

--- a/src/api/formatters.ts
+++ b/src/api/formatters.ts
@@ -87,7 +87,9 @@ export async function initializeFormatters({
 
           formatters.push(await initializeFormatter(stream, target, type))
         } catch (error) {
-          throw new Error(`Cucumber was unable to create file "${absoluteTarget}".`)
+          throw new Error(
+            `Cucumber was unable to create file "${absoluteTarget}".`
+          )
         }
       })(target, type)
     )

--- a/src/api/formatters.ts
+++ b/src/api/formatters.ts
@@ -80,17 +80,14 @@ export async function initializeFormatters({
 
         try {
           await mkdirp(path.dirname(absoluteTarget))
-
-          const stream: IFormatterStream = fs.createWriteStream(null, {
-            fd: await fs.open(absoluteTarget, 'w'),
-          })
-
-          formatters.push(await initializeFormatter(stream, target, type))
         } catch (error) {
-          throw new Error(
-            `Cucumber was unable to create file "${absoluteTarget}".`
-          )
+          logger.warn('Failed to ensure directory for formatter target exists')
         }
+
+        const stream: IFormatterStream = fs.createWriteStream(null, {
+          fd: await fs.open(absoluteTarget, 'w'),
+        })
+        formatters.push(await initializeFormatter(stream, target, type))
       })(target, type)
     )
   })

--- a/src/api/formatters.ts
+++ b/src/api/formatters.ts
@@ -78,8 +78,10 @@ export async function initializeFormatters({
       (async (target, type) => {
         const absoluteTarget = path.resolve(cwd, target)
 
-        if (!(await fs.exists(absoluteTarget))) {
+        try {
           await mkdirp(path.dirname(absoluteTarget))
+        } catch (error) {
+          logger.warn('Failed to ensure directory for formatter target exists')
         }
 
         const stream: IFormatterStream = fs.createWriteStream(null, {

--- a/src/api/formatters.ts
+++ b/src/api/formatters.ts
@@ -80,14 +80,17 @@ export async function initializeFormatters({
 
         try {
           await mkdirp(path.dirname(absoluteTarget))
-        } catch (error) {
-          logger.warn('Failed to ensure directory for formatter target exists')
-        }
 
-        const stream: IFormatterStream = fs.createWriteStream(null, {
-          fd: await fs.open(absoluteTarget, 'w'),
-        })
-        formatters.push(await initializeFormatter(stream, target, type))
+          const stream: IFormatterStream = fs.createWriteStream(null, {
+            fd: await fs.open(absoluteTarget, 'w'),
+          })
+
+          formatters.push(await initializeFormatter(stream, target, type))
+        } catch (error) {
+          logger.warn(
+            `Cucumber was unable to create file "${absoluteTarget}". Check the access permissions of the directory. The test will continue from here, but no report file will be generated.`
+          )
+        }
       })(target, type)
     )
   })

--- a/src/api/formatters.ts
+++ b/src/api/formatters.ts
@@ -87,9 +87,7 @@ export async function initializeFormatters({
 
           formatters.push(await initializeFormatter(stream, target, type))
         } catch (error) {
-          logger.warn(
-            `Cucumber was unable to create file "${absoluteTarget}". Check the access permissions of the directory. The test will continue from here, but no report file will be generated.`
-          )
+          throw new Error(`Cucumber was unable to create file "${absoluteTarget}".`)
         }
       })(target, type)
     )

--- a/src/formatter/builder.ts
+++ b/src/formatter/builder.ts
@@ -102,13 +102,13 @@ const FormatterBuilder = {
     descriptor: string,
     cwd: string
   ) {
-    let normalised: URL | string = descriptor
+    let normalized: URL | string = descriptor
     if (descriptor.startsWith('.')) {
-      normalised = pathToFileURL(path.resolve(cwd, descriptor))
+      normalized = pathToFileURL(path.resolve(cwd, descriptor))
     } else if (descriptor.startsWith('file://')) {
-      normalised = new URL(descriptor)
+      normalized = new URL(descriptor)
     }
-    let CustomClass = await FormatterBuilder.loadFile(normalised)
+    let CustomClass = await FormatterBuilder.loadFile(normalized)
     CustomClass = FormatterBuilder.resolveConstructor(CustomClass)
     if (doesHaveValue(CustomClass)) {
       return CustomClass


### PR DESCRIPTION
### 🤔 What's changed?
```
  Scenario: Created relative path
    When I run cucumber-js with `-f summary:some/long/path/for/reports/summary.txt`
    Then the file "some/long/path/for/reports/summary.txt" has the text:
      """
      1 scenario (1 passed)
      1 step (1 passed)
      <duration-stat>
      """
```
Previously Cucumber wouldn't created long directory chains as seen in this feature - some outside process had to make sure the directory the report file was to be written into exists.

### ⚡️ What's your motivation? 

Fixes #2159 

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

There was a test in place to see if Cucumber will fail if the directory didn't exist that was removed.  It is possible for this feature to fail if Cucumber lacks permission to create directories - but I feel testing this is a bit of overkill as such permission checking wasn't previously being tested and in any event it's a feature of the OS, not Cucumber.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

