### PR TITLE
Ensure ESM entry point get all exported types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Ensure ESM entry point get all exported types ([#2881](https://github.com/cucumber/cucumber-js/pull/2881))
 
 ## [13.1.0] - 2026-07-14
 ### Changed

--- a/package.json
+++ b/package.json
@@ -199,14 +199,14 @@
   "main": "./lib/index.js",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/wrapper.mjs",
-      "require": "./lib/index.js",
-      "types": "./lib/index.d.ts"
+      "require": "./lib/index.js"
     },
     "./api": {
+      "types": "./lib/api/index.d.ts",
       "import": "./lib/api/wrapper.mjs",
-      "require": "./lib/api/index.js",
-      "types": "./lib/api/index.d.ts"
+      "require": "./lib/api/index.js"
     },
     "./lib/*": {
       "require": "./lib/*.js"
@@ -318,7 +318,7 @@
     "pretypes-test": "npm run build-local",
     "test-coverage": "nyc --silent mocha \"src/**/*_spec.ts\" \"compatibility/**/*_spec.ts\" && nyc --silent --no-clean node bin/cucumber.js --tags \"not @source-mapping\" && nyc report --reporter=lcov",
     "test": "npm run lint && npm run exports-test && npm run types-test && npm run unit-test && npm run cck-test && npm run feature-test",
-    "types-test": "tsd",
+    "types-test": "tsd --files 'test-d/**/*.{ts,mts}'",
     "unit-test": "mocha \"src/**/*_spec.ts\""
   },
   "bin": {

--- a/test-d/esm.mts
+++ b/test-d/esm.mts
@@ -1,0 +1,10 @@
+import { type IWorldOptions, World } from '@cucumber/cucumber'
+import type { IRunEnvironment } from '@cucumber/cucumber/api'
+import { expectAssignable } from 'tsd'
+
+// types re-exported from the root and api entry points should be importable
+// under ESM (node16/nodenext) resolution
+declare const worldOptions: IWorldOptions
+expectAssignable<World>(new World(worldOptions))
+
+expectAssignable<IRunEnvironment>({ env: process.env })


### PR DESCRIPTION
### 🤔 What's changed?

Put the `types` export mapping first in the order, so `tsc` will always grab it instead of the auto-generated one from the ESM wrapper which will be missing type-only exports.

### ⚡️ What's your motivation? 

Fixes #2879.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
