### PR TITLE
tone down global install warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Changed
+- Only show global install warning in debug mode ([#2285](https://github.com/cucumber/cucumber-js/pull/2285))
+
 ### Fixed
 - Export `ISupportCodeLibrary` type on `/api` entry point ([#2284](https://github.com/cucumber/cucumber-js/pull/2284))
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,7 +30,7 @@ Unlike many libraries, Cucumber is _stateful_; you call functions to register yo
 
 Some libraries with a command-line interface are designed to be installed globally. Not Cucumber though - for the reasons above, you need to install it as a dependency in your project.
 
-We'll emit a warning if it looks like Cucumber is installed globally.
+We'll emit a warning when in [debug mode](./debugging.md) if it looks like Cucumber is installed globally.
 
 ### Duplicate dependency
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -39,7 +39,10 @@ export default class Cli {
   }
 
   async run(): Promise<ICliRunResult> {
-    await validateInstall()
+    const debugEnabled = debug.enabled('cucumber')
+    if (debugEnabled) {
+      await validateInstall()
+    }
     const { options, configuration: argvConfiguration } = ArgvParser.parse(
       this.argv
     )
@@ -59,12 +62,13 @@ export default class Cli {
         success: true,
       }
     }
+
     const environment = {
       cwd: this.cwd,
       stdout: this.stdout,
       stderr: this.stderr,
       env: this.env,
-      debug: debug.enabled('cucumber'),
+      debug: debugEnabled,
     }
     const { useConfiguration: configuration, runConfiguration } =
       await loadConfiguration(

--- a/src/cli/install_validator.ts
+++ b/src/cli/install_validator.ts
@@ -6,7 +6,7 @@ export async function validateInstall(): Promise<void> {
     console.warn(
       `
       It looks like you're running Cucumber from a global installation.
-      This won't work - you need to have Cucumber installed as a local dependency in your project.
+      If so, you'll likely see issues - you need to have Cucumber installed as a local dependency in your project.
       See https://github.com/cucumber/cucumber-js/blob/main/docs/installation.md#invalid-installations
       `
     )


### PR DESCRIPTION
### 🤔 What's changed?

- Tweak the wording of the global install warning to be less severe
- Only do the check and warning if debug is enabled

### ⚡️ What's your motivation? 

Fixes #2274 - since this can be a false positive, and the issues stemming from it are now [much more obvious and actionable](https://github.com/cucumber/cucumber-js/pull/2089) than they used to be, we don't need this to be prominent any more.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
