### PR TITLE
Simplify ESM wrappers

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,7 +301,7 @@
     "typescript": "^6.0.0"
   },
   "scripts": {
-    "build-local": "tsc --build tsconfig.build.json && shx cp src/wrapper.mjs lib/ && shx cp src/api/wrapper.mjs lib/api/",
+    "build-local": "tsc --p tsconfig.build.json",
     "cck-test": "mocha \"compatibility/**/*_spec.ts\"",
     "exports-generate-docs": "typedoc",
     "exports-test": "api-extractor run --config exports/api/api-extractor.json --verbose && api-extractor run --config exports/root/api-extractor.json --verbose",

--- a/src/formatter/builder.ts
+++ b/src/formatter/builder.ts
@@ -12,7 +12,7 @@ import StepDefinitionSnippetBuilder from './step_definition_snippet_builder'
 import JavascriptSnippetSyntax from './step_definition_snippet_builder/javascript_snippet_syntax'
 import { SnippetInterface } from './step_definition_snippet_builder/snippet_syntax'
 
-interface IGetStepDefinitionSnippetBuilderOptions {
+export interface IGetStepDefinitionSnippetBuilderOptions {
   cwd: string
   snippetInterface?: SnippetInterface
   snippetSyntax?: string

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,9 +1,10 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.mts"],
+  "include": ["src/**/*.ts", "src/**/*.mts", "src/**/wrapper.mjs"],
   "exclude": ["**/*_spec.ts"],
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib"
+    "outDir": "lib",
+    "allowJs": true
   }
 }


### PR DESCRIPTION
### 🤔 What's changed?

Let `tsc` handle the pushing through of `.mjs` wrappers to the output dir, rather than manually copying in our build script.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
