### PR TITLE
Address deprecation warning in Unit Tests

### DIFF
--- a/src/api/test_helpers.ts
+++ b/src/api/test_helpers.ts
@@ -32,6 +32,9 @@ export async function setupEnvironment(): Promise<Partial<IRunEnvironment>> {
 }
 
 export async function teardownEnvironment(environment: IRunEnvironment) {
-  await fs.rmdir(environment.cwd, { recursive: true })
-  environment.stdout.end()
+  return new Promise((resolve) => {
+    fs.rm(environment.cwd, { recursive: true }, resolve)
+  }).then(() => {
+    environment.stdout.end()
+  })
 }


### PR DESCRIPTION
### 🤔 What's changed?

Fixing a deprecation warning in the unit tests.

```
> mocha 'src/**/*_spec.ts'



  ........(node:38244) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
...........................................................................................................
  ...................................................................................................................
  ................................................................................................

  326 passing (4s)
```

### ⚡️ What's your motivation? 

Bugfix - well, a potential bug when the Node team finally follows up on the deprecation.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

