### PR TITLE
Make `transformer` of defineParameterType optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+
+- Type signature of `defineParameterType` correctly reflects `transformer` property's optionality.
 
 ## [10.5.0] - 2024-04-21
 ### Added

--- a/src/support_code_library_builder/types.ts
+++ b/src/support_code_library_builder/types.ts
@@ -71,7 +71,7 @@ export interface IDefineTestRunHookOptions {
 export interface IParameterTypeDefinition<T> {
   name: string
   regexp: readonly RegExp[] | readonly string[] | RegExp | string
-  transformer: (...match: string[]) => T
+  transformer?: (...match: string[]) => T
   useForSnippets?: boolean
   preferForRegexpMatch?: boolean
 }


### PR DESCRIPTION


### 🤔 What's changed?

Make `transformer` of defineParameterType optional.

### ⚡️ What's your motivation? 

This is to accurately reflect actual behavior, as per [documentation](https://github.com/cucumber/cucumber-js/blob/v10.5.0/docs/support_files/api_reference.md) and [tests](https://github.com/cucumber/cucumber-js/blob/v10.5.0/features/parameter_types.feature#L81-L96).

### 🏷️ What kind of change is this?

Minor, backward compatibility type-change.

### ♻️ Anything particular you want feedback on?

Nah, nothing aside from the change itself.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
   - This is already tested.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
