### PR TITLE
Correct advice for ESM with tsx

### DIFF
--- a/docs/transpiling.md
+++ b/docs/transpiling.md
@@ -28,10 +28,19 @@ For CommonJS, you need to use the `requireModule` configuration option to regist
 
 ## ESM
 
-For ESM, you need to use the `import` configuration option to register `tsx/esm`, and then `import` for your TypeScript support code, in that order, like this:
+For ESM, you need a small setup file that explicitly [registers tsx](https://tsx.hirok.io/dev-api/register-esm) using its programmatic API:
 
-- In a configuration file `{ import: ['tsx/esm', 'features/step-definitions/**/*.ts'] }`
-- On the CLI `npx cucumber-js --import tsx/esm --import 'features/step-definitions/**/*.ts'`
+```js
+// tsx-register.js
+import { register } from 'tsx/esm/api'
+
+register()
+```
+
+Then use the `import` configuration option with that file followed by your TypeScript support code, in that order:
+
+- In a configuration file `{ import: ['./tsx-register.js', 'features/step-definitions/**/*.ts'] }`
+- On the CLI `npx cucumber-js --import ./tsx-register.js --import 'features/step-definitions/**/*.ts'`
 
 ### tsconfig-paths
 


### PR DESCRIPTION
### 🤔 What's changed?

Correct an error in the documentation about how to use tsx with ESM. Specifically, you need to import `tsx/esm` and call `register` on it in order for it to kick in at runtime.

### ⚡️ What's your motivation? 

Fixes #2775

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
