### PR TITLE
Replace usage of VError with Error.cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber
 - Prevent mutations on world parameters leaking between test cases ([#2362](https://github.com/cucumber/cucumber-js/pull/2362))
 
 ### Changed
-- Replace usage of VError with Error.cause ([#2363](https://github.com/cucumber/cucumber-js/pull/2363))
+- Replace usage of `VError` with `Error.cause` ([#2363](https://github.com/cucumber/cucumber-js/pull/2363))
 
 ## [10.0.1] - 2023-10-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber
 ### Fixed
 - Prevent mutations on world parameters leaking between test cases ([#2362](https://github.com/cucumber/cucumber-js/pull/2362))
 
+### Changed
+- Replace usage of VError with Error.cause ([#2363](https://github.com/cucumber/cucumber-js/pull/2363))
+
 ## [10.0.1] - 2023-10-20
 ### Fixed
 - Honour order of paths in configuration ([#2345](https://github.com/cucumber/cucumber-js/pull/2345))

--- a/features/support/world.ts
+++ b/features/support/world.ts
@@ -3,10 +3,10 @@ import { PassThrough, pipeline, Writable } from 'node:stream'
 import fs from 'node:fs'
 import path from 'node:path'
 import util from 'node:util'
+import { Console } from 'node:console'
 import { expect } from 'chai'
 import toString from 'stream-to-string'
 import stripAnsi from 'strip-ansi'
-import VError from 'verror'
 import * as messages from '@cucumber/messages'
 import * as messageStreams from '@cucumber/message-streams'
 import FakeReportServer from '../../test/fake_report_server'
@@ -106,13 +106,15 @@ export class World {
       } catch (err) {
         error = err
       }
+      if (error) {
+        new Console(stderr).error(error)
+      }
       stdout.end()
       stderr.end()
-      const stderrSuffix = error != null ? VError.fullStack(error) : ''
       result = {
         error,
         stdout: await toString(stdout),
-        stderr: (await toString(stderr)) + stderrSuffix,
+        stderr: await toString(stderr),
       }
     }
     const envelopes: messages.Envelope[] = []

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "tmp": "^0.2.1",
         "type-fest": "^4.8.3",
         "util-arity": "^1.1.0",
-        "verror": "^1.10.0",
         "xmlbuilder": "^15.1.1",
         "yaml": "^2.2.2",
         "yup": "1.2.0"
@@ -82,7 +81,6 @@
         "@types/sinonjs__fake-timers": "8.1.2",
         "@types/stream-buffers": "3.0.4",
         "@types/tmp": "0.2.3",
-        "@types/verror": "1.10.6",
         "@typescript-eslint/eslint-plugin": "6.7.4",
         "@typescript-eslint/parser": "6.7.4",
         "chai": "4.3.7",
@@ -1829,12 +1827,6 @@
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
-    "node_modules/@types/verror": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.6.tgz",
-      "integrity": "sha512-NNm+gdePAX1VGvPcGZCDKQZKYSiAWigKhKaz5KF94hG6f2s8de9Ow5+7AbXoeKxL8gavZfk4UquSAygOF2duEQ==",
-      "dev": true
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.7.4",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.4.tgz",
@@ -2447,14 +2439,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -3036,11 +3020,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -4133,14 +4112,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
-    },
-    "node_modules/extsprintf": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
-      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
-      "engines": [
-        "node >=0.6.0"
-      ]
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -8565,19 +8536,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
-      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -245,7 +245,6 @@
     "tmp": "^0.2.1",
     "type-fest": "^4.8.3",
     "util-arity": "^1.1.0",
-    "verror": "^1.10.0",
     "xmlbuilder": "^15.1.1",
     "yaml": "^2.2.2",
     "yup": "1.2.0"
@@ -277,7 +276,6 @@
     "@types/sinonjs__fake-timers": "8.1.2",
     "@types/stream-buffers": "3.0.4",
     "@types/tmp": "0.2.3",
-    "@types/verror": "1.10.6",
     "@typescript-eslint/eslint-plugin": "6.7.4",
     "@typescript-eslint/parser": "6.7.4",
     "chai": "4.3.7",

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 /* This is one rare place where we're fine to use process/console directly,
  * but other code abstracts those to remain composable and testable. */
-import VError from 'verror'
 import { validateNodeEngineVersion } from './validate_node_engine_version'
 import Cli, { ICliRunResult } from './'
 
@@ -32,7 +31,7 @@ export default async function run(): Promise<void> {
   try {
     result = await cli.run()
   } catch (error) {
-    logErrorMessageAndExit(VError.fullStack(error))
+    logErrorMessageAndExit(error)
   }
 
   const exitCode = result.success ? 0 : 1

--- a/src/runtime/parallel/run_worker.ts
+++ b/src/runtime/parallel/run_worker.ts
@@ -1,11 +1,10 @@
-import VError from 'verror'
 import { doesHaveValue } from '../../value_checker'
 import Worker from './worker'
 
 function run(): void {
   const exit = (exitCode: number, error?: Error, message?: string): void => {
     if (doesHaveValue(error)) {
-      console.error(VError.fullStack(new VError(error, message))) // eslint-disable-line no-console
+      console.error(new Error(message, { cause: error })) // eslint-disable-line no-console
     }
     process.exit(exitCode)
   }

--- a/src/runtime/run_test_run_hooks.ts
+++ b/src/runtime/run_test_run_hooks.ts
@@ -1,4 +1,3 @@
-import VError from 'verror'
 import UserCodeRunner from '../user_code_runner'
 import { formatLocation } from '../formatter/helpers'
 import { doesHaveValue, valueOrDefault } from '../value_checker'
@@ -29,7 +28,7 @@ export const makeRunTestRunHooks = (
           })
           if (doesHaveValue(error)) {
             const location = formatLocation(hookDefinition)
-            throw new VError(error, errorMessage(name, location))
+            throw new Error(errorMessage(name, location), { cause: error })
           }
         }
       }

--- a/src/try_require.ts
+++ b/src/try_require.ts
@@ -11,9 +11,8 @@ export default function tryRequire(path: string) {
     if (error.code === 'ERR_REQUIRE_ESM') {
       throw Error(
         `Cucumber expected a CommonJS module at '${path}' but found an ES module.
-      Either change the file to CommonJS syntax or use the --import directive instead of --require.
-      
-      Original error message: ${error.message}`
+      Either change the file to CommonJS syntax or use the --import directive instead of --require.`,
+        { cause: error }
       )
     } else {
       throw error


### PR DESCRIPTION
### 🤔 What's changed?

This PR removes `verror`, which was used to propagate errors with the original stack trace plus local context, as it is now unmaintained and is not tolerant of thrown objects that are not instances of `Error`.

Instead, we can make use of a newer native JavaScript feature, [`Error.cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause), to achieve the same thing.

### ⚡️ What's your motivation? 

Fixes #2359

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
