### PR TITLE
[Fix 2720] handling unknown testStepResult in src/formatter/json_form…

### DIFF
--- a/src/formatter/json_formatter.ts
+++ b/src/formatter/json_formatter.ts
@@ -278,7 +278,8 @@ export default class JsonFormatter extends Formatter {
       )
       data.match = { location: formatLocation(stepDefinition) }
     }
-    const { message, status } = testStepResult
+    const message = testStepResult?.message
+    const status = testStepResult?.status ?? 'UNKNOWN'
     data.result = {
       status: messages.TestStepResultStatus[status].toLowerCase(),
     }


### PR DESCRIPTION
### 🤔 What's changed?

cucumber was failing to generate cucumber json report after whole run of many scenarios in parallel mode so I handled the unknown testStepResult error.
 const { message, status } = testStepResult
            ^
TypeError: Cannot destructure property 'message' of 'testStepResult' as it is undefined.
    at JsonFormatter.getStepData (C:\.............\node_modules\@cucumber\cucumber\src\formatter\json_formatter.ts:281:13)

### ⚡️ What's your motivation? 
I was getting constantly failure in getting data from cucumber.json (report file for my automated cases run). So I decided to see the error. https://github.com/cucumber/cucumber-js/issues/2720

