### PR TITLE
Update Node.js support and testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         # these versions must be kept in sync with enginesTested.node in package.json
-        node-version: [20.x, 22.x, 24.x, 25.x]
+        node-version: [22.x, 24.x, 26.x]
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Added
+- Add support for Node.js 26.x ([#2818](https://github.com/cucumber/cucumber-js/pull/2818))
+
 ### Changed
 - BREAKING CHANGE: Reimplement parallel runtime with worker threads ([#2710](https://github.com/cucumber/cucumber-js/pull/2710))
 - BREAKING CHANGE: All `BeforeAll` and `AfterAll` hooks are always executed ([#2710](https://github.com/cucumber/cucumber-js/pull/2710))
@@ -17,6 +20,10 @@ Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber
 ### Deprecated
 - Deprecate legacy `SummaryFormatter` and `ProgressFormatter` classes in favour of new formatter architecture ([#2708](https://github.com/cucumber/cucumber-js/pull/2708))
 - Deprecate `printAttachments` format option in favour of `includeAttachments` ([#2708](https://github.com/cucumber/cucumber-js/pull/2708))
+
+### Removed
+- BREAKING CHANGE: Drop support for Node.js 20.x ([#2818](https://github.com/cucumber/cucumber-js/pull/2818))
+- BREAKING CHANGE: Drop support for Node.js 25.x ([#2818](https://github.com/cucumber/cucumber-js/pull/2818))
 
 ## [12.9.0] - 2026-05-15
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "@types/luxon": "3.7.1",
         "@types/mocha": "10.0.10",
         "@types/mustache": "4.2.6",
-        "@types/node": "^20.11.25",
+        "@types/node": "^22.19.19",
         "@types/semver": "7.7.1",
         "@types/sinon-chai": "3.2.12",
         "@types/sinonjs__fake-timers": "15.0.1",
@@ -104,7 +104,7 @@
         "typescript": "^5.8.3"
       },
       "engines": {
-        "node": "20 || 22 || >=24"
+        "node": "22 || 24 || >=26"
       },
       "funding": {
         "url": "https://opencollective.com/cucumber"
@@ -1753,9 +1753,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.13.tgz",
-      "integrity": "sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -213,10 +213,10 @@
   },
   "types": "./lib/index.d.ts",
   "engines": {
-    "node": "20 || 22 || >=24"
+    "node": "22 || 24 || >=26"
   },
   "enginesTested": {
-    "node": "20 || 22 || 24 || 25"
+    "node": "22 || 24 || 26"
   },
   "dependencies": {
     "@cucumber/ci-environment": "13.0.0",
@@ -275,7 +275,7 @@
     "@types/luxon": "3.7.1",
     "@types/mocha": "10.0.10",
     "@types/mustache": "4.2.6",
-    "@types/node": "^20.11.25",
+    "@types/node": "^22.19.19",
     "@types/semver": "7.7.1",
     "@types/sinon-chai": "3.2.12",
     "@types/sinonjs__fake-timers": "15.0.1",


### PR DESCRIPTION
### 🤔 What's changed?

- Drop support for Node.js 20.x
- Drop support for Node.js 25.x
- Add support for Node.js 26.x

### ⚡️ What's your motivation? 

Alignment with https://github.com/nodejs/release#release-schedule

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :boom: Breaking change (incompatible changes to the API)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
