### PR TITLE
Support custom externalising option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Added
+- Support custom externalising option ([#2780](https://github.com/cucumber/cucumber-js/pull/2780))
 
 ## [12.7.0] - 2026-02-25
 ### Changed

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -116,7 +116,23 @@ By default, the HTML report includes all attachments from your test run as embed
 }
 ```
 
-This will cause attachments to be saved in the same directory as the report file, with filenames that look like `attachment-8e7c5d3d-1ef0-4be6-86e0-16362bad9531.png`. If you want to put the report file somewhere - say, a web server - to be viewed, you'll need to bring those files along with it.
+For more granular control, you can provide an array of content type patterns to match against:
+
+```json
+{
+  "formatOptions": {
+    "html": {
+      "externalAttachments": ["image/*", "video/*"]
+    }
+  }
+}
+```
+
+Patterns can be exact types like `image/png` or use a wildcard for the subtype like `image/*`.
+
+Note that log and link attachments are never externalized regardless of the option value.
+
+Externalized attachments are saved in the same directory as the report file, with filenames that look like `attachment-8e7c5d3d-1ef0-4be6-86e0-16362bad9531.png`. If you want to put the report file somewhere - say, a web server - to be viewed, you'll need to bring those files along with it.
 
 ### `message`
 

--- a/features/html_formatter.feature
+++ b/features/html_formatter.feature
@@ -18,6 +18,7 @@ Feature: HTML formatter
           world.link('https://cucumber.io')
           world.attach(btoa('Base64 text'), 'base64:text/plain')
           world.attach('Plain text', 'text/plain')
+          world.attach('<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>', 'image/svg+xml')
         })
         """
 
@@ -27,10 +28,18 @@ Feature: HTML formatter
       And the html formatter output is complete
       And the formatter has no externalised attachments
 
-    Scenario: With externalAttachments option
+    Scenario: With externalAttachments as true
       When I run cucumber-js with `--format html:html.out --format-options '{"html":{"externalAttachments":true}}'`
       Then it passes
       And the html formatter output is complete
       And the formatter has these external attachments:
+        | <svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg> |
         | Base64 text |
         | Plain text  |
+
+    Scenario: With externalAttachments as array of mime type matchers
+      When I run cucumber-js with `--format html:html.out --format-options '{"html":{"externalAttachments":["image/*"]}}'`
+      Then it passes
+      And the html formatter output is complete
+      And the formatter has these external attachments:
+        | <svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg> |

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@cucumber/gherkin-utils": "11.0.0",
         "@cucumber/html-formatter": "23.0.0",
         "@cucumber/junit-xml-formatter": "0.9.0",
-        "@cucumber/message-streams": "4.1.0",
+        "@cucumber/message-streams": "4.1.1",
         "@cucumber/messages": "32.0.1",
         "@cucumber/pretty-formatter": "1.0.1",
         "@cucumber/tag-expressions": "9.1.0",
@@ -1066,9 +1066,9 @@
       }
     },
     "node_modules/@cucumber/message-streams": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-4.1.0.tgz",
-      "integrity": "sha512-ofYV4aeQKkYxEX7hgzhUMap1xGGpxjQbFPgwlNBA/GoFQdQ8Xw22vhDG08sQ98ugjUlbwSLDjPUe6/q430p7Mg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-4.1.1.tgz",
+      "integrity": "sha512-QCAntLajesWMyX+mZKrj63YghVAts7yKFlZe46XprLbdJZN0ddB+f/Mr9OnyWKC2DHhJ18jzCfKIFCaqpAmUxg==",
       "license": "MIT",
       "dependencies": {
         "mime": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
         "luxon": "3.7.2",
-        "mime": "^3.0.0",
         "mkdirp": "^3.0.0",
         "mz": "^2.7.0",
         "progress": "^2.0.3",
@@ -7272,6 +7271,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
       "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "peer": true,
       "bin": {
         "mime": "cli.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@cucumber/gherkin-utils": "11.0.0",
         "@cucumber/html-formatter": "23.0.0",
         "@cucumber/junit-xml-formatter": "0.9.0",
-        "@cucumber/message-streams": "4.0.1",
+        "@cucumber/message-streams": "4.1.0",
         "@cucumber/messages": "32.0.1",
         "@cucumber/pretty-formatter": "1.0.1",
         "@cucumber/tag-expressions": "9.1.0",
@@ -659,6 +659,16 @@
         "@cucumber/messages": "*"
       }
     },
+    "node_modules/@cucumber/cucumber/node_modules/@cucumber/message-streams": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-4.0.1.tgz",
+      "integrity": "sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@cucumber/messages": ">=17.1.1"
+      }
+    },
     "node_modules/@cucumber/cucumber/node_modules/@cucumber/messages": {
       "version": "27.2.0",
       "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-27.2.0.tgz",
@@ -1056,9 +1066,13 @@
       }
     },
     "node_modules/@cucumber/message-streams": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-4.0.1.tgz",
-      "integrity": "sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-4.1.0.tgz",
+      "integrity": "sha512-ofYV4aeQKkYxEX7hgzhUMap1xGGpxjQbFPgwlNBA/GoFQdQ8Xw22vhDG08sQ98ugjUlbwSLDjPUe6/q430p7Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
       "peerDependencies": {
         "@cucumber/messages": ">=17.1.1"
       }
@@ -7271,7 +7285,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
       "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "peer": true,
       "bin": {
         "mime": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "@cucumber/gherkin-utils": "11.0.0",
     "@cucumber/html-formatter": "23.0.0",
     "@cucumber/junit-xml-formatter": "0.9.0",
-    "@cucumber/message-streams": "4.0.1",
+    "@cucumber/message-streams": "4.1.0",
     "@cucumber/messages": "32.0.1",
     "@cucumber/pretty-formatter": "1.0.1",
     "@cucumber/tag-expressions": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -247,7 +247,6 @@
     "lodash.merge": "^4.6.2",
     "lodash.mergewith": "^4.6.2",
     "luxon": "3.7.2",
-    "mime": "^3.0.0",
     "mkdirp": "^3.0.0",
     "mz": "^2.7.0",
     "progress": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "@cucumber/gherkin-utils": "11.0.0",
     "@cucumber/html-formatter": "23.0.0",
     "@cucumber/junit-xml-formatter": "0.9.0",
-    "@cucumber/message-streams": "4.1.0",
+    "@cucumber/message-streams": "4.1.1",
     "@cucumber/messages": "32.0.1",
     "@cucumber/pretty-formatter": "1.0.1",
     "@cucumber/tag-expressions": "9.1.0",

--- a/src/formatter/builtin/html.ts
+++ b/src/formatter/builtin/html.ts
@@ -1,19 +1,11 @@
 import { promisify } from 'node:util'
 import { finished } from 'node:stream'
-import { writeFile } from 'node:fs'
-import path from 'node:path'
 import { CucumberHtmlStream } from '@cucumber/html-formatter'
-import mimeTypes from 'mime'
-import {
-  Attachment,
-  AttachmentContentEncoding,
-  Envelope,
-  IdGenerator,
-} from '@cucumber/messages'
+import { AttachmentExternalisingStream } from '@cucumber/message-streams'
 import { FormatterPlugin } from '../../plugin'
 
 interface Options {
-  externalAttachments?: true
+  externalAttachments?: boolean | ReadonlyArray<string>
 }
 
 export default {
@@ -24,70 +16,21 @@ export default {
         'Unable to externalise attachments when formatter is not writing to a file'
       )
     }
-    const newId = IdGenerator.uuid()
+    const externaliseStream = new AttachmentExternalisingStream({
+      behaviour: options.externalAttachments,
+      directory,
+    })
     const htmlStream = new CucumberHtmlStream()
-    const writeOperations: Promise<void>[] = []
+    externaliseStream.pipe(htmlStream)
     on('message', (message) => {
-      if (message.attachment && options.externalAttachments) {
-        const { attachment, writeOperation } = externaliseAttachment(
-          newId,
-          message.attachment,
-          directory
-        )
-        htmlStream.write({
-          ...message,
-          attachment,
-        } satisfies Envelope)
-        if (writeOperation) {
-          writeOperations.push(writeOperation)
-        }
-      } else {
-        htmlStream.write(message)
-      }
+      externaliseStream.write(message)
     })
     htmlStream.on('data', (chunk) => write(chunk))
 
     return async () => {
-      htmlStream.end()
+      externaliseStream.end()
       await promisify(finished)(htmlStream)
-      await Promise.all(writeOperations)
     }
   },
   optionsKey: 'html',
 } satisfies FormatterPlugin<Options>
-
-const alwaysInlinedTypes = ['text/x.cucumber.log+plain', 'text/uri-list']
-
-const encodingsMap = {
-  IDENTITY: 'utf-8',
-  BASE64: 'base64',
-} as const
-
-function externaliseAttachment(
-  newId: () => string,
-  original: Attachment,
-  directory: string
-) {
-  if (alwaysInlinedTypes.includes(original.mediaType)) {
-    return { attachment: original }
-  }
-  let filename = `attachment-${newId()}`
-  const extension = mimeTypes.getExtension(original.mediaType)
-  if (extension) {
-    filename += `.${extension}`
-  }
-  const writeOperation = promisify(writeFile)(
-    path.join(directory, filename),
-    Buffer.from(original.body, encodingsMap[original.contentEncoding])
-  )
-  const updated: Attachment = {
-    ...original,
-    contentEncoding: AttachmentContentEncoding.IDENTITY,
-    body: '',
-    url: `./${filename}`,
-  }
-  return {
-    attachment: updated,
-    writeOperation,
-  }
-}

--- a/src/formatter/index.ts
+++ b/src/formatter/index.ts
@@ -18,7 +18,7 @@ export interface FormatOptions {
    */
   colorsEnabled?: boolean
   html?: {
-    externalAttachments?: boolean
+    externalAttachments?: boolean | ReadonlyArray<string>
   }
   rerun?: FormatRerunOptions
   snippetInterface?: SnippetInterface


### PR DESCRIPTION
### 🤔 What's changed?

- Move the attachment externalising behaviour out of here and into `message-streams` (see https://github.com/cucumber/message-streams/pull/89)
- Adopt support for a list of matchers to target which types to externalise

### ⚡️ What's your motivation? 

Fixes #2781.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
