### PR TITLE
Use built-in fs.glob

### DIFF
--- a/compatibility/cck_spec.ts
+++ b/compatibility/cck_spec.ts
@@ -5,7 +5,6 @@ import { pipeline } from 'node:stream/promises'
 import { describe, it } from 'mocha'
 import { config, expect, use } from 'chai'
 import chaiExclude from 'chai-exclude'
-import { glob } from 'glob'
 import * as messages from '@cucumber/messages'
 import * as messageStreams from '@cucumber/message-streams'
 import { Envelope } from '@cucumber/messages'
@@ -31,7 +30,8 @@ config.truncateThreshold = 100
 use(chaiExclude)
 
 describe('Cucumber Compatibility Kit', () => {
-  const directories = glob.sync(`${CCK_FEATURES_PATH}/*`, { nodir: false })
+  // @ts-expect-error -- Requires Node 22
+  const directories = fs.globSync(`${CCK_FEATURES_PATH}/*`)
 
   for (const directory of directories) {
     const suite = path.basename(directory)

--- a/compatibility/cck_spec.ts
+++ b/compatibility/cck_spec.ts
@@ -5,7 +5,6 @@ import { pipeline } from 'node:stream/promises'
 import { describe, it } from 'mocha'
 import { config, expect, use } from 'chai'
 import chaiExclude from 'chai-exclude'
-import { glob } from 'glob'
 import * as messages from '@cucumber/messages'
 import * as messageStreams from '@cucumber/message-streams'
 import { Envelope } from '@cucumber/messages'
@@ -29,7 +28,7 @@ config.truncateThreshold = 100
 use(chaiExclude)
 
 describe('Cucumber Compatibility Kit', () => {
-  const directories = glob.sync(`${CCK_FEATURES_PATH}/*`, { nodir: false })
+  const directories = fs.globSync(`${CCK_FEATURES_PATH}/*`)
 
   for (const directory of directories) {
     const suite = path.basename(directory)

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "debug": "^4.3.4",
         "error-stack-parser": "^2.1.4",
         "figures": "^3.2.0",
-        "glob": "^13.0.0",
         "has-ansi": "^4.0.1",
         "indent-string": "^4.0.0",
         "is-installed-globally": "^0.4.0",
@@ -5026,6 +5025,7 @@
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.2",
@@ -5055,6 +5055,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
       "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "20 || >=22"
@@ -5064,6 +5065,7 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5076,6 +5078,7 @@
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -6697,6 +6700,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7587,6 +7591,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -7603,6 +7608,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
       "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "debug": "^4.3.4",
         "error-stack-parser": "^2.1.4",
         "figures": "^3.2.0",
-        "glob": "^13.0.0",
         "has-ansi": "^4.0.1",
         "indent-string": "^4.0.0",
         "is-installed-globally": "^0.4.0",
@@ -1694,10 +1693,11 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.194",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
-      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==",
-      "dev": true
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/lodash.merge": {
       "version": "4.6.9",
@@ -5009,6 +5009,7 @@
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.2",
@@ -5038,6 +5039,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
       "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "20 || >=22"
@@ -5047,6 +5049,7 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5059,6 +5062,7 @@
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -6680,6 +6684,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7552,6 +7557,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -7568,6 +7574,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
       "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"

--- a/package.json
+++ b/package.json
@@ -237,7 +237,6 @@
     "debug": "^4.3.4",
     "error-stack-parser": "^2.1.4",
     "figures": "^3.2.0",
-    "glob": "^13.0.0",
     "has-ansi": "^4.0.1",
     "indent-string": "^4.0.0",
     "is-installed-globally": "^0.4.0",

--- a/src/paths/paths.ts
+++ b/src/paths/paths.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
-import { glob } from 'glob'
+// @ts-expect-error -- Requires Node 22
+import { glob } from 'node:fs/promises'
 import fs from 'mz/fs'
 import { ILogger } from '../environment'
 import { ISourcesCoordinates, ISupportCodeCoordinates } from '../api'
@@ -54,17 +55,16 @@ async function expandPaths(
 ): Promise<string[]> {
   const expandedPaths = await Promise.all(
     unexpandedPaths.map(async (unexpandedPath) => {
-      const matches = await glob(unexpandedPath, {
-        absolute: true,
-        windowsPathsNoEscape: true,
-        cwd,
-      })
-      const expanded = await Promise.all(
-        matches.map(async (match) => {
+      // @ts-expect-error -- Requires Node 22
+      const matches: string[] = await Array.fromAsync(
+        glob(unexpandedPath, { cwd })
+      )
+      const expanded: string[][] = await Promise.all(
+        matches.map(async (matchRelative) => {
+          const match = path.resolve(cwd, matchRelative)
           if (path.extname(match) === '') {
-            return glob(`${match}/**/*${defaultExtension}`, {
-              windowsPathsNoEscape: true,
-            })
+            // @ts-expect-error -- Requires Node 22
+            return Array.fromAsync(glob(`${match}/**/*${defaultExtension}`))
           }
           return [match]
         })

--- a/src/paths/paths.ts
+++ b/src/paths/paths.ts
@@ -1,6 +1,5 @@
 import path from 'node:path'
-import fs from 'node:fs/promises'
-import { glob } from 'glob'
+import fs, { glob } from 'node:fs/promises'
 import { ILogger } from '../environment'
 import { ISourcesCoordinates, ISupportCodeCoordinates } from '../api'
 import { IResolvedPaths } from './types'
@@ -54,17 +53,14 @@ async function expandPaths(
 ): Promise<string[]> {
   const expandedPaths = await Promise.all(
     unexpandedPaths.map(async (unexpandedPath) => {
-      const matches = await glob(unexpandedPath, {
-        absolute: true,
-        windowsPathsNoEscape: true,
-        cwd,
-      })
-      const expanded = await Promise.all(
-        matches.map(async (match) => {
+      const matches: string[] = await Array.fromAsync(
+        glob(unexpandedPath, { cwd })
+      )
+      const expanded: string[][] = await Promise.all(
+        matches.map(async (matchRelative) => {
+          const match = path.resolve(cwd, matchRelative)
           if (path.extname(match) === '') {
-            return glob(`${match}/**/*${defaultExtension}`, {
-              windowsPathsNoEscape: true,
-            })
+            return Array.fromAsync(glob(`${match}/**/*${defaultExtension}`))
           }
           return [match]
         })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "lib": ["es2022"],
+    "lib": ["es2022", "ESNext.Array"],
     "module": "node16",
     "noImplicitAny": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
### 🤔 What's changed?

Use [glob](https://nodejs.org/docs/latest-v22.x/api/fs.html#fspromisesglobpattern-options) from `node:fs` instead of [glob package](https://npmx.dev/package/glob).

### ⚡️ What's your motivation? 

My motivation is described in #2800. Starting from Node 22 there is a built-in glob which allows us to drop 6 packages from prod dependencies (glob is still installed in dev transitively) and save ~1.6MB. Built-in glob returns an async iterator with relative paths (unless `withFileTypes` is provided) so I've updated paths.ts to follow the previous behaviour.  

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

I used [Array.fromAsync](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fromAsync#browser_compatibility) which is available in Node 22 but it surfaced two issues:
- Current tsconfig.json is slightly outdated so I borrowed the minimum amount of changes needed from https://github.com/tsconfig/bases/blob/main/bases/node22.json but we may consider using updating the full config eventually?
- `@types/lodash` is installed transitively and is very old, using it with `esnext.Array` lib causes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15331 so I had to run `npm upgrade @types/lodash`.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
