### PR TITLE
Remove deprecated Cli export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber
 ### Removed
 - BREAKING CHANGE: Drop support for Node.js 20.x ([#2818](https://github.com/cucumber/cucumber-js/pull/2818))
 - BREAKING CHANGE: Drop support for Node.js 25.x ([#2818](https://github.com/cucumber/cucumber-js/pull/2818))
+- BREAKING CHANGE: Remove deprecated Cli export ([#2820](https://github.com/cucumber/cucumber-js/pull/2820))
 - BREAKING CHANGE: Remove deprecated handling of ambiguous formats ([#2819](https://github.com/cucumber/cucumber-js/pull/2819))
 
 ## [12.9.0] - 2026-05-15

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,10 @@ This document describes breaking changes and how to upgrade. For a complete list
 
 ## 13.0.0
 
+### `Cli`
+
+The `Cli` class is no longer exported from the package. It was used internally to represent an instance of the command-line program invoked via `cucumber-js`, and could be used to run Cucumber programmatically, but is poorly suited for this. To adapt, pivot to the `runCucumber` function from the [JavaScript API](./docs/javascript_api.md), or raise an issue if you feel your use case isn't catered for.
+
 ### Ambiguous colons in formats
 
 A user-specified format supplied via the CLI is made up of a formatter descriptor and an optional target path, separated by a colon. Previously, when either part contained colons of its own - like Windows drives or `file://` URLs - Cucumber tried to detect and handle that on a best-effort basis. That logic has been removed.

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -53,14 +53,6 @@ In a future release, we'll change it so that the command line argument(s) _overr
 
 This will be unlike all other configuration options - no others are changing. However, in the case of paths we think this makes the most sense.
 
-### `Cli`
-
-Deprecated in `8.7.0`, will be removed in `10.0.0` or later.
-
-The `Cli` class is used internally to represent an instance of the command-line program invoked via `cucumber-js`. It can be used to run Cucumber programmatically, but is poorly suited for this.
-
-To adapt, pivot to the `runCucumber` function from the [JavaScript API](./javascript_api.md), or raise an issue if you feel your use case isn't catered for.
-
 ### `colorsEnabled` format option
 
 Deprecated in `12.6.0`, will be removed in `14.0.0` or later.

--- a/exports/root/report.api.md
+++ b/exports/root/report.api.md
@@ -40,9 +40,6 @@ export const BeforeAll: ((code: TestRunHookFunction) => void) & ((options: IDefi
 // @public (undocumented)
 export const BeforeStep: (<WorldType = IWorld<any>>(code: TestStepHookFunction<WorldType>) => void) & (<WorldType = IWorld<any>>(tags: string, code: TestStepHookFunction<WorldType>) => void) & (<WorldType = IWorld<any>>(options: IDefineTestStepHookOptions, code: TestStepHookFunction<WorldType>) => void);
 
-// @public @deprecated (undocumented)
-export const Cli: typeof Cli_2;
-
 // @beta
 const context_2: IContext<any>;
 export { context_2 as context }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,7 @@
  * These docs cover the functions and helpers for user code registration and test setup. The entry point is `@cucumber/cucumber`.
  */
 
-import { deprecate } from 'node:util'
 import * as messages from '@cucumber/messages'
-import { default as _Cli } from './cli'
 import * as formatterHelpers from './formatter/helpers'
 import * as parallelCanAssignHelpers from './support_code_library_builder/parallel_can_assign_helpers'
 import supportCodeLibraryBuilder from './support_code_library_builder'
@@ -72,12 +70,3 @@ export const Status = messages.TestStepResultStatus
 
 // Time helpers
 export { wrapPromiseWithTimeout } from './time'
-
-// Deprecated
-/**
- * @deprecated use `runCucumber` instead; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md
- */
-export const Cli = deprecate(
-  _Cli,
-  '`Cli` is deprecated, use `runCucumber` instead; see https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md'
-)


### PR DESCRIPTION
### 🤔 What's changed?

Remove deprecated public export of `Cli` class.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :boom: Breaking change (incompatible changes to the API)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
