### PR TITLE
Handle worker exit, tolerate missing step result

### DIFF
--- a/features/parallel.feature
+++ b/features/parallel.feature
@@ -123,6 +123,42 @@ Feature: Running scenarios in parallel
     And the first two scenarios run in parallel while the last runs sequentially
     And the scenario 'fail_parallel' retried 3 times
 
+  Scenario: a worker exiting unexpectedly fails the run
+    Given a file named "features/step_definitions/cucumber_steps.js" with:
+      """
+      const {Given} = require('@cucumber/cucumber')
+
+      Given(/^a passing step$/, function() {})
+
+      Given(/^a step that kills the worker$/, function(callback) {
+        setTimeout(() => process.exit(1), 500)
+      })
+      """
+    And a file named "features/a.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given a step that kills the worker
+          And a passing step
+
+        Scenario:
+          Given a passing step
+      """
+    When I run cucumber-js with `--parallel 2 --format json:report.json`
+    Then it fails
+    And the output contains the text:
+      """
+      exited unexpectedly
+      """
+    And the file "report.json" contains the text:
+      """
+      "status": "unknown"
+      """
+    And the file "report.json" contains the text:
+      """
+      "status": "passed"
+      """
+
   Scenario: environment variables are passed to parallel workers
     Given a file named "features/step_definitions/cucumber_steps.js" with:
       """

--- a/src/api/run_cucumber.ts
+++ b/src/api/run_cucumber.ts
@@ -152,19 +152,19 @@ Running from: ${__dirname}
       timestamp: timestamp(),
     },
   } satisfies Envelope)
-  const success = await runtime.run()
+  const result = await runtime.run()
   eventBroadcaster.emit('envelope', {
     testRunFinished: {
       testRunStartedId,
       timestamp: timestamp(),
-      success,
+      ...result,
     },
   } satisfies Envelope)
   await pluginManager.cleanup()
   await cleanupFormatters()
 
   return {
-    success: success && !formatterStreamError,
+    success: result.success && !formatterStreamError,
     support: supportCodeLibrary,
   }
 }

