### PR TITLE
Use util.styleText, update status colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber
 - Deprecate legacy `SummaryFormatter` and `ProgressFormatter` classes in favour of new formatter architecture ([#2708](https://github.com/cucumber/cucumber-js/pull/2708))
 - Deprecate `printAttachments` format option in favour of `includeAttachments` ([#2708](https://github.com/cucumber/cucumber-js/pull/2708))
 
+### Fixed
+- Update status colors to match other formatters ([#2828](https://github.com/cucumber/cucumber-js/pull/2828))
+
 ### Removed
 - BREAKING CHANGE: Drop support for Node.js 20.x ([#2818](https://github.com/cucumber/cucumber-js/pull/2818))
 - BREAKING CHANGE: Drop support for Node.js 25.x ([#2818](https://github.com/cucumber/cucumber-js/pull/2818))

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -106,7 +106,7 @@ Every key is optional; provide only the ones you want to override.
 
 ## Colored output
 
-Many formatters, including the built-in ones, emit some colored output. By default, Cucumber will automatically detect the colors support of the output stream and decide whether to emit colors accordingly. This check comes via the [supports-colors](https://github.com/chalk/supports-color) library and is pretty comprehensive, including awareness of commonly-used operating systems and CI platforms that represent edge cases.
+Many formatters, including the built-in ones, emit some colored output. Node.js will check the underlying stream for color support before deciding whether to emit colors.
 
 If you'd like to override the auto-detection behaviour, set the `FORCE_COLOR` environment variable to `1` to forcibly enable colors, or `0` to forcibly disable them. This is a cross-tool standard that will also influence other tools in your stack such as assertion libraries.
 

--- a/features/support/warn_user_about_enabling_developer_mode.ts
+++ b/features/support/warn_user_about_enabling_developer_mode.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk'
+import { styleText } from 'node:util'
 import { reindent } from 'reindent-template-literals'
 
 export function warnUserAboutEnablingDeveloperMode(error: any): void {
@@ -11,7 +11,8 @@ export function warnUserAboutEnablingDeveloperMode(error: any): void {
 
   // biome-ignore lint/suspicious/noConsole: this is the user-facing warning
   console.error(
-    chalk.red(
+    styleText(
+      'red',
       reindent(`
         Error: Unable to run feature tests!
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@cucumber/pretty-formatter": "3.3.1",
         "@cucumber/tag-expressions": "9.1.0",
         "assertion-error-formatter": "^3.0.0",
-        "chalk": "^4.1.2",
         "cli-table3": "0.6.5",
         "commander": "^14.0.0",
         "debug": "^4.3.4",
@@ -2310,6 +2309,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2620,6 +2620,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2635,6 +2636,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2719,6 +2721,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2729,7 +2732,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/commander": {
       "version": "14.0.0",

--- a/package.json
+++ b/package.json
@@ -231,7 +231,6 @@
     "@cucumber/pretty-formatter": "3.3.1",
     "@cucumber/tag-expressions": "9.1.0",
     "assertion-error-formatter": "^3.0.0",
-    "chalk": "^4.1.2",
     "cli-table3": "0.6.5",
     "commander": "^14.0.0",
     "debug": "^4.3.4",

--- a/src/formatter/builder.ts
+++ b/src/formatter/builder.ts
@@ -42,11 +42,7 @@ const FormatterBuilder = {
         options.cwd
       )
     }
-    const colorFns = getColorFns(
-      options.stream,
-      options.env,
-      options.parsedArgvOptions.colorsEnabled
-    )
+    const colorFns = getColorFns(options.stream)
     const snippetBuilder = await FormatterBuilder.getStepDefinitionSnippetBuilder({
       cwd: options.cwd,
       snippetInterface: options.parsedArgvOptions.snippetInterface,

--- a/src/formatter/get_color_fns.ts
+++ b/src/formatter/get_color_fns.ts
@@ -1,8 +1,8 @@
 import type { Writable } from 'node:stream'
+import { styleText } from 'node:util'
 import type { TestStepResultStatus } from '@cucumber/messages'
-import chalk from 'chalk'
-import { type ColorInfo, supportsColor } from 'supports-color'
-import { doesNotHaveValue } from '../value_checker'
+
+type Format = Parameters<typeof styleText>[0]
 
 export type IColorFn = (text: string) => string
 
@@ -16,53 +16,30 @@ export interface IColorFns {
   errorStack: IColorFn
 }
 
-export default function getColorFns(
-  stream: Writable,
-  env: NodeJS.ProcessEnv,
-  enabled?: boolean
-): IColorFns {
-  const support: ColorInfo = detectSupport(stream, env, enabled)
-  if (support) {
-    const chalkInstance = new chalk.Instance(support)
-    return {
-      forStatus(status: TestStepResultStatus) {
-        return {
-          AMBIGUOUS: chalkInstance.red.bind(chalk),
-          FAILED: chalkInstance.red.bind(chalk),
-          PASSED: chalkInstance.green.bind(chalk),
-          PENDING: chalkInstance.yellow.bind(chalk),
-          SKIPPED: chalkInstance.cyan.bind(chalk),
-          UNDEFINED: chalkInstance.yellow.bind(chalk),
-          UNKNOWN: chalkInstance.yellow.bind(chalk),
-        }[status]
-      },
-      location: chalkInstance.gray.bind(chalk),
-      tag: chalkInstance.cyan.bind(chalk),
-      diffAdded: chalkInstance.green.bind(chalk),
-      diffRemoved: chalkInstance.red.bind(chalk),
-      errorMessage: chalkInstance.red.bind(chalk),
-      errorStack: chalkInstance.grey.bind(chalk),
-    }
-  } else {
-    return {
-      forStatus(_status: TestStepResultStatus) {
-        return (x) => x
-      },
-      location: (x) => x,
-      tag: (x) => x,
-      diffAdded: (x) => x,
-      diffRemoved: (x) => x,
-      errorMessage: (x) => x,
-      errorStack: (x) => x,
-    }
-  }
+const colorByStatus: Record<TestStepResultStatus, Format> = {
+  AMBIGUOUS: 'red',
+  FAILED: 'red',
+  PASSED: 'green',
+  PENDING: 'yellow',
+  SKIPPED: 'cyan',
+  UNDEFINED: 'yellow',
+  UNKNOWN: 'yellow',
 }
 
-function detectSupport(stream: Writable, env: NodeJS.ProcessEnv, enabled?: boolean): ColorInfo {
-  const support: ColorInfo = supportsColor(stream)
-  // if we find FORCE_COLOR, we can let the supports-color library handle that
-  if ('FORCE_COLOR' in env || doesNotHaveValue(enabled)) {
-    return support
+export default function getColorFns(stream: Writable): IColorFns {
+  // styleText validates the stream itself, honoring FORCE_COLOR / NO_COLOR / TTY detection
+  const fn =
+    (format: Format): IColorFn =>
+    (text) =>
+      styleText(format, text, { stream })
+
+  return {
+    forStatus: (status: TestStepResultStatus) => fn(colorByStatus[status]),
+    location: fn('gray'),
+    tag: fn('cyan'),
+    diffAdded: fn('green'),
+    diffRemoved: fn('red'),
+    errorMessage: fn('red'),
+    errorStack: fn('grey'),
   }
-  return enabled ? support || { level: 1 } : false
 }

--- a/src/formatter/get_color_fns.ts
+++ b/src/formatter/get_color_fns.ts
@@ -17,13 +17,13 @@ export interface IColorFns {
 }
 
 const colorByStatus: Record<TestStepResultStatus, Format> = {
-  AMBIGUOUS: 'red',
+  AMBIGUOUS: 'magenta',
   FAILED: 'red',
   PASSED: 'green',
-  PENDING: 'yellow',
-  SKIPPED: 'cyan',
-  UNDEFINED: 'yellow',
-  UNKNOWN: 'yellow',
+  PENDING: 'cyan',
+  SKIPPED: 'yellow',
+  UNDEFINED: 'blue',
+  UNKNOWN: 'gray',
 }
 
 export default function getColorFns(stream: Writable): IColorFns {

--- a/src/formatter/helpers/issue_helpers_spec.ts
+++ b/src/formatter/helpers/issue_helpers_spec.ts
@@ -25,7 +25,7 @@ async function testFormatIssue(
     supportCodeLibrary,
   })
   return formatIssue({
-    colorFns: getColorFns(new PassThrough(), {}, false),
+    colorFns: getColorFns(new PassThrough()),
     number: 1,
     snippetBuilder: await FormatterBuilder.getStepDefinitionSnippetBuilder({
       cwd: 'project/',

--- a/src/formatter/helpers/summary_helpers_spec.ts
+++ b/src/formatter/helpers/summary_helpers_spec.ts
@@ -54,7 +54,7 @@ async function testFormatSummary({
     supportCodeLibrary,
   })
   return formatSummary({
-    colorFns: getColorFns(new PassThrough(), {}, false),
+    colorFns: getColorFns(new PassThrough()),
     testCaseAttempts,
     testRunDuration: durationBetweenTimestamps(testRunStarted.timestamp, testRunFinished.timestamp),
   })


### PR DESCRIPTION
### 🤔 What's changed?

- Use `util.styleText` for terminal coloring instead of `chalk`, saving code and dependencies (per #2800)
- Change the status -> color mappings here to match the ones in our polyglot formatters for consistency

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
