### PR TITLE
fix: updated cli message list and related unit test for scenario messaging (2440)

### DIFF
--- a/src/formatter/helpers/summary_helpers.ts
+++ b/src/formatter/helpers/summary_helpers.ts
@@ -7,6 +7,7 @@ import { ITestCaseAttempt } from './event_data_collector'
 const STATUS_REPORT_ORDER = [
   messages.TestStepResultStatus.FAILED,
   messages.TestStepResultStatus.AMBIGUOUS,
+  messages.TestStepResultStatus.UNKNOWN,
   messages.TestStepResultStatus.UNDEFINED,
   messages.TestStepResultStatus.PENDING,
   messages.TestStepResultStatus.SKIPPED,

--- a/src/formatter/helpers/summary_helpers_spec.ts
+++ b/src/formatter/helpers/summary_helpers_spec.ts
@@ -217,6 +217,8 @@ describe('SummaryHelpers', () => {
           '    Given a skipped step',
           '  Scenario: a6',
           '    Given an undefined step',
+          // an unknown scenario
+          '  Scenario:',
         ].join('\n')
 
         // Act
@@ -224,7 +226,7 @@ describe('SummaryHelpers', () => {
 
         // Assert
         expect(output).to.contain(
-          '6 scenarios (1 failed, 1 ambiguous, 1 undefined, 1 pending, 1 skipped, 1 passed)\n' +
+          '6 scenarios (1 failed, 1 ambiguous, 1 unknown, 1 undefined, 1 pending, 1 skipped, 1 passed)\n' +
             '6 steps (1 failed, 1 ambiguous, 1 undefined, 1 pending, 1 skipped, 1 passed)\n' +
             '0m00.000s (executing steps: 0m00.000s)\n'
         )

--- a/src/formatter/helpers/summary_helpers_spec.ts
+++ b/src/formatter/helpers/summary_helpers_spec.ts
@@ -226,7 +226,7 @@ describe('SummaryHelpers', () => {
 
         // Assert
         expect(output).to.contain(
-          '6 scenarios (1 failed, 1 ambiguous, 1 unknown, 1 undefined, 1 pending, 1 skipped, 1 passed)\n' +
+          '7 scenarios (1 failed, 1 ambiguous, 1 unknown, 1 undefined, 1 pending, 1 skipped, 1 passed)\n' +
             '6 steps (1 failed, 1 ambiguous, 1 undefined, 1 pending, 1 skipped, 1 passed)\n' +
             '0m00.000s (executing steps: 0m00.000s)\n'
         )


### PR DESCRIPTION
### 🤔 What's changed?

Updated CLI status message list to include Unknown case

### ⚡️ What's your motivation? 

I wanted some context as to why my total scenario count was being reported as "NaN scenarios"

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Pretty new to committing to a large public project so anything that comes to mind, including branch and PR naming convention, unit test coverage and if I should update the CHANGELOG Unreleased section(?).

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
  - [x] I have added/updated tests to cover my changes.
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

