### PR TITLE
honour order of paths in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Honour order of paths in configuration ([#2345](https://github.com/cucumber/cucumber-js/pull/2345))
 
 ## [10.0.0] - 2023-10-09
 ### Added

--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -72,11 +72,10 @@ async function expandPaths(
           return [match]
         })
       )
-      return expanded.flat()
+      return expanded.flat().sort()
     })
   )
   const normalized = expandedPaths.flat().map((x) => path.normalize(x))
-  normalized.sort()
   return [...new Set(normalized)]
 }
 

--- a/src/api/paths_spec.ts
+++ b/src/api/paths_spec.ts
@@ -200,6 +200,58 @@ describe('resolvePaths', () => {
     })
   })
 
+  describe('multiple paths ordering', async () => {
+    it('should honour the provided order of multiple files', async () => {
+      // Arrange
+      const cwd = await buildTestWorkingDirectory()
+      const featurePathA = path.join(cwd, 'features', 'a.feature')
+      const featurePathB = path.join(cwd, 'features', 'b.feature')
+      await fsExtra.outputFile(featurePathA, '')
+      await fsExtra.outputFile(featurePathB, '')
+      // Act
+      const { featurePaths } = await resolvePaths(
+        new FakeLogger(),
+        cwd,
+        {
+          paths: ['features/b.feature', 'features/a.feature'],
+        },
+        {
+          requireModules: [],
+          requirePaths: [],
+          importPaths: [],
+        }
+      )
+
+      // Assert
+      expect(featurePaths).to.eql([featurePathB, featurePathA])
+    })
+
+    it('should honour the provided order of multiple directories', async () => {
+      // Arrange
+      const cwd = await buildTestWorkingDirectory()
+      const featurePathA = path.join(cwd, 'features-a', 'something.feature')
+      const featurePathB = path.join(cwd, 'features-b', 'something.feature')
+      await fsExtra.outputFile(featurePathA, '')
+      await fsExtra.outputFile(featurePathB, '')
+      // Act
+      const { featurePaths } = await resolvePaths(
+        new FakeLogger(),
+        cwd,
+        {
+          paths: ['features-b', 'features-a'],
+        },
+        {
+          requireModules: [],
+          requirePaths: [],
+          importPaths: [],
+        }
+      )
+
+      // Assert
+      expect(featurePaths).to.eql([featurePathB, featurePathA])
+    })
+  })
+
   describe('path to an empty rerun file', () => {
     it('returns empty featurePaths and support code paths', async function () {
       // Arrange


### PR DESCRIPTION
### 🤔 What's changed?

Change where we sort the list of expanded paths - do it for the results of each unexpanded path rather than once at the end for the whole result set, meaning the order of paths in the configuration is honoured.

### ⚡️ What's your motivation? 

Fixes #2343.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
