### PR TITLE
set timeouts appropriately

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -7,4 +7,4 @@ forbid-pending: true
 recursive: true
 reporter: dot
 require: 'ts-node/register'
-timeout: 5000
+timeout: 3000

--- a/src/api/load_support_spec.ts
+++ b/src/api/load_support_spec.ts
@@ -5,7 +5,9 @@ import { loadConfiguration } from './load_configuration'
 import { expect } from 'chai'
 import { setupEnvironment, teardownEnvironment } from './test_helpers'
 
-describe('loadSupport', () => {
+describe('loadSupport', function () {
+  this.timeout(10_000)
+
   let environment: IRunEnvironment
   beforeEach(async () => {
     environment = await setupEnvironment()

--- a/src/api/run_cucumber_spec.ts
+++ b/src/api/run_cucumber_spec.ts
@@ -6,7 +6,9 @@ import { loadSupport } from './load_support'
 import { loadConfiguration } from './load_configuration'
 import { setupEnvironment, teardownEnvironment } from './test_helpers'
 
-describe('runCucumber', () => {
+describe('runCucumber', function () {
+  this.timeout(10_000)
+
   describe('preloading support code', () => {
     let environment: IRunEnvironment
     beforeEach(async () => {


### PR DESCRIPTION
Set timeouts on specific suites that take a long time, and set the default back to a reasonable 3s. Should reduce occasional Windows issues in CI.