### PR TITLE
Exempt dependency bots from pull request template

### DIFF
--- a/.github/scripts/driveby-check.mjs
+++ b/.github/scripts/driveby-check.mjs
@@ -4,6 +4,8 @@ import { readFile } from 'node:fs/promises'
 
 const templateMarkers = ["what's changed", 'checklist', '[x] I agree to respect and uphold the']
 
+const exemptAuthors = ['renovate[bot]', 'dependabot[bot]']
+
 const driveByLabel = ':car: driveby'
 
 /**
@@ -14,6 +16,9 @@ const driveByLabel = ':car: driveby'
 export default async function ({ github, context }) {
   const pr = context.payload.pull_request
   if (!pr) {
+    return
+  }
+  if (exemptAuthors.includes(pr.user?.login)) {
     return
   }
   const { owner, repo } = context.repo


### PR DESCRIPTION
### 🤔 What's changed?

Renovate and Dependabot don't have to follow the pull request template, so exclude them from the workflow that insists on it.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*

