### PR TITLE
Fix: Improve type safety in features/support/formatter_output_helpers, removes explicit `any` #1648

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber
 ## [Unreleased]
 ### Changed
 - Improve error handling in publish plugin ([#2526](https://github.com/cucumber/cucumber-js/pull/2526))
+- Improve type safety in features/support/formatter_output_helpers, removes explicit `any` ([#1648](https://github.com/cucumber/cucumber-js/pull/2106))
 
 ## [11.2.0] - 2025-01-09
 ### Added


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

Modified several places where ESLint was complaining about the use of explicit `any` ( after I set `@typescript-eslint/no-explicit-any` to ` 2`) in the `features/support/formatter_output_helpers.ts` file.

There were multiple checks using `doesHaveValue` but unfortunately this does not assure the TypeScript compiler that it is safe to refer to properties of the value; e.g. `let x = 2; if (doesHaveValue(x)) console.log(x.anything) // type error` so I had to add a `isObject` check so that it would be safe to refer to properties of values. So the use of `doesHaveValue` was replaced by `isObject` in a few places. You may want to move the `isObject` function to a shared file like `src/value_checker` because it's not specifically tied to the file it is defined in.

In other places I just replaced `any` with the correct type.

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

This will improve the type safety of the code base a tiny bit and help whittle down the list of files that break when  the `@typescript-eslint/no-explicit-any` rule is enabled.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

There are multiple ways that this issue could have been resolved; I tried to pick a solution that made the least changes to the existing code. You may have different priorities.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
