### PR TITLE
Prevent mutations on world parameters leaking between test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Prevent mutations on world parameters leaking between test cases ([#2362](https://github.com/cucumber/cucumber-js/pull/2362))
 
 ## [10.0.1] - 2023-10-20
 ### Fixed

--- a/features/world_parameters.feature
+++ b/features/world_parameters.feature
@@ -73,6 +73,38 @@ Feature: World Parameters
     When I run cucumber-js with `--world-parameters '{"a":1,"b":2}' --world-parameters '{"a":3}'`
     Then scenario "a scenario" step "Given the world parameters are correct" has status "passed"
 
+  Scenario: world parameters are immutable in practise
+
+    World parameters should be read only, and state should be added to the world instance directly.
+    It's difficult to enforce this immutability in practise, especially with users able to define custom world
+    behaviour. But we can at least ensure we only provide a cloned version to each world instance, so no
+    mutations can leak between test cases.
+
+    Given a file named "features/passing_steps.feature" with:
+      """
+      Feature: a feature
+        Scenario: troublemaker
+          When a world parameter is mutated
+
+        Scenario: a scenario
+          Given the world parameters are correct
+      """
+    Given a file named "features/step_definitions/my_steps.js" with:
+      """
+      const assert = require('assert')
+      const {Given, When} = require('@cucumber/cucumber')
+
+      Given('the world parameters are correct', function() {
+        assert.equal(this.parameters.foo, 'bar')
+      })
+
+      When('a world parameter is mutated', function() {
+        this.parameters.foo = 'baz'
+      })
+      """
+    When I run cucumber-js with `--world-parameters '{"foo":"bar"}'`
+    Then scenario "a scenario" step "Given the world parameters are correct" has status "passed"
+
   Scenario: custom world constructor is passed the parameters
     Given a file named "features/support/world.js" with:
       """

--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -1,3 +1,4 @@
+import { JsonObject } from 'type-fest'
 import { FormatOptions } from '../formatter'
 import { PickleOrder } from '../models/pickle_order'
 
@@ -27,5 +28,5 @@ export interface IConfiguration {
   retryTagFilter: string
   strict: boolean
   tags: string
-  worldParameters: any
+  worldParameters: JsonObject
 }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events'
 import * as messages from '@cucumber/messages'
 import { IdGenerator } from '@cucumber/messages'
+import { JsonObject } from 'type-fest'
 import { EventDataCollector } from '../formatter/helpers'
 import { ISupportCodeLibrary } from '../support_code_library_builder/types'
 import { assembleTestCases } from './assemble_test_cases'
@@ -29,7 +30,7 @@ export interface IRuntimeOptions {
   retry: number
   retryTagFilter: string
   strict: boolean
-  worldParameters: any
+  worldParameters: JsonObject
 }
 
 export default class Runtime implements IRuntime {

--- a/src/runtime/parallel/worker.ts
+++ b/src/runtime/parallel/worker.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events'
 import { pathToFileURL } from 'node:url'
 import * as messages from '@cucumber/messages'
 import { IdGenerator } from '@cucumber/messages'
+import { JsonObject } from 'type-fest'
 import supportCodeLibraryBuilder from '../../support_code_library_builder'
 import { ISupportCodeLibrary } from '../../support_code_library_builder/types'
 import { doesHaveValue } from '../../value_checker'
@@ -31,7 +32,7 @@ export default class Worker {
   private readonly newId: IdGenerator.NewId
   private readonly sendMessage: IMessageSender
   private supportCodeLibrary: ISupportCodeLibrary
-  private worldParameters: any
+  private worldParameters: JsonObject
   private runTestRunHooks: RunsTestRunHooks
 
   constructor({

--- a/src/runtime/test_case_runner.ts
+++ b/src/runtime/test_case_runner.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events'
 import * as messages from '@cucumber/messages'
 import { getWorstTestStepResult, IdGenerator } from '@cucumber/messages'
+import { JsonObject } from 'type-fest'
 import {
   ISupportCodeLibrary,
   ITestCaseHookParameter,
@@ -27,7 +28,7 @@ export interface INewTestCaseRunnerOptions {
   skip: boolean
   filterStackTraces: boolean
   supportCodeLibrary: ISupportCodeLibrary
-  worldParameters: any
+  worldParameters: JsonObject
 }
 
 export default class TestCaseRunner {
@@ -46,7 +47,7 @@ export default class TestCaseRunner {
   private readonly supportCodeLibrary: ISupportCodeLibrary
   private testStepResults: messages.TestStepResult[]
   private world: any
-  private readonly worldParameters: any
+  private readonly worldParameters: JsonObject
 
   constructor({
     eventBroadcaster,

--- a/src/runtime/test_case_runner.ts
+++ b/src/runtime/test_case_runner.ts
@@ -100,7 +100,7 @@ export default class TestCaseRunner {
     this.world = new this.supportCodeLibrary.World({
       attach: this.attachmentManager.create.bind(this.attachmentManager),
       log: this.attachmentManager.log.bind(this.attachmentManager),
-      parameters: this.worldParameters,
+      parameters: structuredClone(this.worldParameters),
     })
     this.testStepResults = []
   }


### PR DESCRIPTION
### 🤔 What's changed?

Clone the world parameters before creating each world instance. This prevents user code that updates the world parameters from leaking those changes across different test cases.

Also, type the `worldParameters` as `JsonObject` in configuration to enforce it should be JSON serialisable.

It would have been nice to somehow ensure immutability even between hooks/steps in the same test case. But realistically, users can have custom world instances, they can do what they want with the `parameters` object they are passed, so there's only so much we can do as the orchestrator.

### ⚡️ What's your motivation? 

Fixes #2356 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
