### PR TITLE
fix: distinct exit code for Cucumber errors vs test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Changed
+- Exit with code `2` (rather than `1`) when Cucumber itself fails to run, e.g. an invalid invocation, configuration or unexpected error, so CI can distinguish this from genuine test failures (which still exit with code `1`) ([#2646](https://github.com/cucumber/cucumber-js/issues/2646))
 
 ## [13.0.0] - 2026-06-02
 ### Added

--- a/features/exit_code.feature
+++ b/features/exit_code.feature
@@ -1,0 +1,45 @@
+@spawn
+Feature: Exit codes
+
+  Cucumber distinguishes the exit code for a run where scenarios failed
+  from a run where Cucumber itself could not be invoked correctly, so that
+  CI can tell genuine test failures apart from a broken command.
+
+  Background:
+    Given a file named "features/step_definitions/cucumber_steps.js" with:
+      """
+      const {Given} = require('@cucumber/cucumber')
+
+      Given('a passing step', function() {})
+      Given('a failing step', function() { throw new Error('boom') })
+      """
+
+  Scenario: exit code 0 when all scenarios pass
+    Given a file named "features/a.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given a passing step
+      """
+    When I run cucumber-js
+    Then it passes
+
+  Scenario: exit code 1 when a scenario fails
+    Given a file named "features/a.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given a failing step
+      """
+    When I run cucumber-js
+    Then it fails with exit code 1
+
+  Scenario: exit code 2 when the configuration is invalid
+    Given a file named "features/a.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given a passing step
+      """
+    When I run cucumber-js with `--config doesntexist.js`
+    Then it fails with exit code 2

--- a/features/step_definitions/cli_steps.ts
+++ b/features/step_definitions/cli_steps.ts
@@ -73,6 +73,16 @@ Then('it fails', function (this: World) {
   this.verifiedLastRunError = true
 })
 
+Then('it fails with exit code {int}', function (this: World, expectedCode: number) {
+  const actualCode: number = doesHaveValue(this.lastRun.error) ? this.lastRun.error.code : 0
+
+  expect(actualCode).to.eql(
+    expectedCode,
+    `Expected exit status ${expectedCode}, but got ${actualCode}`
+  )
+  this.verifiedLastRunError = true
+})
+
 Then('it outputs the text:', function (this: World, text: string) {
   const actualOutput = normalizeText(this.lastRun.output)
   const expectedOutput = normalizeText(text)

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,10 +1,23 @@
 import Cli, { type ICliRunResult } from './'
 import { validateNodeEngineVersion } from './validate_node_engine_version'
 
-function logErrorMessageAndExit(message: string): void {
+/**
+ * Exit code used when test scenarios were run but at least one failed.
+ */
+const EXIT_CODE_TEST_FAILURES = 1
+
+/**
+ * Exit code used when Cucumber itself failed to run, e.g. an invalid
+ * invocation, configuration or an unexpected error. This is distinct from
+ * {@link EXIT_CODE_TEST_FAILURES} so that CI can tell genuine test failures
+ * apart from a broken command.
+ */
+const EXIT_CODE_CUCUMBER_ERROR = 2
+
+function logErrorMessageAndExit(message: unknown): void {
   // biome-ignore lint/suspicious/noConsole: cli entrypoint, other code abstracts console for testability
   console.error(message)
-  process.exit(1)
+  process.exit(EXIT_CODE_CUCUMBER_ERROR)
 }
 
 export default async function run(): Promise<void> {
@@ -13,7 +26,7 @@ export default async function run(): Promise<void> {
     (error) => {
       // biome-ignore lint/suspicious/noConsole: cli entrypoint, other code abstracts console for testability
       console.error(error)
-      process.exit(1)
+      process.exit(EXIT_CODE_CUCUMBER_ERROR)
     },
     // biome-ignore lint/suspicious/noConsole: cli entrypoint, other code abstracts console for testability
     console.warn
@@ -34,7 +47,7 @@ export default async function run(): Promise<void> {
     logErrorMessageAndExit(error)
   }
 
-  const exitCode = result.success ? 0 : 1
+  const exitCode = result.success ? 0 : EXIT_CODE_TEST_FAILURES
   if (result.shouldExitImmediately) {
     process.exit(exitCode)
   } else {


### PR DESCRIPTION
## Problem

Cucumber exits with code `1` both when scenarios fail **and** when Cucumber itself can't be invoked correctly (invalid argument, bad/missing configuration, support-code load failure, unexpected error). CI pipelines therefore can't distinguish a genuine test failure from a broken command — see #2646.

## Fix

Introduce a distinct exit code for "Cucumber errors":

| Outcome | Exit code |
| --- | --- |
| All scenarios pass | `0` |
| One or more scenarios fail | `1` |
| Cucumber failed to run (invalid invocation / configuration / unexpected error) | `2` |

This mirrors [cucumber-ruby](https://github.com/cucumber/cucumber-ruby/issues/844). The change is small and contained in the CLI entrypoint (`src/cli/run.ts`): the thrown-error path and the Node engine-version validation error path now exit with `2`, while the run-result failure path keeps `1`.

Magic numbers replaced with named constants (`EXIT_CODE_TEST_FAILURES`, `EXIT_CODE_CUCUMBER_ERROR`).

### Note / out of scope

Commander's own argument-parsing errors (e.g. an entirely unknown flag like `--no-such-flag`) still exit with Commander's default `1`, because Commander calls `process.exit` itself before control returns to `run.ts`. Routing those through code `2` would require `exitOverride` and special-casing the `--help`/`--version` (exit `0`) flows, which is a larger, riskier change. Happy to do it in a follow-up if maintainers want full consistency.

## Tests

Added `features/exit_code.feature` (a `@spawn` feature so it exercises the real `bin` → `run.ts` exit logic, rather than the in-process harness which fabricates an exit code) with three scenarios: pass → `0`, scenario failure → `1`, invalid config → `2`. Added a reusable `Then it fails with exit code {int}` step in `features/step_definitions/cli_steps.ts`.

Verified the new scenario **fails on `main`** (invalid-config scenario got `1`, expected `2`) and **passes with the fix**.

```
npm run lint         # biome: Checked 279 files. No fixes applied.
npm run unit-test    # 392 passing
npm run types-test   # tsd OK
npm run exports-test # API Extractor completed successfully
npm run feature-test # 335 scenarios (334 passed, 1 skipped) — incl. new feature
npm run cck-test     # 39 passing, 5 pending
```

## Changelog

Added an entry under `## [Unreleased]` → `### Changed`.

### AI assistance

This change was prepared with assistance from Claude Code (Anthropic, Opus 4.x). The author reviewed and verified the diff, the behavioural reproduction, and the full test/lint suite locally. Disclosed via an `Assisted-by:` commit trailer.

Closes #2646
