### PR TITLE
Remove deprecated handling of ambiguous formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber
 ### Removed
 - BREAKING CHANGE: Drop support for Node.js 20.x ([#2818](https://github.com/cucumber/cucumber-js/pull/2818))
 - BREAKING CHANGE: Drop support for Node.js 25.x ([#2818](https://github.com/cucumber/cucumber-js/pull/2818))
+- BREAKING CHANGE: Remove deprecated handling of ambiguous formats ([#2819](https://github.com/cucumber/cucumber-js/pull/2819))
 
 ## [12.9.0] - 2026-05-15
 ### Added

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,19 @@
 
 This document describes breaking changes and how to upgrade. For a complete list of changes including minor and patch releases, please refer to the [changelog](./CHANGELOG.md).
 
+## 13.0.0
+
+### Ambiguous colons in formats
+
+A user-specified format supplied via the CLI is made up of a formatter descriptor and an optional target path, separated by a colon. Previously, when either part contained colons of its own - like Windows drives or `file://` URLs - Cucumber tried to detect and handle that on a best-effort basis. That logic has been removed.
+
+A colon now always delimits the two parts, so any part that itself contains a colon must be wrapped in double quotes. A format that can't be parsed unambiguously (i.e. more than two parts once quotes are taken into account) will now throw an error. To adapt, ensure you use double quotes appropriately:
+
+| Before                                       | After                                            |
+|----------------------------------------------|--------------------------------------------------|
+| `html:file://hostname/formatter/report.html` | `"html":"file://hostname/formatter/report.html"` |
+| `file://C:\custom\formatter`                 | `"file://C:\custom\formatter"`                   |
+
 ## 12.0.0
 
 ### publishQuiet

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -61,17 +61,6 @@ The `Cli` class is used internally to represent an instance of the command-line 
 
 To adapt, pivot to the `runCucumber` function from the [JavaScript API](./javascript_api.md), or raise an issue if you feel your use case isn't catered for.
 
-### Ambiguous colons in formats
-
-Deprecated in `9.6.0`. Will be removed in `11.0.0` or later.
-
-User-specified formats where either the formatter name/path or the target path (or both) contains colon(s) are ambiguous because the separator between the two parts is also a colon. Cucumber tries to detect and handle things like Windows drives and `file://` URLs on a best-effort basis, but this logic is being removed in favour of wrapping values in double-quotes.
-
-| Before                                       | After                                            |
-|----------------------------------------------|--------------------------------------------------|
-| `html:file://hostname/formatter/report.html` | `"html":"file://hostname/formatter/report.html"` |
-| `file://C:\custom\formatter`                 | `"file://C:\custom\formatter"`                   |
-
 ### `colorsEnabled` format option
 
 Deprecated in `12.6.0`, will be removed in `14.0.0` or later.

--- a/src/api/convert_configuration.ts
+++ b/src/api/convert_configuration.ts
@@ -4,11 +4,9 @@ import {
   splitFormatDescriptor,
 } from '../configuration'
 import { IPublishConfig } from '../publish'
-import { ILogger } from '../environment'
 import { IRunConfiguration } from './types'
 
 export async function convertConfiguration(
-  logger: ILogger,
   flatConfiguration: IConfiguration,
   env: NodeJS.ProcessEnv
 ): Promise<IRunConfiguration> {
@@ -38,7 +36,7 @@ export async function convertConfiguration(
       workerOptions: flatConfiguration.workerOptions,
       worldParameters: flatConfiguration.worldParameters,
     },
-    formats: convertFormats(logger, flatConfiguration, env),
+    formats: convertFormats(flatConfiguration, env),
     plugins: {
       specifiers: flatConfiguration.plugin,
       options: flatConfiguration.pluginOptions,
@@ -47,12 +45,11 @@ export async function convertConfiguration(
 }
 
 function convertFormats(
-  logger: ILogger,
   flatConfiguration: IConfiguration,
   env: NodeJS.ProcessEnv
 ) {
   const splitFormats: string[][] = flatConfiguration.format.map((item) =>
-    Array.isArray(item) ? item : splitFormatDescriptor(logger, item)
+    Array.isArray(item) ? item : splitFormatDescriptor(item)
   )
   return {
     stdout:

--- a/src/api/convert_configuration_spec.ts
+++ b/src/api/convert_configuration_spec.ts
@@ -1,17 +1,12 @@
 import { describe, it } from 'mocha'
 import { expect } from 'chai'
 import { DEFAULT_CONFIGURATION } from '../configuration'
-import { FakeLogger } from '../../test/fake_logger'
 import { convertConfiguration } from './convert_configuration'
 import { IRunConfiguration } from './types'
 
 describe('convertConfiguration', () => {
   it('should convert defaults correctly', async () => {
-    const result = await convertConfiguration(
-      new FakeLogger(),
-      DEFAULT_CONFIGURATION,
-      {}
-    )
+    const result = await convertConfiguration(DEFAULT_CONFIGURATION, {})
 
     expect(result).to.eql({
       formats: {
@@ -54,7 +49,6 @@ describe('convertConfiguration', () => {
 
   it('should map multiple formatters with string notation', async () => {
     const result = await convertConfiguration(
-      new FakeLogger(),
       {
         ...DEFAULT_CONFIGURATION,
         format: [
@@ -80,7 +74,6 @@ describe('convertConfiguration', () => {
 
   it('should map multiple formatters with array notation', async () => {
     const result = await convertConfiguration(
-      new FakeLogger(),
       {
         ...DEFAULT_CONFIGURATION,
         format: [
@@ -106,11 +99,10 @@ describe('convertConfiguration', () => {
 
   it('should map formatters correctly when file:// urls are involved', async () => {
     const result = await convertConfiguration(
-      new FakeLogger(),
       {
         ...DEFAULT_CONFIGURATION,
         format: [
-          'file:///my/fancy/formatter',
+          '"file:///my/fancy/formatter"',
           'json:./report.json',
           'html:./report.html',
         ],

--- a/src/api/load_configuration.ts
+++ b/src/api/load_configuration.ts
@@ -60,7 +60,7 @@ export async function loadConfiguration(
   )
   logger.debug('Resolved configuration:', original)
   validateConfiguration(original, logger)
-  const runnable = await convertConfiguration(logger, original, env)
+  const runnable = await convertConfiguration(original, env)
   return {
     useConfiguration: original,
     runConfiguration: runnable,

--- a/src/configuration/split_format_descriptor.ts
+++ b/src/configuration/split_format_descriptor.ts
@@ -1,80 +1,14 @@
-import { ILogger } from '../environment'
+// a formatter and an optional target, separated by a colon, where each part is
+// either "quoted" (and may contain colons) or bare (and may not)
+const pattern = /^(?:"([^"]*)"|([^:]*))(?::(?:"([^"]*)"|([^:]*)))?$/
 
-export function splitFormatDescriptor(
-  logger: ILogger,
-  option: string
-): string[] {
-  const doWarning = (result: string[]) => {
-    let expected = `"${result[0]}"`
-    if (result[1]) {
-      expected += `:"${result[1]}"`
-    }
-    logger.warn(
-      `Each part of a user-specified format should be quoted; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md#ambiguous-colons-in-formats
-Change to ${expected}`
+export function splitFormatDescriptor(option: string): string[] {
+  const match = option.match(pattern)
+  if (match === null) {
+    throw new Error(
+      `Could not parse "${option}"; wrap each part in double quotes if it contains a colon`
     )
   }
-  let result: string[]
-  let match1, match2
-
-  // "foo":"bar" or "foo":bar
-  if ((match1 = option.match(/^"([^"]*)":(.*)$/)) !== null) {
-    // "foo":"bar"
-    if ((match2 = match1[2].match(/^"([^"]*)"$/)) !== null) {
-      result = [match1[1], match2[1]]
-    }
-    // "foo":bar
-    else {
-      result = [match1[1], match1[2]]
-      if (result[1].includes(':')) {
-        doWarning(result)
-      }
-    }
-  }
-  // foo:"bar"
-  else if ((match1 = option.match(/^(.*):"([^"]*)"$/)) !== null) {
-    result = [match1[1], match1[2]]
-    if (result[0].includes(':')) {
-      doWarning(result)
-    }
-  }
-  // "foo"
-  else if ((match1 = option.match(/^"([^"]*)"$/)) !== null) {
-    result = [match1[1], '']
-  }
-  // file://foo or file:///foo or file://C:/foo or file://C:\foo or file:///C:/foo or file:///C:\foo
-  else if (
-    (match1 = option.match(/^(file:\/{2,3}(?:[a-zA-Z]:[/\\])?)(.*)$/)) !== null
-  ) {
-    // file://foo:bar
-    if ((match2 = match1[2].match(/^([^:]*):(.*)$/)) !== null) {
-      result = [match1[1] + match2[1], match2[2]]
-    } else {
-      result = [option, '']
-    }
-    doWarning(result)
-  }
-  // C:\foo or C:/foo
-  else if ((match1 = option.match(/^([a-zA-Z]:[/\\])(.*)$/)) !== null) {
-    // C:\foo:bar or C:/foo:bar
-    if ((match2 = match1[2].match(/^([^:]*):(.*)$/)) !== null) {
-      result = [match1[1] + match2[1], match2[2]]
-    } else {
-      result = [option, '']
-    }
-    doWarning(result)
-  }
-  // foo:bar
-  else if ((match1 = option.match(/^([^:]*):(.*)$/)) !== null) {
-    result = [match1[1], match1[2]]
-    if (option.split(':').length > 2) {
-      doWarning(result)
-    }
-  }
-  // foo
-  else {
-    result = [option, '']
-  }
-
-  return result
+  const [, quotedName, bareName, quotedTarget, bareTarget] = match
+  return [quotedName ?? bareName, quotedTarget ?? bareTarget ?? '']
 }

--- a/src/configuration/split_format_descriptor_spec.ts
+++ b/src/configuration/split_format_descriptor_spec.ts
@@ -1,6 +1,5 @@
 import { describe, it } from 'mocha'
 import { expect } from 'chai'
-import { FakeLogger } from '../../test/fake_logger'
 import { splitFormatDescriptor } from './split_format_descriptor'
 
 describe('splitFormatDescriptor', () => {
@@ -9,6 +8,11 @@ describe('splitFormatDescriptor', () => {
       description: "doesn't split when nothing to split on, adds empty string",
       input: '../custom/formatter',
       output: ['../custom/formatter', ''],
+    },
+    {
+      description: 'splits a bare name and target on the colon',
+      input: 'html:report.html',
+      output: ['html', 'report.html'],
     },
     {
       description: 'splits relative unix paths',
@@ -21,82 +25,9 @@ describe('splitFormatDescriptor', () => {
       output: ['..\\custom\\formatter', '..\\formatter\\output.txt'],
     },
     {
-      description: 'splits file URLs for absolute unix path',
-      input: 'file:///custom/formatter:file:///formatter/output.txt',
-      output: ['file:///custom/formatter', 'file:///formatter/output.txt'],
-      warning:
-        'Change to "file:///custom/formatter":"file:///formatter/output.txt"',
-    },
-    {
-      description: 'splits file URLs for UNC path',
-      input:
-        'file://hostname/custom/formatter:file://hostname/formatter/output.txt',
-      output: [
-        'file://hostname/custom/formatter',
-        'file://hostname/formatter/output.txt',
-      ],
-      warning:
-        'Change to "file://hostname/custom/formatter":"file://hostname/formatter/output.txt"',
-    },
-    {
-      description: 'splits file URLs for absolute windows path',
-      input: 'file://C:\\custom\\formatter:file://C:\\formatter\\output.txt',
-      output: [
-        'file://C:\\custom\\formatter',
-        'file://C:\\formatter\\output.txt',
-      ],
-      warning:
-        'Change to "file://C:\\custom\\formatter":"file://C:\\formatter\\output.txt"',
-    },
-    {
-      description:
-        'splits file URLs for absolute windows path with "/" as directory separator',
-      input: 'file:///C:/custom/formatter:file:///C:/formatter/output.txt',
-      output: [
-        'file:///C:/custom/formatter',
-        'file:///C:/formatter/output.txt',
-      ],
-      warning:
-        'Change to "file:///C:/custom/formatter":"file:///C:/formatter/output.txt"',
-    },
-    {
-      description: 'splits valid file URLs for absolute windows path',
-      input: 'file:///C:\\custom\\formatter:file:///C:\\formatter\\output.txt',
-      output: [
-        'file:///C:\\custom\\formatter',
-        'file:///C:\\formatter\\output.txt',
-      ],
-      warning:
-        'Change to "file:///C:\\custom\\formatter":"file:///C:\\formatter\\output.txt"',
-    },
-    {
-      description:
-        'splits valid file URLs for absolute windows path with "/" as directory separator',
-      input: 'file:///C:/custom/formatter:file:///C:/formatter/output.txt',
-      output: [
-        'file:///C:/custom/formatter',
-        'file:///C:/formatter/output.txt',
-      ],
-      warning:
-        'Change to "file:///C:/custom/formatter":"file:///C:/formatter/output.txt"',
-    },
-    {
       description: 'splits absolute unix paths',
       input: '/custom/formatter:/formatter/output.txt',
       output: ['/custom/formatter', '/formatter/output.txt'],
-    },
-    {
-      description: 'splits absolute windows paths',
-      input: 'C:\\custom\\formatter:C:\\formatter\\output.txt',
-      output: ['C:\\custom\\formatter', 'C:\\formatter\\output.txt'],
-      warning: 'Change to "C:\\custom\\formatter":"C:\\formatter\\output.txt"',
-    },
-    {
-      description:
-        'splits absolute windows paths with "/" as directory separator',
-      input: 'C:/custom/formatter:C:/formatter/output.txt',
-      output: ['C:/custom/formatter', 'C:/formatter/output.txt'],
-      warning: 'Change to "C:/custom/formatter":"C:/formatter/output.txt"',
     },
     {
       description: 'splits UNC paths',
@@ -116,106 +47,67 @@ describe('splitFormatDescriptor', () => {
       ],
     },
     {
-      description: 'splits paths with quotes around them',
+      description: 'splits a bare name and quoted target',
       input: '/custom/formatter:"/formatter directory/output.txt"',
       output: ['/custom/formatter', '/formatter directory/output.txt'],
     },
     {
-      description:
-        'does not split a single file URL for absolute unix path, adds empty string',
-      input: 'file:///custom/formatter',
-      output: ['file:///custom/formatter', ''],
-      warning: 'Change to "file:///custom/formatter"',
-    },
-    {
-      description:
-        'does not split a single file URL for UNC path, adds empty string',
-      input: 'file://hostname/custom/formatter',
-      output: ['file://hostname/custom/formatter', ''],
-      warning: 'Change to "file://hostname/custom/formatter"',
-    },
-    {
-      description:
-        'does not split a single file URL for absolute windows path, adds empty string',
-      input: 'file://C:\\custom\\formatter',
-      output: ['file://C:\\custom\\formatter', ''],
-      warning: 'Change to "file://C:\\custom\\formatter"',
-    },
-    {
-      description:
-        'does not split a single file URL for absolute windows path with "/" as directory separator, adds empty string',
-      input: 'file://C:/custom/formatter',
-      output: ['file://C:/custom/formatter', ''],
-      warning: 'Change to "file://C:/custom/formatter"',
-    },
-    {
-      description:
-        'does not split a valid single file URL for absolute windows path, adds empty string',
-      input: 'file:///C:\\custom\\formatter',
-      output: ['file:///C:\\custom\\formatter', ''],
-      warning: 'Change to "file:///C:\\custom\\formatter"',
-    },
-    {
-      description:
-        'does not split a valid single file URL for absolute windows path with "/" as directory separator, adds empty string',
-      input: 'file:///C:/custom/formatter',
-      output: ['file:///C:/custom/formatter', ''],
-      warning: 'Change to "file:///C:/custom/formatter"',
-    },
-    {
-      description:
-        'does not split a single absolute windows path, adds empty string',
-      input: 'C:\\custom\\formatter',
-      output: ['C:\\custom\\formatter', ''],
-      warning: 'Change to "C:\\custom\\formatter"',
-    },
-    {
-      description:
-        'does not split a single absolute windows path with "/" as directory separator, adds empty string',
-      input: 'C:/custom/formatter',
-      output: ['C:/custom/formatter', ''],
-      warning: 'Change to "C:/custom/formatter"',
-    },
-    {
-      description: 'does not split quoted values: case 1',
+      description: 'does not split fully quoted parts: "foo":"bar"',
       input: '"foo:bar":"baz:qux"',
       output: ['foo:bar', 'baz:qux'],
     },
     {
-      description: 'does not split quoted values: case 2',
-      input: '"foo:bar":baz:qux',
-      output: ['foo:bar', 'baz:qux'],
-      warning: 'Change to "foo:bar":"baz:qux"',
-    },
-    {
-      description: 'does not split quoted values: case 3',
-      input: 'foo:bar:"baz:qux"',
-      output: ['foo:bar', 'baz:qux'],
-      warning: 'Change to "foo:bar":"baz:qux"',
-    },
-    {
-      description: 'does not split quoted values: case 4',
+      description: 'does not split a single quoted value, adds empty string',
       input: '"foo:bar:baz:qux"',
       output: ['foo:bar:baz:qux', ''],
     },
     {
-      description: 'splits string contains multiple ":"',
-      input: 'foo:bar:baz:qux',
-      output: ['foo', 'bar:baz:qux'],
-      warning: 'Change to "foo":"bar:baz:qux"',
+      description: 'uses quoting to keep a file:// formatter and target intact',
+      input: '"html":"file://hostname/formatter/report.html"',
+      output: ['html', 'file://hostname/formatter/report.html'],
+    },
+    {
+      description:
+        'uses quoting to keep a single file:// formatter intact, adds empty string',
+      input: '"file://C:\\custom\\formatter"',
+      output: ['file://C:\\custom\\formatter', ''],
+    },
+    {
+      description:
+        'splits an unquoted file URL on its only colon (now requires quoting)',
+      input: 'file:///custom/formatter',
+      output: ['file', '///custom/formatter'],
     },
   ]
 
-  examples.forEach(({ description, input, output, warning }) => {
+  examples.forEach(({ description, input, output }) => {
     it(description, () => {
-      const logger = new FakeLogger()
-      expect(splitFormatDescriptor(logger, input)).to.eql(output)
-      if (warning) {
-        expect(logger.warn).to.have.been.called()
-        expect(logger.warn.firstCall.firstArg as string).to.contain(warning)
-      } else {
-        expect(logger.warn).not.to.have.been.called()
-      }
+      expect(splitFormatDescriptor(input)).to.eql(output)
+    })
+  })
+
+  const ambiguous = [
+    {
+      description: 'throws when a bare name and target both contain colons',
+      input: 'foo:bar:baz:qux',
+    },
+    {
+      description:
+        'throws when a quoted name is followed by a bare target with colons',
+      input: '"foo:bar":baz:qux',
+    },
+    {
+      description:
+        'throws when a bare name with colons precedes a quoted target',
+      input: 'foo:bar:"baz:qux"',
+    },
+  ]
+
+  ambiguous.forEach(({ description, input }) => {
+    it(description, () => {
+      expect(() => splitFormatDescriptor(input)).to.throw(
+        `Could not parse "${input}"`
+      )
     })
   })
 })


### PR DESCRIPTION
### 🤔 What's changed?

Remove the old deprecated handling of colons in format strings:

> A user-specified format supplied via the CLI is made up of a formatter descriptor and an optional target path, separated by a colon. Previously, when either part contained colons of its own - like Windows drives or `file://` URLs - Cucumber tried to detect and handle that on a best-effort basis. That logic has been removed.
>
> A colon now always delimits the two parts, so any part that itself contains a colon must be wrapped in double quotes. A format that can't be parsed unambiguously (i.e. more than two parts once quotes are taken into account) will now throw an error.

This makes the implementation of parsing a format string massively simpler.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :boom: Breaking change (incompatible changes to the API)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
