### PR TITLE
Add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@cucumber/cucumber" style="text-decoration: none"><img src="https://img.shields.io/npm/v/@cucumber/cucumber?style=flat&color=dark-green" alt="Latest version on npm"></a>
   <a href="https://coveralls.io/github/cucumber/cucumber-js?branch=master" style="text-decoration: none"><img src="https://coveralls.io/repos/github/cucumber/cucumber-js/badge.svg?branch=main" alt="Coverage"></a>
-  <a href="https://scorecard.dev/viewer/?uri=github.com/cucumber/cucumber-js"><img src="https://api.scorecard.dev/projects/github.com/cucumber/cucumber-jvm/badge" alt="OpenSSF Scorecard"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/cucumber/cucumber-js"><img src="https://api.scorecard.dev/projects/github.com/cucumber/cucumber-js/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://opencollective.com/cucumber"><img src="https://opencollective.com/cucumber/backers/badge.svg" alt="Backers"></a>
   <a href="https://opencollective.com/cucumber"><img src="https://opencollective.com/cucumber/sponsors/badge.svg" alt="Sponsors"></a>
   <a href="https://vshymanskyy.github.io/StandWithUkraine"><img src="https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg" alt="Ukraine solidarity"></a>

--- a/README.md
+++ b/README.md
@@ -9,11 +9,16 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@cucumber/cucumber" style="text-decoration: none"><img src="https://img.shields.io/npm/v/@cucumber/cucumber?style=flat&color=dark-green" alt="Latest version on npm"></a>
-  <a href="https://github.com/cucumber/cucumber-js/actions" style="text-decoration: none"><img src="https://github.com/cucumber/cucumber-js/actions/workflows/build.yml/badge.svg" alt="Build status"></a>
   <a href="https://coveralls.io/github/cucumber/cucumber-js?branch=master" style="text-decoration: none"><img src="https://coveralls.io/repos/github/cucumber/cucumber-js/badge.svg?branch=main" alt="Coverage"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/cucumber/cucumber-js"><img src="https://api.scorecard.dev/projects/github.com/cucumber/cucumber-jvm/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://opencollective.com/cucumber"><img src="https://opencollective.com/cucumber/backers/badge.svg" alt="Backers"></a>
   <a href="https://opencollective.com/cucumber"><img src="https://opencollective.com/cucumber/sponsors/badge.svg" alt="Sponsors"></a>
   <a href="https://vshymanskyy.github.io/StandWithUkraine"><img src="https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg" alt="Ukraine solidarity"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/cucumber/cucumber-js/actions" style="text-decoration: none"><img src="https://github.com/cucumber/cucumber-js/actions/workflows/build.yml/badge.svg" alt="Build status"></a>
+  <a href="https://github.com/cucumber/cucumber-js/actions" style="text-decoration: none"><img src="https://github.com/cucumber/cucumber-js/actions/workflows/release-npm.yml/badge.svg" alt="Release status"></a>
 </p>
 
 [Cucumber](https://github.com/cucumber) is a tool for running automated tests written in plain language. Because they're


### PR DESCRIPTION

### ⚡️ What's your motivation? 

Contribute to: https://github.com/cucumber/common/issues/2312

Because the Github CI badges have a different style I've put them on their own row and added one for the release to make the row look less empty.

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
