### PR TITLE
Replace mkdirp dependency

### DIFF
--- a/exports/root/report.api.md
+++ b/exports/root/report.api.md
@@ -41,8 +41,7 @@ export const BeforeAll: ((code: TestRunHookFunction) => void) & ((options: IDefi
 export const BeforeStep: (<WorldType = IWorld<any>>(code: TestStepHookFunction<WorldType>) => void) & (<WorldType = IWorld<any>>(tags: string, code: TestStepHookFunction<WorldType>) => void) & (<WorldType = IWorld<any>>(options: IDefineTestStepHookOptions, code: TestStepHookFunction<WorldType>) => void);
 
 // @beta
-const context_2: IContext<any>;
-export { context_2 as context }
+export const context: IContext<any>;
 
 // @public (undocumented)
 export class DataTable {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
         "luxon": "3.7.2",
-        "mkdirp": "^3.0.0",
         "read-package-up": "^12.0.0",
         "semver": "7.8.2",
         "string-argv": "0.3.2",
@@ -5245,21 +5244,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha": {

--- a/package.json
+++ b/package.json
@@ -246,7 +246,6 @@
     "lodash.merge": "^4.6.2",
     "lodash.mergewith": "^4.6.2",
     "luxon": "3.7.2",
-    "mkdirp": "^3.0.0",
     "read-package-up": "^12.0.0",
     "semver": "7.8.2",
     "string-argv": "0.3.2",

--- a/src/formatter/create_stream.ts
+++ b/src/formatter/create_stream.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { Writable } from 'node:stream'
-import { mkdirp } from 'mkdirp'
 import type { ILogger } from '../environment'
 
 export async function createStream(
@@ -14,7 +13,7 @@ export async function createStream(
   const directory = path.dirname(absoluteTarget)
 
   try {
-    await mkdirp(directory)
+    await fs.promises.mkdir(directory, { recursive: true })
   } catch (e) {
     logger.warn('Failed to ensure directory for formatter target exists', e)
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "typeRoots": ["./node_modules/@types", "./src/types"],
+    "types": ["node"],
     "declaration": true,
     "inlineSourceMap": true,
     "inlineSources": true,


### PR DESCRIPTION
### 🤔 What's changed?

Use built-in [mkdir](https://nodejs.org/docs/latest-v22.x/api/fs.html#fspromisesmkdirpath-options) instead of [mkdirp](https://github.com/isaacs/node-mkdirp) package.

### ⚡️ What's your motivation? 

Continuation of #2800. According to mkdirp's own [comparison](https://github.com/isaacs/node-mkdirp#use-fsmkdirpath-recursive-true-cb-if) should be used only if a handful of specific scenarios and from what I can tell cucumber doesn't care about any of those.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

This is indirectly tested by using cucumber as a test runner for its own tests. But might be worth adding a unit test?

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
