### PR TITLE
Clarify world parameters configuration example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber
 - Deprecate `printAttachments` format option in favour of `includeAttachments` ([#2708](https://github.com/cucumber/cucumber-js/pull/2708))
 
 ### Fixed
+- Clarify how to configure world parameters in configuration files ([#2317](https://github.com/cucumber/cucumber-js/issues/2317))
 - Update status colors to match other formatters ([#2828](https://github.com/cucumber/cucumber-js/pull/2828))
 - Surface `Error.cause` chain (with stack frames) in output ([#2813](https://github.com/cucumber/cucumber-js/pull/2813))
 

--- a/docs/support_files/world.md
+++ b/docs/support_files/world.md
@@ -71,10 +71,11 @@ Tests often require configuration and environment information. One of the most f
 
 The `worldParameters` configuration option allows you to provide this information to Cucumber. It takes the data in the form of an object literal, like this:
 
-- In a configuration file, add it to the profile. For example, a CommonJS
-  configuration can use
+- In a configuration file, add it to the profile. The syntax depends on the
+  file format: a CommonJS configuration can put it in the `default` profile
+  with
   `{ default: { worldParameters: { appUrl: 'http://localhost:3000/' } } }`,
-  while an ESM configuration can use
+  while an ESM configuration can express the default profile with
   `export default { worldParameters: { appUrl: 'http://localhost:3000/' } }`.
   See [Configuration files](../configuration.md#files) and
   [Profiles](../profiles.md).

--- a/docs/support_files/world.md
+++ b/docs/support_files/world.md
@@ -71,7 +71,13 @@ Tests often require configuration and environment information. One of the most f
 
 The `worldParameters` configuration option allows you to provide this information to Cucumber. It takes the data in the form of an object literal, like this:
 
-- In a configuration file `{ worldParameters: { appUrl: 'http://localhost:3000/' } }`
+- In a configuration file, add it to the profile. For example, a CommonJS
+  configuration can use
+  `{ default: { worldParameters: { appUrl: 'http://localhost:3000/' } } }`,
+  while an ESM configuration can use
+  `export default { worldParameters: { appUrl: 'http://localhost:3000/' } }`.
+  See [Configuration files](../configuration.md#files) and
+  [Profiles](../profiles.md).
 - On the CLI `$ cucumber-js --world-parameters '{"appUrl":"http://localhost:3000/"}'`
 
 This option is repeatable, so you can use it multiple times and the objects will be merged with the later ones taking precedence.


### PR DESCRIPTION
## Summary
- clarify that `worldParameters` belongs inside a profile in CommonJS configuration files
- show the equivalent ESM default export and link to the configuration and profiles documentation
- add a changelog entry

## Testing
- `npm test`

Fixes #2317
