### PR TITLE
support attachments with filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Added
+- Support attachments with filenames ([#2297](https://github.com/cucumber/cucumber-js/pull/2297))
 
 ## [9.2.0] - 2023-06-22
 ### Added

--- a/compatibility/features/attachments/attachments.ts
+++ b/compatibility/features/attachments/attachments.ts
@@ -87,19 +87,25 @@ When('the {word} png is attached', async function (filename) {
   )
 })
 
-When('a PDF document is attached with a filename', async function (this: World) {
-  await this.attach(
-    fs.createReadStream(
-      path.join(
-        process.cwd(),
-        'node_modules',
-        '@cucumber',
-        'compatibility-kit',
-        'features',
-        'attachments',
-        'document.pdf'
-      )
-    ),
-    'application/pdf'
-  )
-})
+When(
+  'a PDF document is attached with a filename',
+  async function (this: World) {
+    await this.attach(
+      fs.createReadStream(
+        path.join(
+          process.cwd(),
+          'node_modules',
+          '@cucumber',
+          'compatibility-kit',
+          'features',
+          'attachments',
+          'document.pdf'
+        )
+      ),
+      {
+        mediaType: 'application/pdf',
+        fileName: 'document.pdf',
+      }
+    )
+  }
+)

--- a/compatibility/features/attachments/attachments.ts
+++ b/compatibility/features/attachments/attachments.ts
@@ -86,3 +86,20 @@ When('the {word} png is attached', async function (filename) {
     'image/png'
   )
 })
+
+When('a PDF document is attached with a filename', async function (this: World) {
+  await this.attach(
+    fs.createReadStream(
+      path.join(
+        process.cwd(),
+        'node_modules',
+        '@cucumber',
+        'compatibility-kit',
+        'features',
+        'attachments',
+        'document.pdf'
+      )
+    ),
+    'application/pdf'
+  )
+})

