### PR TITLE
allow single-item arrays as a format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Allow single-item arrays as a format ([#2324](https://github.com/cucumber/cucumber-js/pull/2324))
 
 ## [9.5.0] - 2023-09-03
 ### Added

--- a/src/api/convert_configuration_spec.ts
+++ b/src/api/convert_configuration_spec.ts
@@ -39,7 +39,7 @@ describe('convertConfiguration', () => {
     })
   })
 
-  it('should map multiple formatters with string and array notations', async () => {
+  it('should map multiple formatters with string notation', async () => {
     const result = await convertConfiguration(
       {
         ...DEFAULT_CONFIGURATION,
@@ -47,6 +47,31 @@ describe('convertConfiguration', () => {
           'summary',
           'message',
           'json:./report.json',
+          'html:./report.html',
+        ],
+      },
+      {}
+    )
+
+    expect(result.formats).to.eql({
+      stdout: 'message',
+      files: {
+        './report.html': 'html',
+        './report.json': 'json',
+      },
+      publish: false,
+      options: {},
+    })
+  })
+
+  it('should map multiple formatters with array notation', async () => {
+    const result = await convertConfiguration(
+      {
+        ...DEFAULT_CONFIGURATION,
+        format: [
+          ['summary'],
+          ['message'],
+          ['json', './report.json'],
           ['html', './report.html'],
         ],
       },

--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -1,7 +1,7 @@
 import { FormatOptions } from '../formatter'
 import { PickleOrder } from '../models/pickle_order'
 
-type FormatsConfiguration = Array<string | [string, string]>
+type FormatsConfiguration = Array<string | [string, string?]>
 
 export interface IConfiguration {
   backtrace: boolean


### PR DESCRIPTION
### 🤔 What's changed?

When expressing a format as an array, support a single-item array in the typing.

### ⚡️ What's your motivation? 

If you want to use a formatter for stdout but with a local path containing colons etc, you may want to express that as a single item array to avoid Cucumber seeing the colon(s) and interpreting it as a formatter+target string to be broken apart. See https://github.com/webdriverio/webdriverio/pull/11010/files#r1309127113 for an example in the wild.

This worked anyway at runtime, but the types needed to reflect that, and some tests have been updated to prove it.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
