### PR TITLE
upgrade html-formatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@cucumber/gherkin": "26.2.0",
         "@cucumber/gherkin-streams": "5.0.1",
         "@cucumber/gherkin-utils": "8.0.2",
-        "@cucumber/html-formatter": "20.3.0",
+        "@cucumber/html-formatter": "20.4.0",
         "@cucumber/message-streams": "4.0.1",
         "@cucumber/messages": "22.0.0",
         "@cucumber/tag-expressions": "5.0.1",
@@ -653,9 +653,9 @@
       }
     },
     "node_modules/@cucumber/html-formatter": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-20.3.0.tgz",
-      "integrity": "sha512-4DOuA2jmw2WqK63HxCWoXmyozGCrKeCddQ2wHWsQaAVP8YxWyzzY6azFJaByqvZW45WdaQ/5aMJWvEy+XAEXJg==",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-20.4.0.tgz",
+      "integrity": "sha512-TnLSXC5eJd8AXHENo69f5z+SixEVtQIf7Q2dZuTpT/Y8AOkilGpGl1MQR1Vp59JIw+fF3EQSUKdf+DAThCxUNg==",
       "peerDependencies": {
         "@cucumber/messages": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "@cucumber/gherkin": "26.2.0",
     "@cucumber/gherkin-streams": "5.0.1",
     "@cucumber/gherkin-utils": "8.0.2",
-    "@cucumber/html-formatter": "20.3.0",
+    "@cucumber/html-formatter": "20.4.0",
     "@cucumber/message-streams": "4.0.1",
     "@cucumber/messages": "22.0.0",
     "@cucumber/tag-expressions": "5.0.1",


### PR DESCRIPTION
### 🤔 What's changed?

Upgrade to the latest `html-formatter`.

### ⚡️ What's your motivation? 

Brings in ability to download attachments like PDFs that aren't viewable directly in the report - see https://github.com/cucumber/react-components/pull/333

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
