### PR TITLE
fix: properly handle ES module default exports in configuration files

### DIFF
--- a/features/esm.feature
+++ b/features/esm.feature
@@ -125,3 +125,57 @@ Feature: ES modules support
       """
         Error: Cucumber expected a CommonJS module
       """
+
+  @esm
+  Scenario: ES module configuration file with export default should load step definitions
+    Given a file named "features/a.feature" with:
+      """
+      Feature:
+        Scenario: one
+          Given a step that should be found
+      """
+    And a file named "features/step_definitions/cucumber_steps.js" with:
+      """
+      import {Given} from '@cucumber/cucumber'
+
+      Given(/^a step that should be found$/, function() {});
+      """
+    And a file named "cucumber.js" with:
+      """
+      export default {
+        default: {
+          import: ['features/**/*.js'],
+          format: ['progress']
+        }
+      }
+      """
+    When I run cucumber-js
+    Then it runs 1 scenarios
+    And it passes
+
+  @esm
+  Scenario: ES module configuration file should properly extract default export from mjs
+    Given a file named "features/a.feature" with:
+      """
+      Feature:
+        Scenario: one
+          Given a step that should also be found
+      """
+    And a file named "features/step_definitions/cucumber_steps.js" with:
+      """
+      import {Given} from '@cucumber/cucumber'
+
+      Given(/^a step that should also be found$/, function() {});
+      """
+    And a file named "cucumber.mjs" with:
+      """
+      export default {
+        default: {
+          import: ['features/**/*.js'],
+          format: ['progress']
+        }
+      }
+      """
+    When I run cucumber-js with `--config cucumber.mjs`
+    Then it runs 1 scenarios
+    And it passes

--- a/src/configuration/from_file.ts
+++ b/src/configuration/from_file.ts
@@ -103,7 +103,8 @@ async function loadFile(
       logger.debug(
         `Loading configuration file "${file}" as ESM based on extension`
       )
-      definitions = await import(pathToFileURL(filePath).toString())
+      const importedModule = await import(pathToFileURL(filePath).toString())
+      definitions = importedModule.default || importedModule
       break
     case '.js':
       {
@@ -118,7 +119,8 @@ async function loadFile(
           logger.debug(
             `Loading configuration file "${file}" as ESM based on "${parentPackage.name}" package type`
           )
-          definitions = await import(pathToFileURL(filePath).toString())
+          const importedModuleJs = await import(pathToFileURL(filePath).toString())
+          definitions = importedModuleJs.default || importedModuleJs
         } else {
           logger.debug(
             `Loading configuration file "${file}" as CommonJS based on "${parentPackage.name}" package type`


### PR DESCRIPTION
When importing ES module configuration files, the import() function returns an object with a 'default' property containing the exported value. This fix extracts the default export correctly to prevent double-nesting of configuration objects that would make them inaccessible during parsing.

Fixes issue where ES module configuration files with export default syntax would not be properly parsed, causing step definitions and other configuration to be ignored.

🤖 Generated with [Claude Code](https://claude.ai/code)

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
