### PR TITLE
Use fake timers instead of real setTimeout waits

### DIFF
--- a/src/runtime/stopwatch_spec.ts
+++ b/src/runtime/stopwatch_spec.ts
@@ -1,40 +1,54 @@
 import { TimeConversion } from '@cucumber/messages'
+import FakeTimers, { type InstalledClock } from '@sinonjs/fake-timers'
 import { expect } from 'chai'
-import { describe, it } from 'mocha'
+import { afterEach, beforeEach, describe, it } from 'mocha'
+import timeMethods from '../time'
 import { create, timestamp } from './stopwatch'
 
 describe('stopwatch', () => {
-  it('returns a duration between the start and stop', async () => {
-    const stopwatch = create()
-    stopwatch.start()
-    await new Promise((resolve) => setTimeout(resolve, 1200))
-    stopwatch.stop()
-    expect(TimeConversion.durationToMilliseconds(stopwatch.duration())).to.be.closeTo(1200, 50)
-  })
+  describe('duration', () => {
+    let clock: InstalledClock
 
-  it('accounts for an initial duration', async () => {
-    const stopwatch = create(TimeConversion.millisecondsToDuration(300))
-    stopwatch.start()
-    await new Promise((resolve) => setTimeout(resolve, 200))
-    stopwatch.stop()
-    expect(TimeConversion.durationToMilliseconds(stopwatch.duration())).to.be.closeTo(500, 50)
-  })
+    beforeEach(() => {
+      clock = FakeTimers.withGlobal(timeMethods).install()
+    })
 
-  it('returns accurate durations ad-hoc if not stopped', async () => {
-    const stopwatch = create()
-    stopwatch.start()
-    await new Promise((resolve) => setTimeout(resolve, 200))
-    expect(TimeConversion.durationToMilliseconds(stopwatch.duration())).to.be.closeTo(200, 50)
-    await new Promise((resolve) => setTimeout(resolve, 200))
-    stopwatch.stop()
-    expect(TimeConversion.durationToMilliseconds(stopwatch.duration())).to.be.closeTo(400, 50)
-  })
+    afterEach(() => {
+      clock.uninstall()
+    })
 
-  it('returns 0 duration if never started', async () => {
-    const stopwatch = create()
-    await new Promise((resolve) => setTimeout(resolve, 200))
-    stopwatch.stop()
-    expect(TimeConversion.durationToMilliseconds(stopwatch.duration())).to.eq(0)
+    it('returns a duration between the start and stop', () => {
+      const stopwatch = create()
+      stopwatch.start()
+      clock.tick(1200)
+      stopwatch.stop()
+      expect(TimeConversion.durationToMilliseconds(stopwatch.duration())).to.eq(1200)
+    })
+
+    it('accounts for an initial duration', () => {
+      const stopwatch = create(TimeConversion.millisecondsToDuration(300))
+      stopwatch.start()
+      clock.tick(200)
+      stopwatch.stop()
+      expect(TimeConversion.durationToMilliseconds(stopwatch.duration())).to.eq(500)
+    })
+
+    it('returns accurate durations ad-hoc if not stopped', () => {
+      const stopwatch = create()
+      stopwatch.start()
+      clock.tick(200)
+      expect(TimeConversion.durationToMilliseconds(stopwatch.duration())).to.eq(200)
+      clock.tick(200)
+      stopwatch.stop()
+      expect(TimeConversion.durationToMilliseconds(stopwatch.duration())).to.eq(400)
+    })
+
+    it('returns 0 duration if never started', () => {
+      const stopwatch = create()
+      clock.tick(200)
+      stopwatch.stop()
+      expect(TimeConversion.durationToMilliseconds(stopwatch.duration())).to.eq(0)
+    })
   })
 
   it('returns a timestamp close to now', () => {


### PR DESCRIPTION
### 🤔 What's changed?

The `stopwatch` specs waited on real `setTimeout` calls — 1200 + 200 + 200 + 200 + 200 ms — so running the file spent roughly two seconds just sleeping, then checked the measured duration with a `closeTo(…, 50)` tolerance.

I swapped the real waits for `@sinonjs/fake-timers` and advance the clock with `clock.tick(…)`. I reused the `FakeTimers.withGlobal(timeMethods).install()` setup that already exists in `test_case_runner_spec.ts` and `assemble_test_cases_spec.ts`, because the stopwatch reads the clock through the shared `../time` methods object, so faking that object is enough. The four duration tests are now synchronous and assert exact values (`to.eq(1200)`), and the file runs in ~12ms. I left the `returns a timestamp close to now` test on the real clock since it's already instant.

### ⚡️ What's your motivation?

Two things bugged me about these specs: they're slow for no real reason (sleeping in a unit test), and the `closeTo(…, 50)` tolerance is a latent flake — under CI load the event loop can drift past 50ms and fail an assertion that has nothing to do with an actual regression. Faking the clock removes both problems at once.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

I scoped the fake clock to a nested `describe('duration')` so the `timestamp` test keeps the real clock. If you'd prefer I fake the whole file and pin `timestamp` against a fixed `now` instead, I'm happy to change it.

### 📋 Checklist:

- [x] I agree to respect and uphold the Cucumber Community Code of Conduct
- [ ] I've changed the behaviour of the code — no, this is test-only; behaviour is unchanged and the assertions are just tightened
- [ ] My change requires a change to the documentation
- [ ] Users should know about my change — no, it's an internal test change with nothing user-facing, so no CHANGELOG entry