### PR TITLE
Rework integration with Cucumber Reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Added
+- Emit new `publish:url` event for plugins ([#2808](https://github.com/cucumber/cucumber-js/pull/2808))
+
 ### Changed
 - BREAKING CHANGE: Set `FORCE_COLOR` based on deprecated format option ([#2769](https://github.com/cucumber/cucumber-js/pull/2769))
 - Redesigned output for summary, progress, progress bar and pretty formatters ([#2708](https://github.com/cucumber/cucumber-js/pull/2708))

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -87,6 +87,7 @@ You can register passive event handlers for these things that happen in Cucumber
 
 - `message` - emitted for each [Cucumber Message](https://github.com/cucumber/messages) during the process. These are most commonly consumed by [Formatters](./formatters.md), but have other uses too.
 - `paths:resolve` - emitted when Cucumber has resolved the paths on the file system from which it will load feature files and support code.
+- `publish:url` - emitted when Cucumber Reports has reserved a slot for a new report, with the URL where it will be available as a string. Only fires when publishing is enabled and the initial reservation succeeds; it does not guarantee the upload itself will succeed.
 
 Here's an example emitting a log when the test run finishes:
 

--- a/exports/api/report.api.md
+++ b/exports/api/report.api.md
@@ -32,12 +32,13 @@ export type CoordinatorEnvironment = {
 export type CoordinatorEventHandler<K extends CoordinatorEventKey> = (value: CoordinatorEventValues[K]) => void;
 
 // @public
-export type CoordinatorEventKey = 'message' | 'paths:resolve';
+export type CoordinatorEventKey = 'message' | 'paths:resolve' | 'publish:url';
 
 // @public
 export type CoordinatorEventValues = {
     message: Readonly<Envelope>;
     'paths:resolve': Readonly<IResolvedPaths>;
+    'publish:url': string;
 };
 
 // @public

--- a/features/publish.feature
+++ b/features/publish.feature
@@ -1,4 +1,4 @@
-@flaky
+@spawn @flaky
 Feature: Publish reports
 
   Background:
@@ -17,7 +17,6 @@ Feature: Publish reports
       Given(/^a step$/, function() {})
       """
 
-  @spawn
   Scenario: Report is published when --publish is specified
     When I run cucumber-js with arguments `--publish` and env ``
     Then it passes
@@ -35,7 +34,6 @@ Feature: Publish reports
       | testCaseFinished |
       | testRunFinished  |
 
-  @spawn
   Scenario: Report is published when CUCUMBER_PUBLISH_ENABLED is set
     When I run cucumber-js with arguments `` and env `CUCUMBER_PUBLISH_ENABLED=1`
     Then it passes
@@ -53,7 +51,6 @@ Feature: Publish reports
       | testCaseFinished |
       | testRunFinished  |
 
-  @spawn
   Scenario: Report is published when CUCUMBER_PUBLISH_TOKEN is set
     When I run cucumber-js with arguments `` and env `CUCUMBER_PUBLISH_TOKEN=f318d9ec-5a3d-4727-adec-bd7b69e2edd3`
     Then it passes
@@ -72,7 +69,6 @@ Feature: Publish reports
       | testRunFinished  |
     And the server should receive an "Authorization" header with value "Bearer f318d9ec-5a3d-4727-adec-bd7b69e2edd3"
 
-  @spawn
   Scenario: a banner is displayed after publication
     When I run cucumber-js with arguments `--publish` and env ``
     Then the error output contains the text:
@@ -85,7 +81,6 @@ Feature: Publish reports
       └──────────────────────────────────────────────────────────────────────────┘
       """
 
-  @spawn
   Scenario: results are not published due to a client error
     When I run cucumber-js with env `CUCUMBER_PUBLISH_TOKEN=keyboardcat`
     Then it passes
@@ -96,7 +91,6 @@ Feature: Publish reports
       └─────────────────────┘
       """
 
-  @spawn
   Scenario: results are not published due to a service error
     Given report publishing is not working
     When I run cucumber-js with arguments `--publish` and env ``
@@ -110,7 +104,6 @@ Feature: Publish reports
       Failed to publish report to http://localhost:9987 with status 500
       """
 
-  @spawn
   Scenario: results are not published due to an error on uploading
     Given report uploads are not working
     When I run cucumber-js with arguments `--publish` and env ``
@@ -122,4 +115,23 @@ Feature: Publish reports
     And the error output contains the text:
       """
       Failed to upload report to http://localhost:9987 with status 500
+      """
+
+  Scenario: a plugin can subscribe to the publish:url event
+    Given a file named "my_plugin.mjs" with:
+      """
+      export default {
+        type: 'plugin',
+        coordinator({ on, logger }) {
+          on('publish:url', (url) => {
+            logger.info(`Got report URL: ${url}`)
+          })
+        }
+      }
+      """
+    When I run cucumber-js with arguments `--publish --plugin ./my_plugin.mjs` and env ``
+    Then it passes
+    And the error output contains the text:
+      """
+      Got report URL: https://reports.cucumber.io/reports/f318d9ec-5a3d-4727-adec-bd7b69e2edd3
       """

--- a/src/api/plugins.ts
+++ b/src/api/plugins.ts
@@ -57,7 +57,11 @@ export async function initializeForLoadSources(
 ): Promise<PluginManager> {
   // eventually we'll load plugin packages here
   const pluginManager = new PluginManager(environment)
-  await pluginManager.initCoordinator('loadSources', filterPlugin, coordinates)
+  await pluginManager.initCoordinatorInternal(
+    'loadSources',
+    filterPlugin,
+    coordinates
+  )
   return pluginManager
 }
 
@@ -74,17 +78,12 @@ export async function initializeForRunCucumber(
 ): Promise<PluginManager> {
   const pluginManager = new PluginManager(environment)
 
-  await pluginManager.initCoordinator(
-    'runCucumber',
-    publishPlugin,
-    configuration.formats.publish
-  )
-  await pluginManager.initCoordinator(
+  await pluginManager.initCoordinatorInternal(
     'runCucumber',
     filterPlugin,
     configuration.sources
   )
-  await pluginManager.initCoordinator(
+  await pluginManager.initCoordinatorInternal(
     'runCucumber',
     shardingPlugin,
     configuration.sources
@@ -93,7 +92,7 @@ export async function initializeForRunCucumber(
   if (configuration.plugins) {
     for (const specifier of configuration.plugins.specifiers) {
       const plugin = await loadPlugin(specifier, environment.cwd)
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         plugin,
         configuration.plugins.options,
@@ -101,6 +100,13 @@ export async function initializeForRunCucumber(
       )
     }
   }
+
+  // internal plugins that `emit` go last so consumers have a chance to `on`
+  await pluginManager.initCoordinatorInternal(
+    'runCucumber',
+    publishPlugin,
+    configuration.formats.publish
+  )
 
   return pluginManager
 }

--- a/src/configuration/check_schema.ts
+++ b/src/configuration/check_schema.ts
@@ -33,7 +33,7 @@ const schema = yup.object().shape({
   order: yup.string().matches(/^random:.*|random|defined$/),
   paths: yup.array().of(yup.string()),
   parallel: yup.number().integer().min(0),
-  plugin: yup.array().of(yup.string()),
+  plugin: yup.array().of(yup.string().trim().required()),
   pluginOptions: yup.object(),
   publish: yup.boolean(),
   require: yup.array().of(yup.string()),

--- a/src/filter/filter_plugin.ts
+++ b/src/filter/filter_plugin.ts
@@ -1,8 +1,8 @@
-import { Plugin } from '../plugin'
+import { InternalPlugin } from '../plugin'
 import PickleFilter from '../pickle_filter'
 import { orderPickles } from './order_pickles'
 
-export const filterPlugin: Plugin = {
+export const filterPlugin: InternalPlugin = {
   type: 'plugin',
   coordinator: async ({ on, transform, options, logger, environment }) => {
     let unexpandedSourcePaths: string[] = []

--- a/src/plugin/plugin_manager.ts
+++ b/src/plugin/plugin_manager.ts
@@ -1,5 +1,6 @@
 import { UsableEnvironment } from '../environment'
 import {
+  CoordinatorContext,
   CoordinatorEventHandler,
   CoordinatorEventKey,
   CoordinatorEventValues,
@@ -7,6 +8,7 @@ import {
   CoordinatorTransformKey,
   CoordinatorTransformValues,
   FormatterPlugin,
+  InternalPlugin,
   Plugin,
   PluginCleanup,
   PluginOperation,
@@ -39,6 +41,7 @@ export class PluginManager {
   private readonly handlers: HandlerRegistry = {
     message: [],
     'paths:resolve': [],
+    'publish:url': [],
   }
   private readonly transformers: TransformerRegistry = {
     'pickles:filter': [],
@@ -104,13 +107,57 @@ export class PluginManager {
     }
   }
 
-  async initCoordinator<OptionsType>(
+  async initCoordinatorExternal<OptionsType>(
     operation: PluginOperation,
     plugin: Plugin<OptionsType>,
     options: OptionsType,
     specifier?: string
   ) {
+    const context = this.makeCoordinatorContext(
+      operation,
+      plugin,
+      options,
+      specifier
+    )
+    await this.initCoordinator(plugin, context, specifier)
+  }
+
+  async initCoordinatorInternal<OptionsType>(
+    operation: PluginOperation,
+    plugin: Plugin<OptionsType>,
+    options: OptionsType
+  ) {
     const context = {
+      ...this.makeCoordinatorContext(operation, plugin, options),
+      emit: this.emit.bind(this),
+    }
+    await this.initCoordinator(plugin, context)
+  }
+
+  private async initCoordinator<OptionsType>(
+    plugin: Plugin<OptionsType>,
+    context: CoordinatorContext<OptionsType>,
+    specifier?: string
+  ) {
+    const cleanupFn = await wrapErrorAsync(
+      async () => await plugin.coordinator(context),
+      `${formatCulprit(specifier)} errored when trying to init`
+    )
+    if (typeof cleanupFn === 'function') {
+      this.cleanupFns.push({
+        cleanupFn: cleanupFn,
+        specifier,
+      })
+    }
+  }
+
+  private makeCoordinatorContext<OptionsType>(
+    operation: PluginOperation,
+    plugin: Plugin<OptionsType> | InternalPlugin<OptionsType>,
+    options: OptionsType,
+    specifier?: string
+  ) {
+    return {
       operation,
       on: <K extends CoordinatorEventKey>(
         event: K,
@@ -131,17 +178,6 @@ export class PluginManager {
         env: { ...this.environment.env },
       },
     }
-    const cleanupFn = await wrapErrorAsync(
-      async () => await plugin.coordinator(context),
-      specifier,
-      `Plugin "${specifier}" errored when trying to init`
-    )
-    if (typeof cleanupFn === 'function') {
-      this.cleanupFns.push({
-        cleanupFn: cleanupFn,
-        specifier,
-      })
-    }
   }
 
   emit<K extends CoordinatorEventKey>(
@@ -151,8 +187,7 @@ export class PluginManager {
     this.handlers[event].forEach(({ handler, specifier }) => {
       wrapError(
         () => handler(value),
-        specifier,
-        `Plugin "${specifier}" errored when trying to handle a "${event}" event`
+        `${formatCulprit(specifier)} errored when trying to handle a "${event}" event`
       )
     })
   }
@@ -165,8 +200,7 @@ export class PluginManager {
     for (const { transformer, specifier } of this.transformers[event]) {
       const returned = await wrapErrorAsync(
         async () => await transformer(transformed),
-        specifier,
-        `Plugin "${specifier}" errored when trying to do a "${event}" transform`
+        `${formatCulprit(specifier)} errored when trying to do a "${event}" transform`
       )
       if (typeof returned !== 'undefined') {
         transformed = returned
@@ -179,35 +213,31 @@ export class PluginManager {
     for (const { cleanupFn, specifier } of this.cleanupFns) {
       await wrapErrorAsync(
         async () => await cleanupFn(),
-        specifier,
-        `Plugin "${specifier}" errored when trying to cleanup`
+        `${formatCulprit(specifier)} errored when trying to cleanup`
       )
     }
   }
 }
 
-function wrapError<T>(fn: () => T, specifier: string, message: string): T {
+function formatCulprit(specifier?: string) {
+  return specifier ? `Plugin "${specifier}"` : 'Cucumber'
+}
+
+function wrapError<T>(fn: () => T, message: string): T {
   try {
     return fn()
   } catch (error) {
-    if (specifier) {
-      throw new Error(message, { cause: error })
-    }
-    throw error
+    throw new Error(message, { cause: error })
   }
 }
 
 async function wrapErrorAsync<T>(
   fn: () => Promise<T>,
-  specifier: string,
   message: string
 ): Promise<T> {
   try {
     return await fn()
   } catch (error) {
-    if (specifier) {
-      throw new Error(message, { cause: error })
-    }
-    throw error
+    throw new Error(message, { cause: error })
   }
 }

--- a/src/plugin/plugin_manager_spec.ts
+++ b/src/plugin/plugin_manager_spec.ts
@@ -4,6 +4,7 @@ import { FakeLogger } from '../../test/fake_logger'
 import { IFilterablePickle } from '../filter'
 import { UsableEnvironment } from '../environment'
 import { PluginManager } from './plugin_manager'
+import { InternalPlugin } from './types'
 
 describe('PluginManager', () => {
   const usableEnvironment: UsableEnvironment = {
@@ -18,7 +19,7 @@ describe('PluginManager', () => {
   it('passes the correct context to the coordinator function', async () => {
     const pluginManager = new PluginManager(usableEnvironment)
     const coordinator = sinon.fake()
-    await pluginManager.initCoordinator(
+    await pluginManager.initCoordinatorExternal(
       'runCucumber',
       {
         type: 'plugin',
@@ -44,7 +45,7 @@ describe('PluginManager', () => {
     const originalError = new Error('whoops')
 
     try {
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -64,12 +65,12 @@ describe('PluginManager', () => {
     }
   })
 
-  it('does not wrap errors from internal plugin coordinator functions', async () => {
+  it('wraps errors from internal plugin coordinator functions as Cucumber', async () => {
     const pluginManager = new PluginManager(usableEnvironment)
     const originalError = new Error('whoops')
 
     try {
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -81,7 +82,8 @@ describe('PluginManager', () => {
       )
       expect.fail('Expected error to be thrown')
     } catch (error) {
-      expect(error).to.equal(originalError)
+      expect(error.message).to.equal('Cucumber errored when trying to init')
+      expect(error.cause).to.equal(originalError)
     }
   })
 
@@ -90,7 +92,7 @@ describe('PluginManager', () => {
       const pluginManager = new PluginManager(usableEnvironment)
 
       try {
-        await pluginManager.initCoordinator(
+        await pluginManager.initCoordinatorExternal(
           'runCucumber',
           {
             type: 'plugin',
@@ -114,7 +116,7 @@ describe('PluginManager', () => {
       const pluginManager = new PluginManager(usableEnvironment)
       const handler1 = sinon.fake()
       const handler2 = sinon.fake()
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -122,7 +124,7 @@ describe('PluginManager', () => {
         },
         {}
       )
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -148,7 +150,7 @@ describe('PluginManager', () => {
     it('wraps errors from custom plugin event handlers', async () => {
       const pluginManager = new PluginManager(usableEnvironment)
       const originalError = new Error('handler failed')
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -176,10 +178,10 @@ describe('PluginManager', () => {
       }
     })
 
-    it('does not wrap errors from internal plugin event handlers', async () => {
+    it('wraps errors from internal plugin event handlers as Cucumber', async () => {
       const pluginManager = new PluginManager(usableEnvironment)
       const originalError = new Error('handler failed')
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -199,7 +201,10 @@ describe('PluginManager', () => {
         })
         expect.fail('Expected error to be thrown')
       } catch (error) {
-        expect(error).to.equal(originalError)
+        expect(error.message).to.equal(
+          'Cucumber errored when trying to handle a "message" event'
+        )
+        expect(error.cause).to.equal(originalError)
       }
     })
   })
@@ -209,7 +214,7 @@ describe('PluginManager', () => {
       const pluginManager = new PluginManager(usableEnvironment)
 
       try {
-        await pluginManager.initCoordinator(
+        await pluginManager.initCoordinatorExternal(
           'runCucumber',
           {
             type: 'plugin',
@@ -250,7 +255,7 @@ describe('PluginManager', () => {
 
     it('should apply transforms in the order registered', async () => {
       const pluginManager = new PluginManager(usableEnvironment)
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -263,7 +268,7 @@ describe('PluginManager', () => {
         },
         {}
       )
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -286,7 +291,7 @@ describe('PluginManager', () => {
 
     it('should treat undefined as a noop', async () => {
       const pluginManager = new PluginManager(usableEnvironment)
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -307,7 +312,7 @@ describe('PluginManager', () => {
     it('wraps errors from custom plugin transformers', async () => {
       const pluginManager = new PluginManager(usableEnvironment)
       const originalError = new Error('transformer failed')
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -331,10 +336,10 @@ describe('PluginManager', () => {
       }
     })
 
-    it('does not wrap errors from internal plugin transformers', async () => {
+    it('wraps errors from internal plugin transformers as Cucumber', async () => {
       const pluginManager = new PluginManager(usableEnvironment)
       const originalError = new Error('transformer failed')
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -350,8 +355,68 @@ describe('PluginManager', () => {
         await pluginManager.transform('pickles:filter', filterablePickles)
         expect.fail('Expected error to be thrown')
       } catch (error) {
-        expect(error).to.equal(originalError)
+        expect(error.message).to.equal(
+          'Cucumber errored when trying to do a "pickles:filter" transform'
+        )
+        expect(error.cause).to.equal(originalError)
       }
+    })
+  })
+
+  describe('emit', () => {
+    it('passes an emit function to internal plugins', async () => {
+      const pluginManager = new PluginManager(usableEnvironment)
+      const coordinator = sinon.fake()
+      await pluginManager.initCoordinatorInternal(
+        'runCucumber',
+        {
+          type: 'plugin',
+          coordinator,
+        },
+        {}
+      )
+
+      expect(coordinator.lastCall.firstArg.emit).to.be.a('function')
+    })
+
+    it('does not pass an emit function to external plugins', async () => {
+      const pluginManager = new PluginManager(usableEnvironment)
+      const coordinator = sinon.fake()
+      await pluginManager.initCoordinatorExternal(
+        'runCucumber',
+        {
+          type: 'plugin',
+          coordinator,
+        },
+        {}
+      )
+
+      expect(coordinator.lastCall.firstArg.emit).to.be.undefined
+    })
+
+    it('allows an internal plugin to emit events to registered handlers', async () => {
+      const pluginManager = new PluginManager(usableEnvironment)
+      const handler = sinon.fake()
+      await pluginManager.initCoordinatorExternal(
+        'runCucumber',
+        {
+          type: 'plugin',
+          coordinator: ({ on }) => on('publish:url', handler),
+        },
+        {}
+      )
+      const internalPlugin: InternalPlugin = {
+        type: 'plugin',
+        coordinator: ({ emit }) =>
+          emit('publish:url', 'https://example.com/report'),
+      }
+      await pluginManager.initCoordinatorInternal(
+        'runCucumber',
+        internalPlugin,
+        {}
+      )
+
+      expect(handler).to.have.been.calledOnceWith('https://example.com/report')
     })
   })
 
@@ -360,7 +425,7 @@ describe('PluginManager', () => {
       const pluginManager = new PluginManager(usableEnvironment)
       const cleanup1 = sinon.fake()
       const cleanup2 = sinon.fake()
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -368,7 +433,7 @@ describe('PluginManager', () => {
         },
         {}
       )
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -386,7 +451,7 @@ describe('PluginManager', () => {
     it('wraps errors from custom plugin cleanup functions', async () => {
       const pluginManager = new PluginManager(usableEnvironment)
       const originalError = new Error('cleanup failed')
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -409,10 +474,10 @@ describe('PluginManager', () => {
       }
     })
 
-    it('does not wrap errors from internal plugin cleanup functions', async () => {
+    it('wraps errors from internal plugin cleanup functions as Cucumber', async () => {
       const pluginManager = new PluginManager(usableEnvironment)
       const originalError = new Error('cleanup failed')
-      await pluginManager.initCoordinator(
+      await pluginManager.initCoordinatorExternal(
         'runCucumber',
         {
           type: 'plugin',
@@ -427,7 +492,10 @@ describe('PluginManager', () => {
         await pluginManager.cleanup()
         expect.fail('Expected error to be thrown')
       } catch (error) {
-        expect(error).to.equal(originalError)
+        expect(error.message).to.equal(
+          'Cucumber errored when trying to cleanup'
+        )
+        expect(error.cause).to.equal(originalError)
       }
     })
   })

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -38,7 +38,7 @@ export type CoordinatorEnvironment = {
  * Keys for event handlers that plugins can register
  * @public
  */
-export type CoordinatorEventKey = 'message' | 'paths:resolve'
+export type CoordinatorEventKey = 'message' | 'paths:resolve' | 'publish:url'
 
 /**
  * Keys for transforms that plugins can register
@@ -53,6 +53,7 @@ export type CoordinatorTransformKey = 'pickles:filter' | 'pickles:order'
 export type CoordinatorEventValues = {
   message: Readonly<Envelope>
   'paths:resolve': Readonly<IResolvedPaths>
+  'publish:url': string
 }
 
 /**
@@ -151,6 +152,29 @@ export type Plugin<OptionsType = any> = {
    * Optional key to extract plugin-specific options from the root options object
    */
   optionsKey?: string
+}
+
+/**
+ * Context object passed to an internal plugin's coordinator function
+ * @internal
+ */
+export type InternalCoordinatorContext<OptionsType> =
+  CoordinatorContext<OptionsType> & {
+    emit: <EventKey extends CoordinatorEventKey>(
+      event: EventKey,
+      value: CoordinatorEventValues[EventKey]
+    ) => void
+  }
+
+/**
+ * A built-in plugin with the additional ability to emit events
+ * @internal
+ */
+export type InternalPlugin<OptionsType = any> = {
+  type: 'plugin'
+  coordinator: (
+    context: InternalCoordinatorContext<OptionsType>
+  ) => PromiseLike<PluginCleanup | void> | PluginCleanup | void
 }
 
 /**

--- a/src/publish/publish_plugin.ts
+++ b/src/publish/publish_plugin.ts
@@ -8,7 +8,7 @@ import { createReadStream, createWriteStream } from 'node:fs'
 import { createGzip } from 'node:zlib'
 import { supportsColor } from 'supports-color'
 import hasAnsi from 'has-ansi'
-import { Plugin } from '../plugin'
+import { InternalPlugin } from '../plugin'
 
 type TouchResult = {
   banner: string
@@ -17,9 +17,9 @@ type TouchResult = {
 
 const DEFAULT_CUCUMBER_PUBLISH_URL = 'https://reports.cucumber.io/api/reports'
 
-export const publishPlugin: Plugin = {
+export const publishPlugin: InternalPlugin = {
   type: 'plugin',
-  coordinator: async ({ on, logger, options, environment }) => {
+  coordinator: async ({ on, emit, logger, options, environment }) => {
     if (!options) {
       return undefined
     }
@@ -51,6 +51,10 @@ export const publishPlugin: Plugin = {
           sanitisePublishOutput(touchResult.banner, environment.stderr) + '\n'
         )
       }
+    }
+
+    if (touchResult.url) {
+      emit('publish:url', touchResult.url)
     }
 
     const uploadUrl = touchResponse.headers.get('Location')

--- a/src/publish/publish_plugin.ts
+++ b/src/publish/publish_plugin.ts
@@ -15,7 +15,7 @@ type TouchResult = {
   url?: string
 }
 
-const DEFAULT_CUCUMBER_PUBLISH_URL = 'https://messages.cucumber.io/api/reports'
+const DEFAULT_CUCUMBER_PUBLISH_URL = 'https://reports.cucumber.io/api/reports'
 
 export const publishPlugin: Plugin = {
   type: 'plugin',

--- a/src/publish/publish_plugin.ts
+++ b/src/publish/publish_plugin.ts
@@ -10,6 +10,11 @@ import { supportsColor } from 'supports-color'
 import hasAnsi from 'has-ansi'
 import { Plugin } from '../plugin'
 
+type TouchResult = {
+  banner: string
+  url?: string
+}
+
 const DEFAULT_CUCUMBER_PUBLISH_URL = 'https://messages.cucumber.io/api/reports'
 
 export const publishPlugin: Plugin = {
@@ -19,27 +24,32 @@ export const publishPlugin: Plugin = {
       return undefined
     }
     const { url = DEFAULT_CUCUMBER_PUBLISH_URL, token } = options
-    const headers: { [key: string]: string } = {}
+    const headers: { [key: string]: string } = {
+      Accept: 'application/json',
+    }
     if (token !== undefined) {
       headers.Authorization = `Bearer ${token}`
     }
     const touchResponse = await fetch(url, { headers })
-    const banner = await touchResponse.text()
+
+    if (touchResponse.status >= 500) {
+      return () => {
+        logger.error(
+          `Failed to publish report to ${new URL(url).origin} with status ${
+            touchResponse.status
+          }`
+        )
+        logger.debug(touchResponse)
+      }
+    }
+
+    const touchResult = (await touchResponse.json()) as TouchResult
 
     if (!touchResponse.ok) {
       return () => {
-        if (touchResponse.status < 500) {
-          environment.stderr.write(
-            sanitisePublishOutput(banner, environment.stderr) + '\n'
-          )
-        } else {
-          logger.error(
-            `Failed to publish report to ${new URL(url).origin} with status ${
-              touchResponse.status
-            }`
-          )
-          logger.debug(touchResponse)
-        }
+        environment.stderr.write(
+          sanitisePublishOutput(touchResult.banner, environment.stderr) + '\n'
+        )
       }
     }
 
@@ -75,7 +85,8 @@ export const publishPlugin: Plugin = {
           })
           if (uploadResponse.ok) {
             environment.stderr.write(
-              sanitisePublishOutput(banner, environment.stderr) + '\n'
+              sanitisePublishOutput(touchResult.banner, environment.stderr) +
+                '\n'
             )
           } else {
             logger.error(

--- a/src/sharding/sharding_plugin.ts
+++ b/src/sharding/sharding_plugin.ts
@@ -1,6 +1,6 @@
-import { Plugin } from '../plugin'
+import { InternalPlugin } from '../plugin'
 
-export const shardingPlugin: Plugin = {
+export const shardingPlugin: InternalPlugin = {
   type: 'plugin',
   coordinator: async ({ transform, options }) => {
     transform('pickles:filter', async (allPickles) => {

--- a/test/fake_report_server.ts
+++ b/test/fake_report_server.ts
@@ -54,23 +54,26 @@ export default class FakeReportServer {
       this.receivedHeaders = { ...this.receivedHeaders, ...req.headers }
       const token = extractAuthorizationToken(req.headers.authorization)
       if (token && !isValidUUID(token)) {
-        res.status(401).end(`┌─────────────────────┐
+        res.status(401).json({
+          banner: `┌─────────────────────┐
 │ Error invalid token │
 └─────────────────────┘
-`)
+`,
+        })
         return
       }
 
       res.setHeader('Location', `http://localhost:${this.port}/s3`)
-      res.status(202)
-
-      res.end(`┌──────────────────────────────────────────────────────────────────────────┐
+      res.status(202).json({
+        banner: `┌──────────────────────────────────────────────────────────────────────────┐
 │ View your Cucumber Report at:                                            │
 │ https://reports.cucumber.io/reports/f318d9ec-5a3d-4727-adec-bd7b69e2edd3 │
 │                                                                          │
 │ This report will self-destruct in 24h unless it is claimed or deleted.   │
 └──────────────────────────────────────────────────────────────────────────┘
-`)
+`,
+        url: 'https://reports.cucumber.io/reports/f318d9ec-5a3d-4727-adec-bd7b69e2edd3',
+      })
     })
 
     this.server = http.createServer(app)


### PR DESCRIPTION
### 🤔 What's changed?

- Switch to the `reports.cucumber.io` domain for the API interaction, avoiding a redirect hop
- Opt into the new JSON response from the API per https://github.com/cucumber/cucumber-reports/pull/87
- Emit a new `publish:url` event for plugins

### ⚡️ What's your motivation? 

Fixes https://github.com/cucumber/cucumber-js/issues/1797.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
