### PR TITLE
wait for stream to finish at end of publish plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber
 ### Added
 - Support array notation of formats with path in configuration files ([#2318](https://github.com/cucumber/cucumber-js/pull/2318))
 
+### Fixed
+- Wait for stream to finish at end of publish plugin ([#2322](https://github.com/cucumber/cucumber-js/pull/2322))
+
 ## [9.4.0] - 2023-08-12
 ### Fixed
 - Fix type import from cucumber-expressions ([#2310](https://github.com/cucumber/cucumber-js/pull/2310))

--- a/src/publish/publish_plugin.ts
+++ b/src/publish/publish_plugin.ts
@@ -35,8 +35,13 @@ export const publishPlugin: Plugin = async ({
   stream.pipe(readerStream)
   stream.on('error', (error: Error) => logger.error(error.message))
   on('message', (value) => stream.write(JSON.stringify(value) + '\n'))
-  return () => stream.end()
+  return () =>
+    new Promise<void>((resolve) => {
+      stream.on('finish', () => resolve())
+      stream.end()
+    })
 }
+
 /*
 This is because the Cucumber Reports service returns a pre-formatted console message
 including ANSI escapes, so if our stderr stream doesn't support those we need to


### PR DESCRIPTION
### 🤔 What's changed?

Await the `finish` of the stream when cleaning up publish plugin.

### ⚡️ What's your motivation? 

Fixes #2321.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