--- a/docs/support_files/attachments.md
+++ b/docs/support_files/attachments.md
@@ -14,39 +14,52 @@ After(function () {
 ```
 
 By default, text is saved with a MIME type of `text/plain`.  You can also specify
-a different MIME type:
+a different MIME type as part of a second argument:
 
 ```javascript
 var {After} = require('@cucumber/cucumber');
 
 After(function () {
-  this.attach('{"name": "some JSON"}', 'application/json');
+  this.attach('{"name": "some JSON"}', { mediaType: 'application/json' });
+});
+```
+
+If you'd like, you can also specify a filename to be used if the attachment is made available to download as a file via a formatter:
+
+```javascript
+var {After} = require('@cucumber/cucumber');
+
+After(function () {
+  this.attach('{"name": "some JSON"}', {
+    mediaType: 'application/json',
+    fileName: 'results.json'
+  });
 });
 ```
 
 Images and other binary data can be attached using a [stream.Readable](https://nodejs.org/api/stream.html).
 The data will be `base64` encoded in the output.
-You should wait for the stream to be read before continuing by providing a callback or waiting for the returned promise to resolve.
+You should wait for the stream to be read before continuing by awaiting the returned promise or providing a callback.
 
 ```javascript
 var {After, Status} = require('@cucumber/cucumber');
+
+// Awaiting the promise
+After(async function (testCase) {
+  if (testCase.result.status === Status.FAILED) {
+    var stream = getScreenshotOfError();
+    await this.attach(stream, { mediaType: 'image/png' });
+  }
+});
 
 // Passing a callback
 After(function (testCase, callback) {
   if (testCase.result.status === Status.FAILED) {
     var stream = getScreenshotOfError();
-    this.attach(stream, 'image/png', callback);
+    this.attach(stream, { mediaType: 'image/png' }, callback);
   }
   else {
     callback();
-  }
-});
-
-// Returning the promise
-After(function (testCase) {
-  if (testCase.result.status === Status.FAILED) {
-    var stream = getScreenshotOfError();
-    return this.attach(stream, 'image/png');
   }
 });
 ```
@@ -60,38 +73,23 @@ var {After, Status} = require('@cucumber/cucumber');
 After(function (testCase) {
   if (testCase.result.status === Status.FAILED) {
     var buffer = getScreenshotOfError();
-    this.attach(buffer, 'image/png');
+    this.attach(buffer, { mediaType: 'image/png' });
   }
 });
 ```
 
-If you've already got a base64-encoded string, you can prefix your mime type with `base64:` to indicate this:
-
-```javascript
-var {After, Status} = require('@cucumber/cucumber');
-
-After(function (testCase) {
-  if (testCase.result.status === Status.FAILED) {
-    var base64String = getScreenshotOfError();
-    this.attach(base64String, 'base64:image/png');
-  }
-});
-```
-
-Here is an example of saving a screenshot using [Selenium WebDriver](https://www.npmjs.com/package/selenium-webdriver)
+If you've already got a base64-encoded string, you can prefix your mime type with `base64:` to indicate this. Here's an example of saving a screenshot using [Selenium WebDriver](https://www.npmjs.com/package/selenium-webdriver)
 when a scenario fails:
 
 ```javascript
 var {After, Status} = require('@cucumber/cucumber');
 
-After(function (testCase) {
-  var world = this;
+After(async function (testCase) {
   if (testCase.result.status === Status.FAILED) {
-    return webDriver.takeScreenshot().then(function(screenShot) {
-      world.attach(screenShot, 'base64:image/png');
-    });
+    const screenshot = await driver.takeScreenshot()
+    this.attach(screenshot, { mediaType: 'base64:image/png' })
   }
-});
+})
 ```
 
 Attachments are also printed by the progress, progress-bar and summary formatters.
@@ -102,7 +100,7 @@ It can be used to debug scenarios, especially in parallel mode.
 // Step definition
 Given(/^a basic step$/, function() {
   this.attach('Some info.')
-  this.attach('{"some", "JSON"}}', 'application/json')
+  this.attach('{"some": "JSON"}}', { mediaType: 'application/json' })
 })
 
 // Result format

--- a/docs/support_files/attachments.md
+++ b/docs/support_files/attachments.md
@@ -98,15 +98,20 @@ It can be used to debug scenarios, especially in parallel mode.
 
 ```javascript
 // Step definition
-Given(/^a basic step$/, function() {
+Given('a basic step', async function() {
   this.attach('Some info.')
   this.attach('{"some": "JSON"}}', { mediaType: 'application/json' })
+  this.attach((await driver.takeScreenshot()), {
+    mediaType: 'base64:image/png',
+    fileName: 'screenshot.png'
+  })
 })
 
 // Result format
 // ✔ Given a basic step # path:line
 //    Attachment (text/plain): Some info.
 //    Attachment (application/json)
+//    Attachment (image/png): screenshot.png
 ```
 
 ## Logging

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "cucumber-js": "bin/cucumber.js"
       },
       "devDependencies": {
-        "@cucumber/compatibility-kit": "11.3.0",
+        "@cucumber/compatibility-kit": "^12.0.0",
         "@cucumber/query": "12.0.1",
         "@microsoft/api-documenter": "7.19.27",
         "@microsoft/api-extractor": "7.33.7",
@@ -564,9 +564,9 @@
       "integrity": "sha512-jLzRtVwdtNt+uAmTwvXwW9iGYLEOJFpDSmnx/dgoMGKXUWRx1UHT86Q696CLdgXO8kyTwsgJY0c6n5SW9VitAA=="
     },
     "node_modules/@cucumber/compatibility-kit": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/compatibility-kit/-/compatibility-kit-11.3.0.tgz",
-      "integrity": "sha512-hMpyQ1ZWlkwyUJ/Hzh37W3KJSopPdpJq8JWhQbJ2pE92LuzfiXm//JVGk1IXV31uTP4jPt3X4ouujDelQVELhQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/compatibility-kit/-/compatibility-kit-12.0.0.tgz",
+      "integrity": "sha512-p+wvlFLoYILwsCcKpai/2lnTby/02gvtcIb22fC59srDAQapXhLwcR7irHbX4Hhj+06TbQLSMbd1T2uZrccJzw==",
       "dev": true
     },
     "node_modules/@cucumber/cucumber-expressions": {

--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
     "yup": "^0.32.11"
   },
   "devDependencies": {
-    "@cucumber/compatibility-kit": "11.3.0",
+    "@cucumber/compatibility-kit": "^12.0.0",
     "@cucumber/query": "12.0.1",
     "@microsoft/api-documenter": "7.19.27",
     "@microsoft/api-extractor": "7.33.7",

--- a/src/formatter/helpers/issue_helpers_spec.ts
+++ b/src/formatter/helpers/issue_helpers_spec.ts
@@ -260,8 +260,8 @@ describe('IssueHelpers', () => {
                ${figures.tick} Given attachment step1 # steps.ts:35
                    Attachment (text/plain): Some info
                    Attachment (application/json)
-                   Attachment (image/png)
-               ${figures.cross} When attachment step2 # steps.ts:41
+                   Attachment (image/png): screenshot.png
+               ${figures.cross} When attachment step2 # steps.ts:44
                    Attachment (text/plain): Other info
                    error
                - Then a passing step # steps.ts:29
@@ -290,7 +290,7 @@ describe('IssueHelpers', () => {
             reindent(`
               1) Scenario: my scenario # a.feature:2
                  ${figures.tick} Given attachment step1 # steps.ts:35
-                 ${figures.cross} When attachment step2 # steps.ts:41
+                 ${figures.cross} When attachment step2 # steps.ts:44
                      error
                  - Then a passing step # steps.ts:29
 

--- a/src/formatter/helpers/test_case_attempt_formatter.ts
+++ b/src/formatter/helpers/test_case_attempt_formatter.ts
@@ -69,8 +69,13 @@ function formatStep({
     text += indentString(`${colorFn(argumentsText)}\n`, 4)
   }
   if (valueOrDefault(printAttachments, true)) {
-    attachments.forEach(({ body, mediaType }) => {
-      const message = mediaType === 'text/plain' ? `: ${body}` : ''
+    attachments.forEach(({ body, mediaType, fileName }) => {
+      let message = ''
+      if (mediaType === 'text/plain') {
+        message = `: ${body}`
+      } else if (fileName) {
+        message = `: ${fileName}`
+      }
       text += indentString(`Attachment (${mediaType})${message}\n`, 4)
     })
   }

--- a/src/runtime/attachment_manager/index.ts
+++ b/src/runtime/attachment_manager/index.ts
@@ -15,15 +15,19 @@ export interface IAttachment {
 
 export type IAttachFunction = (attachment: IAttachment) => void
 
-export type ICreateStringAttachment = (data: string, mediaType?: string) => void
-export type ICreateBufferAttachment = (data: Buffer, mediaType: string) => void
+export interface ICreateAttachmentOptions {
+  mediaType: string
+  fileName?: string
+}
+export type ICreateStringAttachment = (data: string, mediaType?: string | ICreateAttachmentOptions) => void
+export type ICreateBufferAttachment = (data: Buffer, mediaType: string | ICreateAttachmentOptions) => void
 export type ICreateStreamAttachment = (
   data: Readable,
-  mediaType: string
+  mediaType: string | ICreateAttachmentOptions
 ) => Promise<void>
 export type ICreateStreamAttachmentWithCallback = (
   data: Readable,
-  mediaType: string,
+  mediaType: string | ICreateAttachmentOptions,
   callback: () => void
 ) => void
 export type ICreateAttachment = ICreateStringAttachment &
@@ -45,7 +49,7 @@ export default class AttachmentManager {
 
   create(
     data: Buffer | Readable | string,
-    mediaType?: string,
+    mediaType?: string | ICreateAttachmentOptions,
     callback?: () => void
   ): void | Promise<void> {
     if (Buffer.isBuffer(data)) {

--- a/src/runtime/attachment_manager/index.ts
+++ b/src/runtime/attachment_manager/index.ts
@@ -59,39 +59,43 @@ export default class AttachmentManager {
     mediaTypeOrOptions?: string | ICreateAttachmentOptions,
     callback?: () => void
   ): void | Promise<void> {
-    // eslint-disable-next-line prefer-const
-    let { mediaType, fileName } = normaliseOptions(mediaTypeOrOptions)
+    const options = normaliseOptions(mediaTypeOrOptions)
     if (Buffer.isBuffer(data)) {
-      if (doesNotHaveValue(mediaType)) {
+      if (doesNotHaveValue(options.mediaType)) {
         throw Error('Buffer attachments must specify a media type')
       }
-      this.createBufferAttachment(data, mediaType, fileName)
+      this.createBufferAttachment(data, options.mediaType, options.fileName)
     } else if (isStream.readable(data)) {
-      if (doesNotHaveValue(mediaType)) {
+      if (doesNotHaveValue(options.mediaType)) {
         throw Error('Stream attachments must specify a media type')
       }
-      return this.createStreamAttachment(data, mediaType, fileName, callback)
+      return this.createStreamAttachment(
+        data,
+        options.mediaType,
+        options.fileName,
+        callback
+      )
     } else if (typeof data === 'string') {
-      if (doesNotHaveValue(mediaType)) {
-        mediaType = 'text/plain'
+      if (doesNotHaveValue(options.mediaType)) {
+        options.mediaType = 'text/plain'
       }
-      if (mediaType.startsWith('base64:')) {
+      if (options.mediaType.startsWith('base64:')) {
         this.createStringAttachment(
           data,
           {
             encoding: messages.AttachmentContentEncoding.BASE64,
-            contentType: mediaType.replace('base64:', ''),
+            contentType: options.mediaType.replace('base64:', ''),
           },
-          fileName
+          options.fileName
         )
       } else {
         this.createStringAttachment(
           data,
           {
             encoding: messages.AttachmentContentEncoding.IDENTITY,
-            contentType: mediaType,
+            contentType: options.mediaType,
           },
-          fileName
+          options.fileName
         )
       }
     } else {

--- a/src/runtime/attachment_manager/index.ts
+++ b/src/runtime/attachment_manager/index.ts
@@ -19,15 +19,15 @@ export interface ICreateAttachmentOptions {
   mediaType: string
   fileName?: string
 }
-export type ICreateStringAttachment = (data: string, mediaType?: string | ICreateAttachmentOptions) => void
-export type ICreateBufferAttachment = (data: Buffer, mediaType: string | ICreateAttachmentOptions) => void
+export type ICreateStringAttachment = (data: string, mediaTypeOrOptions?: string | ICreateAttachmentOptions) => void
+export type ICreateBufferAttachment = (data: Buffer, mediaTypeOrOptions: string | ICreateAttachmentOptions) => void
 export type ICreateStreamAttachment = (
   data: Readable,
-  mediaType: string | ICreateAttachmentOptions
+  mediaTypeOrOptions: string | ICreateAttachmentOptions
 ) => Promise<void>
 export type ICreateStreamAttachmentWithCallback = (
   data: Readable,
-  mediaType: string | ICreateAttachmentOptions,
+  mediaTypeOrOptions: string | ICreateAttachmentOptions,
   callback: () => void
 ) => void
 export type ICreateAttachment = ICreateStringAttachment &
@@ -49,32 +49,32 @@ export default class AttachmentManager {
 
   create(
     data: Buffer | Readable | string,
-    mediaType?: string | ICreateAttachmentOptions,
+    mediaTypeOrOptions?: string | ICreateAttachmentOptions,
     callback?: () => void
   ): void | Promise<void> {
     if (Buffer.isBuffer(data)) {
-      if (doesNotHaveValue(mediaType)) {
+      if (doesNotHaveValue(mediaTypeOrOptions)) {
         throw Error('Buffer attachments must specify a media type')
       }
-      this.createBufferAttachment(data, mediaType)
+      this.createBufferAttachment(data, mediaTypeOrOptions)
     } else if (isStream.readable(data)) {
-      if (doesNotHaveValue(mediaType)) {
+      if (doesNotHaveValue(mediaTypeOrOptions)) {
         throw Error('Stream attachments must specify a media type')
       }
-      return this.createStreamAttachment(data, mediaType, callback)
+      return this.createStreamAttachment(data, mediaTypeOrOptions, callback)
     } else if (typeof data === 'string') {
-      if (doesNotHaveValue(mediaType)) {
-        mediaType = 'text/plain'
+      if (doesNotHaveValue(mediaTypeOrOptions)) {
+        mediaTypeOrOptions = 'text/plain'
       }
-      if (mediaType.startsWith('base64:')) {
+      if (mediaTypeOrOptions.startsWith('base64:')) {
         this.createStringAttachment(data, {
           encoding: messages.AttachmentContentEncoding.BASE64,
-          contentType: mediaType.replace('base64:', ''),
+          contentType: mediaTypeOrOptions.replace('base64:', ''),
         })
       } else {
         this.createStringAttachment(data, {
           encoding: messages.AttachmentContentEncoding.IDENTITY,
-          contentType: mediaType,
+          contentType: mediaTypeOrOptions,
         })
       }
     } else {

--- a/src/runtime/attachment_manager/index.ts
+++ b/src/runtime/attachment_manager/index.ts
@@ -149,11 +149,11 @@ export default class AttachmentManager {
     media: IAttachmentMedia,
     fileName?: string
   ): void {
-    const attachment: IAttachment = { data, media }
-    if (fileName) {
-      attachment.fileName = fileName
-    }
-    this.onAttachment(attachment)
+    this.onAttachment({
+      data,
+      media,
+      ...(fileName ? { fileName } : {}),
+    })
   }
 }
 

--- a/src/runtime/attachment_manager/index.ts
+++ b/src/runtime/attachment_manager/index.ts
@@ -62,17 +62,17 @@ export default class AttachmentManager {
     // eslint-disable-next-line prefer-const
     let { mediaType, fileName } = normaliseOptions(mediaTypeOrOptions)
     if (Buffer.isBuffer(data)) {
-      if (doesNotHaveValue(mediaTypeOrOptions)) {
+      if (doesNotHaveValue(mediaType)) {
         throw Error('Buffer attachments must specify a media type')
       }
       this.createBufferAttachment(data, mediaType, fileName)
     } else if (isStream.readable(data)) {
-      if (doesNotHaveValue(mediaTypeOrOptions)) {
+      if (doesNotHaveValue(mediaType)) {
         throw Error('Stream attachments must specify a media type')
       }
       return this.createStreamAttachment(data, mediaType, fileName, callback)
     } else if (typeof data === 'string') {
-      if (doesNotHaveValue(mediaTypeOrOptions)) {
+      if (doesNotHaveValue(mediaType)) {
         mediaType = 'text/plain'
       }
       if (mediaType.startsWith('base64:')) {

--- a/src/runtime/attachment_manager/index_spec.ts
+++ b/src/runtime/attachment_manager/index_spec.ts
@@ -64,6 +64,40 @@ describe('AttachmentManager', () => {
           )
         })
       })
+
+      describe('with mime type and filename', () => {
+        it('adds the data and media and filename', function () {
+          // Arrange
+          const attachments: IAttachment[] = []
+          const attachmentManager = new AttachmentManager((x) =>
+            attachments.push(x)
+          )
+
+          // Act
+          const result = attachmentManager.create(Buffer.from('my string'), {
+            mediaType: 'text/special',
+            fileName: 'foo.txt',
+          })
+
+          // Assert
+          expect(result).to.eql(undefined)
+          expect(attachments).to.eql([
+            {
+              data: 'bXkgc3RyaW5n',
+              media: {
+                contentType: 'text/special',
+                encoding: 'BASE64',
+              },
+              fileName: 'foo.txt',
+            },
+          ])
+          const decodedData = Buffer.from(
+            attachments[0].data,
+            'base64'
+          ).toString()
+          expect(decodedData).to.eql('my string')
+        })
+      })
     })
 
     describe('readable stream', () => {
@@ -138,6 +172,93 @@ describe('AttachmentManager', () => {
                   contentType: 'text/special',
                   encoding: 'BASE64',
                 },
+              },
+            ])
+            const decodedData = Buffer.from(
+              attachments[0].data,
+              'base64'
+            ).toString()
+            expect(decodedData).to.eql('my string')
+          })
+        })
+      })
+
+      describe('with mime type and filename', () => {
+        describe('with callback', () => {
+          it('does not return a promise and adds the data and media and filename', async function () {
+            // Arrange
+            const attachments: IAttachment[] = []
+            const attachmentManager = new AttachmentManager((x) =>
+              attachments.push(x)
+            )
+            const readableStream = new stream.PassThrough()
+            let result: any
+
+            // Act
+            await new Promise<void>((resolve) => {
+              result = attachmentManager.create(
+                readableStream,
+                {
+                  mediaType: 'text/special',
+                  fileName: 'foo.txt',
+                },
+                resolve
+              )
+              setTimeout(() => {
+                readableStream.write('my string')
+                readableStream.end()
+              }, 25)
+            })
+
+            // Assert
+            expect(result).to.eql(undefined)
+            expect(attachments).to.eql([
+              {
+                data: 'bXkgc3RyaW5n',
+                media: {
+                  contentType: 'text/special',
+                  encoding: 'BASE64',
+                },
+                fileName: 'foo.txt',
+              },
+            ])
+            const decodedData = Buffer.from(
+              attachments[0].data,
+              'base64'
+            ).toString()
+            expect(decodedData).to.eql('my string')
+          })
+        })
+
+        describe('without callback', () => {
+          it('returns a promise and adds the data and media and filename', async function () {
+            // Arrange
+            const attachments: IAttachment[] = []
+            const attachmentManager = new AttachmentManager((x) =>
+              attachments.push(x)
+            )
+            const readableStream = new stream.PassThrough()
+
+            // Act
+            const result = attachmentManager.create(readableStream, {
+              mediaType: 'text/special',
+              fileName: 'foo.txt',
+            })
+            setTimeout(() => {
+              readableStream.write('my string')
+              readableStream.end()
+            }, 25)
+            await result
+
+            // Assert
+            expect(attachments).to.eql([
+              {
+                data: 'bXkgc3RyaW5n',
+                media: {
+                  contentType: 'text/special',
+                  encoding: 'BASE64',
+                },
+                fileName: 'foo.txt',
               },
             ])
             const decodedData = Buffer.from(
@@ -251,6 +372,35 @@ describe('AttachmentManager', () => {
                 contentType: 'text/plain',
                 encoding: 'IDENTITY',
               },
+            },
+          ])
+        })
+      })
+
+      describe('with media type and filename', () => {
+        it('adds the data and media and filename', function () {
+          // Arrange
+          const attachments: IAttachment[] = []
+          const attachmentManager = new AttachmentManager((x) =>
+            attachments.push(x)
+          )
+
+          // Act
+          const result = attachmentManager.create('my string', {
+            mediaType: 'text/special',
+            fileName: 'foo.txt',
+          })
+
+          // Assert
+          expect(result).to.eql(undefined)
+          expect(attachments).to.eql([
+            {
+              data: 'my string',
+              media: {
+                contentType: 'text/special',
+                encoding: 'IDENTITY',
+              },
+              fileName: 'foo.txt',
             },
           ])
         })

--- a/src/runtime/test_case_runner.ts
+++ b/src/runtime/test_case_runner.ts
@@ -61,23 +61,26 @@ export default class TestCaseRunner {
     supportCodeLibrary,
     worldParameters,
   }: INewTestCaseRunnerOptions) {
-    this.attachmentManager = new AttachmentManager(({ data, media }) => {
-      if (doesNotHaveValue(this.currentTestStepId)) {
-        throw new Error(
-          'Cannot attach when a step/hook is not running. Ensure your step/hook waits for the attach to finish.'
-        )
+    this.attachmentManager = new AttachmentManager(
+      ({ data, media, fileName }) => {
+        if (doesNotHaveValue(this.currentTestStepId)) {
+          throw new Error(
+            'Cannot attach when a step/hook is not running. Ensure your step/hook waits for the attach to finish.'
+          )
+        }
+        const attachment: messages.Envelope = {
+          attachment: {
+            body: data,
+            contentEncoding: media.encoding,
+            mediaType: media.contentType,
+            fileName,
+            testCaseStartedId: this.currentTestCaseStartedId,
+            testStepId: this.currentTestStepId,
+          },
+        }
+        this.eventBroadcaster.emit('envelope', attachment)
       }
-      const attachment: messages.Envelope = {
-        attachment: {
-          body: data,
-          contentEncoding: media.encoding,
-          mediaType: media.contentType,
-          testCaseStartedId: this.currentTestCaseStartedId,
-          testStepId: this.currentTestStepId,
-        },
-      }
-      this.eventBroadcaster.emit('envelope', attachment)
-    })
+    )
     this.eventBroadcaster = eventBroadcaster
     this.stopwatch = stopwatch
     this.gherkinDocument = gherkinDocument

--- a/test/fixtures/steps.ts
+++ b/test/fixtures/steps.ts
@@ -35,7 +35,10 @@ export function getBaseSupportCodeLibrary(): ISupportCodeLibrary {
     Given('attachment step1', async function (this: World) {
       await this.attach('Some info')
       await this.attach('{"name": "some JSON"}', 'application/json')
-      await this.attach(Buffer.from([137, 80, 78, 71]), 'image/png')
+      await this.attach(Buffer.from([137, 80, 78, 71]), {
+        mediaType: 'image/png',
+        fileName: 'screenshot.png',
+      })
     })
 
     Given('attachment step2', async function (this: World) {


### PR DESCRIPTION
### 🤔 What's changed?

Add support for providing an optional filename for attachments, which is emitted as part of the `attachment` message and thus can be used in formatters.

To achieve this, we make the second argument to `this.attach` an options object, with backwards compatibility so a media type string still works as before.

### ⚡️ What's your motivation? 

Follow the cross-platform standards.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
