### PR TITLE
chore: remove defunct npm 8 step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i -g npm@8
       - run: npm install-test
 
   coverage:


### PR DESCRIPTION
Remove now-defunct step that used to forcibly install npm 8. This was needed when 7 -> 8 changed a lockfile format, but now we can just go with whatever version is bundled with Node.js