--- a/src/formatter/helpers/event_data_collector.ts
+++ b/src/formatter/helpers/event_data_collector.ts
@@ -97,12 +97,20 @@ export default class EventDataCollector {
   }
 
   private initTestCaseAttempt(testCaseStarted: TestCaseStarted): void {
+    // pre-seed a fallback UNKNOWN result for every step
+    const stepResults: Record<string, TestStepResult> = {}
+    for (const testStep of this.testCaseMap[testCaseStarted.testCaseId].testSteps) {
+      stepResults[testStep.id] = {
+        duration: { seconds: 0, nanos: 0 },
+        status: TestStepResultStatus.UNKNOWN,
+      }
+    }
     this.testCaseAttemptDataMap[testCaseStarted.id] = {
       attempt: testCaseStarted.attempt,
       willBeRetried: false,
       testCaseId: testCaseStarted.testCaseId,
       stepAttachments: {},
-      stepResults: {},
+      stepResults,
       worstTestStepResult: {
         duration: { seconds: 0, nanos: 0 },
         status: TestStepResultStatus.UNKNOWN,

--- a/src/runtime/coordinator.ts
+++ b/src/runtime/coordinator.ts
@@ -2,8 +2,9 @@ import type { EventEmitter } from 'node:events'
 import type { IdGenerator } from '@cucumber/messages'
 import { assembleTestCases, type SourcedPickle } from '../assemble'
 import type { SupportCodeLibrary } from '../support_code_library_builder/types'
+import { formatError } from './format_error'
 import type { Runtime } from './index'
-import type { RuntimeAdapter } from './types'
+import type { RuntimeAdapter, RuntimeResult } from './types'
 
 /**
  * Handles the high-level coordination of the test run on the main thread
@@ -22,7 +23,7 @@ export class Coordinator implements Runtime {
     private adapter: RuntimeAdapter
   ) {}
 
-  async run(): Promise<boolean> {
+  async run(): Promise<RuntimeResult> {
     try {
       await this.adapter.setup()
 
@@ -43,9 +44,15 @@ export class Coordinator implements Runtime {
         successByPhase.testCases = await this.adapter.runTestCases(assembledTestCases)
       }
       successByPhase.afterAllHooks = await this.adapter.runAfterAllHooks()
-      return (
-        successByPhase.beforeAllHooks && successByPhase.testCases && successByPhase.afterAllHooks
-      )
+      return {
+        success:
+          successByPhase.beforeAllHooks && successByPhase.testCases && successByPhase.afterAllHooks,
+      }
+    } catch (error: unknown) {
+      return {
+        success: false,
+        exception: formatError(error as Error, false).exception,
+      }
     } finally {
       await this.adapter.teardown()
     }

--- a/src/runtime/coordinator.ts
+++ b/src/runtime/coordinator.ts
@@ -20,6 +20,7 @@ export class Coordinator implements Runtime {
     private newId: IdGenerator.NewId,
     private sourcedPickles: ReadonlyArray<SourcedPickle>,
     private supportCodeLibrary: SupportCodeLibrary,
+    private filterStacktraces: boolean,
     private adapter: RuntimeAdapter
   ) {}
 
@@ -51,7 +52,7 @@ export class Coordinator implements Runtime {
     } catch (error: unknown) {
       return {
         success: false,
-        exception: formatError(error as Error, false).exception,
+        exception: formatError(error as Error, this.filterStacktraces).exception,
       }
     } finally {
       await this.adapter.teardown()

--- a/src/runtime/make_runtime.ts
+++ b/src/runtime/make_runtime.ts
@@ -48,6 +48,7 @@ export async function makeRuntime({
     newId,
     sourcedPickles,
     supportCodeLibrary,
+    options.filterStacktraces,
     adapter
   )
 }

--- a/src/runtime/parallel/adapter.ts
+++ b/src/runtime/parallel/adapter.ts
@@ -19,11 +19,12 @@ import type { ManagedWorker, Phase, WorkerCommand, WorkerData, WorkerEvent } fro
  * triggered or the phase to be settled.
  */
 export class WorkerThreadsAdapter implements RuntimeAdapter {
-  private readiness: {
+  private readiness?: {
     resolve: () => void
     reject: (reason: unknown) => void
   }
-  private phase: Phase
+  private phase?: Phase
+  private tearingDown = false
   private readonly workers: Set<ManagedWorker> = new Set()
   private readonly running: Map<ManagedWorker, WorkerCommand> = new Map()
 
@@ -87,6 +88,9 @@ export class WorkerThreadsAdapter implements RuntimeAdapter {
         workerThread.on('error', (error) => {
           this.handleErrorFromWorker(error, worker)
         })
+        workerThread.on('exit', (exitCode) => {
+          this.handleExitFromWorker(exitCode, worker)
+        })
       }
     })
     delete this.readiness
@@ -126,6 +130,7 @@ export class WorkerThreadsAdapter implements RuntimeAdapter {
   }
 
   async teardown(): Promise<void> {
+    this.tearingDown = true
     for (const worker of this.workers.values()) {
       await worker.workerThread.terminate()
       // close our end of the channel so it stops keeping the loop alive
@@ -171,7 +176,16 @@ export class WorkerThreadsAdapter implements RuntimeAdapter {
   }
 
   private handleErrorFromWorker(error: Error, worker: ManagedWorker) {
-    const reason = new Error(`Error on worker ${worker.id}`, { cause: error })
+    this.fail(new Error(`Error on worker ${worker.id}`, { cause: error }))
+  }
+
+  private handleExitFromWorker(exitCode: number, worker: ManagedWorker) {
+    if (!this.tearingDown) {
+      this.fail(new Error(`Worker ${worker.id} exited unexpectedly with code ${exitCode}`))
+    }
+  }
+
+  private fail(reason: Error) {
     this.readiness?.reject(reason)
     this.phase?.reject(reason)
     void this.teardown()

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,3 +1,4 @@
+import type { Exception } from '@cucumber/messages'
 import type { JsonObject } from 'type-fest'
 import type { AssembledTestCase } from '../assemble'
 
@@ -11,8 +12,13 @@ export interface RuntimeOptions {
   worldParameters: JsonObject
 }
 
+export interface RuntimeResult {
+  success: boolean
+  exception?: Exception
+}
+
 export interface Runtime {
-  run: () => Promise<boolean>
+  run: () => Promise<RuntimeResult>
 }
 
 export interface RuntimeAdapter {


### PR DESCRIPTION
### 🤔 What's changed?

- The parallel runtime now handles an unexpected exit of a worker thread, and treats it as an error
- Errors from the runtime (serial or parallel) are now caught and included in the `TestRunFinished` message, and the test run finishes cleanly
- The `EventDataCollector` that feeds legacy formatters (e.g. `json`) now includes a fallback to an "UNKNOWN" result for every test step, so 

### ⚡️ What's your motivation? 

Fixes #2720.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
