### PR TITLE
fix logFailedTestCases for RerunFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber
 ### Added
 - New option for JUnit test suite name to be passed in `formatOptions` ([#2265](https://github.com/cucumber/cucumber-js/issues/2265))
 
+### Fixed
+- Correctly interpret retried scenarios in rerun formatter ([#2290](https://github.com/cucumber/cucumber-js/issues/2290))
+
 ## [9.1.2] - 2023-05-07
 ### Changed
 - Only show global install warning in debug mode ([#2285](https://github.com/cucumber/cucumber-js/pull/2285))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber
 - New option for JUnit test suite name to be passed in `formatOptions` ([#2265](https://github.com/cucumber/cucumber-js/issues/2265))
 - Logging and calculation is decoupled in `logFailedTestCases()` for easier customization ([#2290](https://github.com/cucumber/cucumber-js/issues/2290))
 
+### Changed
+- separator of `RerunFormatter` is changed to protected from private ([#2290](https://github.com/cucumber/cucumber-js/issues/2290))
+
 ### Fixed
 - Correctly interpret retried scenarios in rerun formatter ([#2290](https://github.com/cucumber/cucumber-js/issues/2290))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber
 ## [Unreleased]
 ### Added
 - New option for JUnit test suite name to be passed in `formatOptions` ([#2265](https://github.com/cucumber/cucumber-js/issues/2265))
+- Logging and calculation is decoupled in `logFailedTestCases()` for easier customization ([#2290](https://github.com/cucumber/cucumber-js/issues/2290))
 
 ### Fixed
 - Correctly interpret retried scenarios in rerun formatter ([#2290](https://github.com/cucumber/cucumber-js/issues/2290))

--- a/features/retry.feature
+++ b/features/retry.feature
@@ -571,7 +571,7 @@ Feature: Retry flaky tests
       And scenario "Failing" attempt 1 step "Given a failing step" has status "failed"
       And scenario "Passing" step "Given a passing step" has status "skipped"
 
-  Scenario: RerunFormatter accidentally reports retried attempts too
+  Scenario: RerunFormatter does not report attempts that are retried
     Given a file named "features/a.feature" with:
       """
       Feature:
@@ -595,6 +595,6 @@ Feature: Retry flaky tests
     When I run cucumber-js with `--retry 1 --format rerun`
     Then it outputs the text:
       """
-       features/a.feature:2:2
+       features/a.feature:2
       """
     And it fails

--- a/features/retry.feature
+++ b/features/retry.feature
@@ -27,7 +27,7 @@ Feature: Retry flaky tests
         Scenario: Failing
           Given a failing step
       """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 
@@ -47,7 +47,7 @@ Feature: Retry flaky tests
         Scenario: Failing
           Given a failing step
       """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 
@@ -67,7 +67,7 @@ Feature: Retry flaky tests
         Scenario: Flaky
           Given a flaky step
       """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 
@@ -107,7 +107,7 @@ Feature: Retry flaky tests
         Scenario: Flaky
           Given a flaky step
       """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 
@@ -149,7 +149,7 @@ Feature: Retry flaky tests
         Scenario: Good
           Given a good step
       """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 
@@ -197,7 +197,7 @@ Feature: Retry flaky tests
         Scenario: Good
           Given a good step
       """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 
@@ -246,7 +246,7 @@ Feature: Retry flaky tests
         Scenario: Bad
           Given a bad step
       """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 
@@ -305,7 +305,7 @@ Feature: Retry flaky tests
         Scenario: Failing
           Given a failing step
       """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 
@@ -330,7 +330,7 @@ Feature: Retry flaky tests
         Scenario: Flaky
           Given a flaky step
       """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 
@@ -357,7 +357,7 @@ Feature: Retry flaky tests
         Scenario: Flaky
           Given a flaky step
       """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 
@@ -386,7 +386,7 @@ Feature: Retry flaky tests
         Scenario: Also Flaky
           Given an other flaky step
       """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 
@@ -430,7 +430,7 @@ Feature: Retry flaky tests
         Scenario: Third Flaky
           Given one more flaky step
       """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 
@@ -479,7 +479,7 @@ Feature: Retry flaky tests
         Scenario: Flaky
           Given a flaky step
       """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Before, After, Given, setWorldConstructor} = require('@cucumber/cucumber')
 
@@ -526,7 +526,7 @@ Feature: Retry flaky tests
         Scenario: Passing
           Given a passing step
       """
-      Given a file named "features/step_definitions/cucumber_steps.js" with:
+      And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 
@@ -558,7 +558,7 @@ Feature: Retry flaky tests
         Scenario: Passing
           Given a passing step
       """
-      Given a file named "features/step_definitions/cucumber_steps.js" with:
+      And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 
@@ -578,7 +578,7 @@ Feature: Retry flaky tests
         Scenario: Flaky
           Given a flaky step
       """
-    Given a file named "features/step_definitions/cucumber_steps.js" with:
+    And a file named "features/step_definitions/cucumber_steps.js" with:
       """
       const {Given} = require('@cucumber/cucumber')
 

--- a/src/formatter/rerun_formatter.ts
+++ b/src/formatter/rerun_formatter.ts
@@ -37,19 +37,21 @@ export default class RerunFormatter extends Formatter {
     const mapping: UriToLinesMap = {}
     this.eventDataCollector
       .getTestCaseAttempts()
-      .forEach(({ gherkinDocument, pickle, worstTestStepResult }) => {
-        if (isFailedAttempt(worstTestStepResult)) {
-          const relativeUri = pickle.uri
-          const line =
-            getGherkinScenarioLocationMap(gherkinDocument)[
-              pickle.astNodeIds[pickle.astNodeIds.length - 1]
-            ].line
-          if (doesNotHaveValue(mapping[relativeUri])) {
-            mapping[relativeUri] = []
+      .forEach(
+        ({ gherkinDocument, pickle, worstTestStepResult, willBeRetried }) => {
+          if (isFailedAttempt(worstTestStepResult) && !willBeRetried) {
+            const relativeUri = pickle.uri
+            const line =
+              getGherkinScenarioLocationMap(gherkinDocument)[
+                pickle.astNodeIds[pickle.astNodeIds.length - 1]
+              ].line
+            if (doesNotHaveValue(mapping[relativeUri])) {
+              mapping[relativeUri] = []
+            }
+            mapping[relativeUri].push(line)
           }
-          mapping[relativeUri].push(line)
         }
-      })
+      )
     const text = Object.keys(mapping)
       .map((uri) => {
         const lines = mapping[uri]

--- a/src/formatter/rerun_formatter.ts
+++ b/src/formatter/rerun_formatter.ts
@@ -18,7 +18,7 @@ function isFailedAttempt(worstTestStepResult: messages.TestStepResult) {
 }
 
 export default class RerunFormatter extends Formatter {
-  private readonly separator: string
+  protected readonly separator: string
   public static readonly documentation: string =
     'Prints failing files with line numbers.'
 

--- a/src/formatter/rerun_formatter.ts
+++ b/src/formatter/rerun_formatter.ts
@@ -13,6 +13,10 @@ interface UriToLinesMap {
   [uri: string]: number[]
 }
 
+function isFailedAttempt(worstTestStepResult: messages.TestStepResult) {
+  return worstTestStepResult.status !== messages.TestStepResultStatus.PASSED
+}
+
 export default class RerunFormatter extends Formatter {
   private readonly separator: string
   public static readonly documentation: string =
@@ -34,9 +38,7 @@ export default class RerunFormatter extends Formatter {
     this.eventDataCollector
       .getTestCaseAttempts()
       .forEach(({ gherkinDocument, pickle, worstTestStepResult }) => {
-        if (
-          worstTestStepResult.status !== messages.TestStepResultStatus.PASSED
-        ) {
+        if (isFailedAttempt(worstTestStepResult)) {
           const relativeUri = pickle.uri
           const line =
             getGherkinScenarioLocationMap(gherkinDocument)[

--- a/src/formatter/rerun_formatter.ts
+++ b/src/formatter/rerun_formatter.ts
@@ -33,7 +33,7 @@ export default class RerunFormatter extends Formatter {
     this.separator = valueOrDefault(rerunOptions.separator, DEFAULT_SEPARATOR)
   }
 
-  logFailedTestCases(): void {
+  getFailureMap(): UriToLinesMap {
     const mapping: UriToLinesMap = {}
     this.eventDataCollector
       .getTestCaseAttempts()
@@ -52,12 +52,23 @@ export default class RerunFormatter extends Formatter {
           }
         }
       )
-    const text = Object.keys(mapping)
+
+    return mapping
+  }
+
+  formatFailedTestCases(): string {
+    const mapping = this.getFailureMap()
+
+    return Object.keys(mapping)
       .map((uri) => {
         const lines = mapping[uri]
         return `${uri}:${lines.join(':')}`
       })
       .join(this.separator)
-    this.log(text)
+  }
+
+  logFailedTestCases(): void {
+    const failedTestCases = this.formatFailedTestCases()
+    this.log(failedTestCases)
   }
 }


### PR DESCRIPTION
Referring to https://github.com/cucumber/cucumber-js/issues/2290

###  What's changed?

- `RerunFormatter` used to log failed attempts even if the attempt was retried. For example, it was possible that a testcase might have been fixed with one of the retry attempts, but still was logged due to earlier failing attempt. From now, `RerunFormatter` does not log attempts that are retried.
- Some minor quality of life changes for users who would like to `extends` `RerunFormatter`.

###  What's your motivation? 

I am using `retry`  to stabilize tests of a distributed system. It was possible (for example right after a deployment), that the first couple of test attempts are failed against a service. I am also using `RerunFormatter` to log the failures. However, as `RerunFormatter` logged the failed attempts too, it was difficult to find out what  testcases I needed to look at in case of a regression.

I attempted to `extend` `RerunFormatter` according to my needs, which turned out to be more complex than I anticipated.

I created an issue and this patchet about both behavior of the `RerunFormatter`, and the challenges of it's customization.

###  What kind of change is this?

- :bug: `RerunFormatter`'s `logFailedTestCases` output is changed. 
- :bank: Minor refactors and changes to `RerunFormatter` to simplify `extends`-ing from it.

###  Anything particular you want feedback on?

This is my first time I am working with typescript/javascript. I appreciate any feedbacks, let it be small or complex. However, I may need a bit more guidance due to my infamiliarity with the language. Do not hesitate to overexplain the change requests. :)
I also set `Allow edits by maintainers` if you feel something is easier for you to change, instead of guiding me through.

### Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

