### PR TITLE
Add debug logging to start of run

### DIFF
--- a/src/api/run_cucumber.ts
+++ b/src/api/run_cucumber.ts
@@ -4,6 +4,7 @@ import { EventDataCollector } from '../formatter/helpers'
 import { emitMetaMessage, emitSupportCodeMessages } from '../cli/helpers'
 import { resolvePaths } from '../paths'
 import { SupportCodeLibrary } from '../support_code_library_builder/types'
+import { version } from '../version'
 import { IRunOptions, IRunEnvironment, IRunResult } from './types'
 import { makeRuntime } from './runtime'
 import { initializeFormatters } from './formatters'
@@ -27,6 +28,11 @@ export async function runCucumber(
 ): Promise<IRunResult> {
   const mergedEnvironment = mergeEnvironment(environment)
   const { cwd, stdout, stderr, env, logger } = mergedEnvironment
+
+  logger.debug(`Running cucumber-js ${version} 
+Working directory: ${cwd}
+Running from: ${__dirname}  
+`)
 
   const newId = IdGenerator.uuid()
 


### PR DESCRIPTION
### 🤔 What's changed?

Add some debug-level logging to the start of the run, emitting the working directory and the `__dirname` of the `runCucumber` function.

### ⚡️ What's your motivation? 

To help diagnose #2353.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
