### PR TITLE
Add option to pass in custom test suite name for Junit formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
-Added option for Junit test suite name to be passed in formatOptions ([#2265](https://github.com/cucumber/cucumber-js/issues/2265))
+### Added
+- New option for JUnit test suite name to be passed in `formatOptions` ([#2265](https://github.com/cucumber/cucumber-js/issues/2265))
+
 ## [9.1.2] - 2023-05-07
 ### Changed
 - Only show global install warning in debug mode ([#2285](https://github.com/cucumber/cucumber-js/pull/2285))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
-
+Added option for Junit test suite name to be passed in formatOptions ([#2265](https://github.com/cucumber/cucumber-js/issues/2265))
 ## [9.1.2] - 2023-05-07
 ### Changed
 - Only show global install warning in debug mode ([#2285](https://github.com/cucumber/cucumber-js/pull/2285))

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -107,6 +107,10 @@ Outputs details of the test run in the legacy JSON format.
 
 The JUnit formatter produces an XML-based report in the standard(ish) [JUnit format](https://github.com/junit-team/junit5/blob/43638eb6a870e0d6c49224053dfeb39dcf0ef33f/platform-tests/src/test/resources/jenkins-junit.xsd). This is most commonly useful for having your CI platform pick up your tests results and factor them into its reporting. Consult your CI platform's docs for where exactly you should output this report to and what the filename should be.
 
+Options specific to this formatter:
+
+- `suiteName` - value to go in the `name` attribute of the `testsuite` element in the output (defaults to `cucumber-js`)
+
 ### `snippets`
 
 The Snippets Formatter doesn't output anything regarding the test run; it just prints [Snippets to implement any undefined steps](./snippets.md). This is useful when you want to quickly zero in on the steps you have to implement and grab the snippet code for them in one go.

--- a/src/formatter/junit_formatter.ts
+++ b/src/formatter/junit_formatter.ts
@@ -18,6 +18,7 @@ import {
   getGherkinStepMap,
 } from './helpers/gherkin_document_parser'
 import { getPickleStepMap, getStepKeyword } from './helpers/pickle_parser'
+import { valueOrDefault } from '../value_checker'
 
 interface IJUnitTestSuite {
   name: string
@@ -68,10 +69,15 @@ interface IBuildJUnitTestStepOptions {
 
 export default class JunitFormatter extends Formatter {
   private readonly names: Record<string, string[]> = {}
+  private readonly suiteName: string
   public static readonly documentation: string = 'Outputs JUnit report'
 
   constructor(options: IFormatterOptions) {
     super(options)
+    this.suiteName = valueOrDefault(
+      options.parsedArgvOptions.junit?.suiteName,
+      'cucumber-js'
+    )
     options.eventBroadcaster.on('envelope', (envelope: messages.Envelope) => {
       if (doesHaveValue(envelope.testRunFinished)) {
         this.onTestRunFinished()
@@ -242,7 +248,7 @@ export default class JunitFormatter extends Formatter {
     const failures = tests.length - passed - skipped
 
     const testSuite: IJUnitTestSuite = {
-      name: 'cucumber-js',
+      name: this.suiteName,
       tests,
       failures,
       skipped,

--- a/src/formatter/junit_formatter_spec.ts
+++ b/src/formatter/junit_formatter_spec.ts
@@ -561,4 +561,44 @@ describe('JunitFormatter', () => {
       )
     })
   })
+
+  describe('custom test suite name', () => {
+    it('outputs with the custom name', async () => {
+      // Arrange
+      const sources = [
+        {
+          data: [
+            'Feature: my feature',
+            '  Scenario: my scenario',
+            '    Given a passing step',
+          ].join('\n'),
+          uri: 'a.feature',
+        },
+      ]
+
+      const supportCodeLibrary = getJUnitFormatterSupportCodeLibrary(clock)
+
+      // Act
+      const output = await testFormatter({
+        parsedArgvOptions: {
+          "junit": {
+            "suiteName": "my test suite"
+          }
+        },
+        sources,
+        supportCodeLibrary,
+        type: 'junit',
+      })
+
+      // Assert
+      expect(output).xml.to.deep.equal(
+        '<?xml version="1.0"?>\n' +
+          '<testsuite failures="0" skipped="0" name="my test suite" time="0.001" tests="1">\n' +
+          '  <testcase classname="my feature" name="my scenario" time="0.001">\n' +
+          '    <system-out><![CDATA[Given a passing step......................................................passed]]></system-out>\n' +
+          '  </testcase>\n' +
+          '</testsuite>'
+      )
+    })
+  })
 })

--- a/src/formatter/junit_formatter_spec.ts
+++ b/src/formatter/junit_formatter_spec.ts
@@ -581,9 +581,9 @@ describe('JunitFormatter', () => {
       // Act
       const output = await testFormatter({
         parsedArgvOptions: {
-          "junit": {
-            "suiteName": "my test suite"
-          }
+          junit: {
+            suiteName: 'my test suite',
+          },
         },
         sources,
         supportCodeLibrary,
@@ -594,6 +594,41 @@ describe('JunitFormatter', () => {
       expect(output).xml.to.deep.equal(
         '<?xml version="1.0"?>\n' +
           '<testsuite failures="0" skipped="0" name="my test suite" time="0.001" tests="1">\n' +
+          '  <testcase classname="my feature" name="my scenario" time="0.001">\n' +
+          '    <system-out><![CDATA[Given a passing step......................................................passed]]></system-out>\n' +
+          '  </testcase>\n' +
+          '</testsuite>'
+      )
+    })
+  })
+
+  describe('no custom test suite name', () => {
+    it('outputs with cucumber-js as test suite name', async () => {
+      // Arrange
+      const sources = [
+        {
+          data: [
+            'Feature: my feature',
+            '  Scenario: my scenario',
+            '    Given a passing step',
+          ].join('\n'),
+          uri: 'a.feature',
+        },
+      ]
+
+      const supportCodeLibrary = getJUnitFormatterSupportCodeLibrary(clock)
+
+      // Act
+      const output = await testFormatter({
+        sources,
+        supportCodeLibrary,
+        type: 'junit',
+      })
+
+      // Assert
+      expect(output).xml.to.deep.equal(
+        '<?xml version="1.0"?>\n' +
+          '<testsuite failures="0" skipped="0" name="cucumber-js" time="0.001" tests="1">\n' +
           '  <testcase classname="my feature" name="my scenario" time="0.001">\n' +
           '    <system-out><![CDATA[Given a passing step......................................................passed]]></system-out>\n' +
           '  </testcase>\n' +


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?
Added functionality which allows users to pass in custom test suite names for the Junit formatter
<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 
Fixes #2265 
<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->


- :zap: New feature (non-breaking change which adds new behaviour)


### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->
I haven't added anything to the docs because I wasn't sure if there was a suitable place, but I am happy to write some documentation if it is needed :-). 
I added two unit tests, I tried to stick to the current format being used but I'm not entirely sure it's correct.
Finally there is a test failing under the 16x windows build. However it seems this test has failed in other PRs so I'm not sure it's related to the changes I've added. 

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behavior of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
