### PR TITLE
accept provided configuration as array of argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Changed
+- Allow `provided` configuration to be an array ([#2374](https://github.com/cucumber/cucumber-js/pull/2374))
 
 ## [10.3.0] - 2024-01-15
 ### Added

--- a/exports/api/report.api.md
+++ b/exports/api/report.api.md
@@ -40,7 +40,7 @@ export interface IConfiguration {
 export interface ILoadConfigurationOptions {
     file?: string | false;
     profiles?: string[];
-    provided?: Partial<IConfiguration> | string;
+    provided?: Partial<IConfiguration> | string[] | string;
 }
 
 // @public

--- a/src/api/load_configuration_spec.ts
+++ b/src/api/load_configuration_spec.ts
@@ -12,6 +12,15 @@ describe('loadConfiguration', function () {
   })
   afterEach(async () => teardownEnvironment(environment))
 
+  it('should handle configuration directly provided as an array of strings', async () => {
+    const { useConfiguration } = await loadConfiguration(
+      { provided: ['--world-parameters', '{"foo":"bar"}'] },
+      environment
+    )
+
+    expect(useConfiguration.worldParameters).to.deep.eq({ foo: 'bar' })
+  })
+
   it('should handle configuration directly provided as a string', async () => {
     const { useConfiguration } = await loadConfiguration(
       { provided: `--world-parameters '{"foo":"bar"}'` },

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -28,11 +28,13 @@ export interface ILoadConfigurationOptions {
    *   failFast: true,
    *   parallel: 2
    * \}
+   * @example ["--fail-fast", "--parallel", "2"]
    * @example "--fail-fast --parallel 2"
    * @remarks
-   * This can also be provided as a string of argv-style arguments.
+   * This can also be provided as an array or single string of argv-style
+   * arguments.
    */
-  provided?: Partial<IConfiguration> | string
+  provided?: Partial<IConfiguration> | string[] | string
 }
 
 /**

--- a/src/configuration/parse_configuration.ts
+++ b/src/configuration/parse_configuration.ts
@@ -7,10 +7,19 @@ import { checkSchema } from './check_schema'
 export function parseConfiguration(
   logger: ILogger,
   source: string,
-  definition: Partial<IConfiguration> | string | undefined
+  definition: Partial<IConfiguration> | string[] | string | undefined
 ): Partial<IConfiguration> {
   if (!definition) {
     return {}
+  }
+  if (Array.isArray(definition)) {
+    logger.debug(`${source} configuration value is an array; parsing as argv`)
+    const { configuration } = ArgvParser.parse([
+      'node',
+      'cucumber-js',
+      ...definition,
+    ])
+    return configuration
   }
   if (typeof definition === 'string') {
     logger.debug(`${source} configuration value is a string; parsing as argv`)


### PR DESCRIPTION
### 🤔 What's changed?

Further to https://github.com/cucumber/cucumber-js/pull/2373, the argv-style provided configuration should also support being an array of strings, as you might pull directly from `process.argv`.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
