### PR TITLE
Include assertion info in stack trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber
 
 ### Fixed
 - Handle thrown strings correctly ([#2708](https://github.com/cucumber/cucumber-js/pull/2708))
+- Include assertion info in stack trace ([#2803](https://github.com/cucumber/cucumber-js/pull/2803))
 
 ## [12.8.2] - 2026-04-25
 ### Changed

--- a/src/runtime/format_error.ts
+++ b/src/runtime/format_error.ts
@@ -28,7 +28,7 @@ export function formatError(
   } catch {
     // if we weren't able to parse and process, we'll settle for the original
   }
-  const legacyMessage = format(error, {
+  const stackTrace = format(error, {
     colorFns: {
       errorStack: (stack: string) => {
         return processedStackTrace ? `\n${processedStackTrace}` : stack
@@ -37,12 +37,8 @@ export function formatError(
   })
   const type = error.constructor.name
   const message = typeof error === 'string' ? error : error.message
-  let stackTrace = `${type}: ${message}`
-  if (processedStackTrace) {
-    stackTrace += '\n' + processedStackTrace
-  }
   return {
-    message: legacyMessage,
+    message: stackTrace,
     exception: {
       type,
       message,

--- a/src/runtime/format_error_spec.ts
+++ b/src/runtime/format_error_spec.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert'
+import { stripVTControlCharacters } from 'node:util'
 import { expect } from 'chai'
 import { formatError } from './format_error'
 
@@ -81,8 +82,9 @@ describe('formatError', () => {
             assert.ok(false, 'Thing that should have been truthy was falsy!')
           })
           expect(result).to.have.string(' at ')
+          expect(result).to.have.string('AssertionError')
           expect(result).to.have.string(
-            'AssertionError: Thing that should have been truthy was falsy!'
+            'Thing that should have been truthy was falsy!'
           )
         })
 
@@ -96,12 +98,24 @@ describe('formatError', () => {
           )
         })
 
+        it('should handle an assertion error', () => {
+          const result = testFormatError(() => {
+            assert.equal(1, 2, 'number go up')
+          })
+          const sanitised = stripVTControlCharacters(result)
+          expect(sanitised).to.have.string('number go up')
+          expect(sanitised).to.have.string('+ expected')
+          expect(sanitised).to.have.string('- actual')
+          expect(sanitised).to.have.string('-1')
+          expect(sanitised).to.have.string('+2')
+        })
+
         it('should handle an omitted message', () => {
           const result = testFormatError(() => {
             throw new Error()
           })
           expect(result).to.have.string(' at ')
-          expect(result).to.have.string('Error: ')
+          expect(result).to.have.string('{}')
         })
 
         it('should handle a thrown string', () => {


### PR DESCRIPTION
### 🤔 What's changed?

When composing the `Exception` message, use the output from `assertion-error-formatter` in the `stackTrace` field so that actual/expected diffs etc still make it into output from newer formatters.

### ⚡️ What's your motivation? 

Fixes #2802.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
