### PR TITLE
Document support for using a proxy when publishing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,7 +108,7 @@ These options can be used in a configuration file (see [above](#files)) or on th
 | `parallel`        | `number`   | No         | `--parallel`              | Run tests in parallel with the given number of worker processes - see [Parallel](./parallel.md)                    | 0       |
 | `plugin`          | `string[]` | Yes        | `--plugin`                | Paths or package names of plugins to load - see [Plugins](./plugins.md)                                            | []      |
 | `pluginOptions`   | `object`   | Yes        | `--plugin-options`        | Options to be provided to plugins - see [Plugins](./plugins.md)                                                    | {}      |
-| `publish`         | `boolean`  | No         | `--publish`               | Publish a report of your test run to <https://reports.cucumber.io/>                                                | false   |
+| `publish`         | `boolean`  | No         | `--publish`               | Publish a report of your test run to Cucumber Reports - see [Publishing](./publishing.md)                          | false   |
 | `require`         | `string[]` | Yes        | `--require`, `-r`         | Paths to where your support code is, for CommonJS - see [below](#finding-your-code)                                | []      |
 | `requireModule`   | `string[]` | Yes        | `--require-module`        | Names of transpilation modules to load, loaded via `require()` - see [Transpiling](./transpiling.md)               | []      |
 | `retry`           | `number`   | No         | `--retry`                 | Retry failing tests up to the given number of times - see [Retry](./retry.md)                                      | 0       |

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -2,7 +2,7 @@
 
 In cucumber-js, Formatters ingest data about your test run in real time and then output content, either to the console or a file, in a useful format. (Some frameworks refer to this kind of thing as "reporters".)
 
-cucumber-js provides many built-in Formatters, plus building blocks with which you can [write your own](./custom_formatters.md).
+cucumber-js provides many built-in Formatters, plus building blocks with which you can [write your own](./custom_formatters.md). If you'd rather view and share your results as a hosted report, see [Publishing](./publishing.md).
 
 You can specify one or more formats via the `format` configuration option:
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,36 @@
+# Publishing reports
+
+You can publish a report of your test run to [Cucumber Reports](https://reports.cucumber.io/), a free service for viewing and sharing results. Enable it with the `publish` configuration option:
+
+- In a configuration file `{ publish: true }`
+- On the CLI `cucumber-js --publish`
+- Environment variable `CUCUMBER_PUBLISH_ENABLED=true`
+
+At the end of the run, the URL where your report is available is printed to the terminal.
+
+Reports are anonymous and self-destruct after 24 hours unless claimed.
+
+## Publishing privately
+
+If you have an private/internal service that follows the Cucumber Reports API, you can point to that with environment variables:
+
+| Variable                   | Description                                                                                    |
+|----------------------------|------------------------------------------------------------------------------------------------|
+| `CUCUMBER_PUBLISH_URL`     | Base URL of the reports service to publish to                                                  |
+| `CUCUMBER_PUBLISH_TOKEN`   | Authentication token, will be added as a Bearer token in the `Authorizaton` header if supplied |
+
+## Publishing behind a proxy
+
+If your network requires outbound HTTP(S) requests to go via a proxy, set the standard proxy environment variables, plus [`NODE_USE_ENV_PROXY`](https://nodejs.org/api/cli.html#node_use_env_proxy1), which is what tells Node.js to honour them:
+
+```shell
+NODE_USE_ENV_PROXY=1 HTTPS_PROXY=http://proxy.example.com:3128 npx cucumber-js --publish
+```
+
+Some notes on this:
+
+- `NODE_USE_ENV_PROXY` is a Node option rather than a cucumber-js one, and applies to the whole process. You can also enable it with `NODE_OPTIONS="--use-env-proxy"`, or the `--use-env-proxy` flag if you're invoking `node` directly.
+- It requires Node.js 22.21.0 or 24.0.0 and above.
+- `HTTPS_PROXY` covers requests to Cucumber Reports itself; `HTTP_PROXY` is only relevant if you've pointed `CUCUMBER_PUBLISH_URL` at a plain HTTP service.
+- `NO_PROXY` is honoured, so you can bypass the proxy for specific hosts.
+- Credentials in the proxy URL (e.g. `http://user:pass@proxy.example.com:3128`) are supported.

--- a/features/publish.feature
+++ b/features/publish.feature
@@ -69,6 +69,25 @@ Feature: Publish reports
       | testRunFinished  |
     And the server should receive an "Authorization" header with value "Bearer f318d9ec-5a3d-4727-adec-bd7b69e2edd3"
 
+  Scenario: Report is published via a proxy when NODE_USE_ENV_PROXY is set
+    Given a proxy server is running on 'http://localhost:9988'
+    When I run cucumber-js with arguments `--publish` and env `HTTP_PROXY=http://localhost:9988 NODE_USE_ENV_PROXY=1`
+    Then it passes
+    And the proxy server should have tunnelled to "localhost:9987"
+    And the server should receive the following message types:
+      | meta             |
+      | source           |
+      | gherkinDocument  |
+      | pickle           |
+      | stepDefinition   |
+      | testRunStarted   |
+      | testCase         |
+      | testCaseStarted  |
+      | testStepStarted  |
+      | testStepFinished |
+      | testCaseFinished |
+      | testRunFinished  |
+
   Scenario: a banner is displayed after publication
     When I run cucumber-js with arguments `--publish` and env ``
     Then the error output contains the text:

--- a/features/publish.feature
+++ b/features/publish.feature
@@ -73,7 +73,7 @@ Feature: Publish reports
     Given a proxy server is running on 'http://localhost:9988'
     When I run cucumber-js with arguments `--publish` and env `HTTP_PROXY=http://localhost:9988 NODE_USE_ENV_PROXY=1`
     Then it passes
-    And the proxy server should have tunnelled to "localhost:9987"
+    And the proxy server should have proxied to "localhost:9987"
     And the server should receive the following message types:
       | meta             |
       | source           |

--- a/features/step_definitions/report_server_steps.ts
+++ b/features/step_definitions/report_server_steps.ts
@@ -3,6 +3,7 @@ import { URL } from 'node:url'
 import { gunzipSync } from 'node:zlib'
 import { expect } from 'chai'
 import { type DataTable, Given, Then } from '../..'
+import FakeProxyServer from '../../test/fake_proxy_server'
 import FakeReportServer from '../../test/fake_report_server'
 import type { World } from '../support/world'
 
@@ -10,6 +11,12 @@ Given('a report server is running on {string}', async function (this: World, url
   const port = parseInt(new URL(url).port, 10)
   this.reportServer = new FakeReportServer(port)
   await this.reportServer.start()
+})
+
+Given('a proxy server is running on {string}', async function (this: World, url: string) {
+  const port = parseInt(new URL(url).port, 10)
+  this.proxyServer = new FakeProxyServer(port)
+  await this.proxyServer.start()
 })
 
 Given('report publishing is not working', async function (this: World) {
@@ -39,6 +46,10 @@ Then(
     expect(receivedMessageTypes).to.deep.eq(expectedMessageTypes)
   }
 )
+
+Then('the proxy server should have tunnelled to {string}', function (this: World, target: string) {
+  expect(this.proxyServer.tunnelledTargets).to.include(target)
+})
 
 Then(
   'the server should receive a(n) {string} header with value {string}',

--- a/features/step_definitions/report_server_steps.ts
+++ b/features/step_definitions/report_server_steps.ts
@@ -47,8 +47,8 @@ Then(
   }
 )
 
-Then('the proxy server should have tunnelled to {string}', function (this: World, target: string) {
-  expect(this.proxyServer.tunnelledTargets).to.include(target)
+Then('the proxy server should have proxied to {string}', function (this: World, target: string) {
+  expect(this.proxyServer.proxiedTargets).to.include(target)
 })
 
 Then(

--- a/features/support/hooks.ts
+++ b/features/support/hooks.ts
@@ -53,6 +53,10 @@ After(async function (this: World) {
     await this.reportServer.stop()
   }
 
+  if (this.proxyServer?.started) {
+    await this.proxyServer.stop()
+  }
+
   if (
     doesHaveValue(this.lastRun) &&
     doesHaveValue(this.lastRun.error) &&

--- a/features/support/world.ts
+++ b/features/support/world.ts
@@ -12,6 +12,7 @@ import { setWorldConstructor } from '../../'
 import { type IRunEnvironment, loadConfiguration, runCucumber } from '../../lib/api'
 import { ArgvParser } from '../../lib/configuration'
 import { doesHaveValue } from '../../src/value_checker'
+import type FakeProxyServer from '../../test/fake_proxy_server'
 import type FakeReportServer from '../../test/fake_report_server'
 
 const asyncPipeline = util.promisify(pipeline)
@@ -38,6 +39,7 @@ export class World {
   public verifiedLastRunError: boolean
   public localExecutablePath: string
   public reportServer: FakeReportServer
+  public proxyServer: FakeProxyServer
 
   parseEnvString(str: string): NodeJS.ProcessEnv {
     const result: NodeJS.ProcessEnv = {}

--- a/test/fake_proxy_server.ts
+++ b/test/fake_proxy_server.ts
@@ -1,0 +1,49 @@
+import http from 'node:http'
+import net, { type Server } from 'node:net'
+
+/**
+ * Fake implementation of an HTTP proxy, as a user behind a corporate network
+ * might have to publish reports through. Used for testing only.
+ *
+ * Node tunnels proxied requests with CONNECT even when the target is plain
+ * http, so the payloads pass through opaquely and all we can observe is which
+ * targets were tunnelled to.
+ */
+export default class FakeProxyServer {
+  private readonly server: Server
+  public tunnelledTargets: string[] = []
+
+  constructor(private readonly port: number) {
+    this.server = http.createServer((_req, res) => {
+      // we only expect CONNECT, so anything else is a mistake worth surfacing
+      res.writeHead(501).end()
+    })
+
+    this.server.on('connect', (req, clientSocket, head) => {
+      this.tunnelledTargets.push(req.url)
+      const { hostname, port } = new URL(`http://${req.url}`)
+      const targetSocket = net.connect(parseInt(port, 10), hostname, () => {
+        clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n')
+        targetSocket.write(head)
+        targetSocket.pipe(clientSocket)
+        clientSocket.pipe(targetSocket)
+      })
+      targetSocket.on('error', () => clientSocket.end())
+      clientSocket.on('error', () => targetSocket.end())
+    })
+  }
+
+  async start(): Promise<void> {
+    return new Promise((resolve) => this.server.listen(this.port, () => resolve()))
+  }
+
+  async stop(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.server.close((err) => (err ? reject(err) : resolve()))
+    })
+  }
+
+  get started(): boolean {
+    return this.server.listening
+  }
+}

--- a/test/fake_proxy_server.ts
+++ b/test/fake_proxy_server.ts
@@ -5,22 +5,38 @@ import net, { type Server } from 'node:net'
  * Fake implementation of an HTTP proxy, as a user behind a corporate network
  * might have to publish reports through. Used for testing only.
  *
- * Node tunnels proxied requests with CONNECT even when the target is plain
- * http, so the payloads pass through opaquely and all we can observe is which
- * targets were tunnelled to.
+ * Handles both ways a proxy can be asked to relay a request, since which one
+ * Node uses for a given target has varied across versions: an absolute-form
+ * request that we forward on, or a CONNECT tunnel that we pipe through blindly.
+ * Either way all we record is the target, as a tunnel is opaque to us.
  */
 export default class FakeProxyServer {
   private readonly server: Server
-  public tunnelledTargets: string[] = []
+  public proxiedTargets: string[] = []
 
   constructor(private readonly port: number) {
-    this.server = http.createServer((_req, res) => {
-      // we only expect CONNECT, so anything else is a mistake worth surfacing
-      res.writeHead(501).end()
+    this.server = http.createServer((req, res) => {
+      const { hostname, port, pathname, search } = new URL(req.url)
+      this.proxiedTargets.push(`${hostname}:${port}`)
+      const forwarded = http.request(
+        {
+          host: hostname,
+          port,
+          path: pathname + search,
+          method: req.method,
+          headers: req.headers,
+        },
+        (targetRes) => {
+          res.writeHead(targetRes.statusCode, targetRes.headers)
+          targetRes.pipe(res)
+        }
+      )
+      forwarded.on('error', (err) => res.writeHead(502).end(err.message))
+      req.pipe(forwarded)
     })
 
     this.server.on('connect', (req, clientSocket, head) => {
-      this.tunnelledTargets.push(req.url)
+      this.proxiedTargets.push(req.url)
       const { hostname, port } = new URL(`http://${req.url}`)
       const targetSocket = net.connect(parseInt(port, 10), hostname, () => {
         clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n')


### PR DESCRIPTION
### 🤔 What's changed?

Add documentation for how to publish via a proxy.

(This was already supported - we use plain `fetch` and Node.js applies the proxy behaviour to that internally as long as the right environment variables are set.)

### ⚡️ What's your motivation? 

Fixes #1644

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)
- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
