### PR TITLE
Remove explicit any from production code

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,8 +14,7 @@
       },
       "suspicious": {
         "noConfusingVoidType": "off",
-        "noConsole": "error",
-        "noExplicitAny": "off"
+        "noConsole": "error"
       }
     }
   },
@@ -31,6 +30,16 @@
         "rules": {
           "style": {
             "noNonNullAssertion": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/*_spec.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "off"
           }
         }
       }

--- a/exports/api/report.api.md
+++ b/exports/api/report.api.md
@@ -134,13 +134,13 @@ export interface ILoadSupportOptions {
 // @public
 export interface ILogger {
     // (undocumented)
-    debug: (message?: any, ...optionalParams: any[]) => void;
+    debug: (message?: unknown, ...optionalParams: unknown[]) => void;
     // (undocumented)
-    error: (message?: any, ...optionalParams: any[]) => void;
+    error: (message?: unknown, ...optionalParams: unknown[]) => void;
     // (undocumented)
-    info: (message?: any, ...optionalParams: any[]) => void;
+    info: (message?: unknown, ...optionalParams: unknown[]) => void;
     // (undocumented)
-    warn: (message?: any, ...optionalParams: any[]) => void;
+    warn: (message?: unknown, ...optionalParams: unknown[]) => void;
 }
 
 // @public

--- a/exports/root/report.api.md
+++ b/exports/root/report.api.md
@@ -145,9 +145,9 @@ export const FormatterBuilder: {
     build(FormatterConstructor: string | typeof Formatter, options: IBuildOptions): Promise<Formatter>;
     getConstructorByType(type: string, cwd: string): Promise<typeof Formatter>;
     getStepDefinitionSnippetBuilder(input: IGetStepDefinitionSnippetBuilderOptions): Promise<StepDefinitionSnippetBuilder>;
-    loadCustomClass(type: "formatter" | "syntax", descriptor: string, cwd: string): Promise<any>;
+    loadCustomClass<T extends Function>(type: "formatter" | "syntax", descriptor: string, cwd: string): Promise<T>;
     loadFile(urlOrName: URL | string): Promise<any>;
-    resolveConstructor(ImportedCode: any): any;
+    resolveConstructor(ImportedCode: unknown): Function | null;
 };
 
 declare namespace formatterHelpers {
@@ -378,15 +378,15 @@ export interface IWorldOptions<ParametersType = any> {
 export class JsonFormatter extends Formatter {
     constructor(options: IFormatterOptions);
     // (undocumented)
-    convertNameToId(obj: Feature | Pickle): string;
+    convertNameToId(obj: Feature | Rule | Pickle): string;
     // (undocumented)
     static readonly documentation: string;
     // (undocumented)
-    formatDataTable(dataTable: PickleTable): any;
+    formatDataTable(dataTable: PickleTable): IJsonDataTable;
     // (undocumented)
-    formatDocString(docString: PickleDocString, gherkinStep: Step): any;
+    formatDocString(docString: PickleDocString, gherkinStep: Step): IJsonDocString;
     // (undocumented)
-    formatStepArgument(stepArgument: PickleStepArgument, gherkinStep: Step): any;
+    formatStepArgument(stepArgument: PickleStepArgument, gherkinStep: Step): IJsonStepArgument[];
     // (undocumented)
     getFeatureData(input: IBuildJsonFeatureOptions): IJsonFeature;
     // (undocumented)
@@ -532,7 +532,7 @@ export class UsageJsonFormatter extends Formatter {
     // (undocumented)
     logUsage(): void;
     // (undocumented)
-    replacer(key: string, value: any): any;
+    replacer(key: string, value: unknown): unknown;
 }
 
 // @public (undocumented)

--- a/features/step_definitions/cli_steps.ts
+++ b/features/step_definitions/cli_steps.ts
@@ -67,7 +67,9 @@ When(
 Then('it passes', () => {})
 
 Then('it fails', function (this: World) {
-  const actualCode: number = doesHaveValue(this.lastRun.error) ? this.lastRun.error.code : 0
+  const actualCode: number | string = doesHaveValue(this.lastRun.error)
+    ? this.lastRun.error.code
+    : 0
 
   expect(actualCode).not.to.eql(0, `Expected non-zero exit status, but got ${actualCode}`)
   this.verifiedLastRunError = true

--- a/features/support/warn_user_about_enabling_developer_mode.ts
+++ b/features/support/warn_user_about_enabling_developer_mode.ts
@@ -1,8 +1,8 @@
 import { styleText } from 'node:util'
 import { reindent } from 'reindent-template-literals'
 
-export function warnUserAboutEnablingDeveloperMode(error: any): void {
-  if (!(error?.code === 'EPERM')) {
+export function warnUserAboutEnablingDeveloperMode(error: unknown): void {
+  if (!((error as NodeJS.ErrnoException)?.code === 'EPERM')) {
     throw error
   }
   if (!(process.platform === 'win32')) {

--- a/features/support/world.ts
+++ b/features/support/world.ts
@@ -17,15 +17,22 @@ import type FakeReportServer from '../../test/fake_report_server'
 
 const asyncPipeline = util.promisify(pipeline)
 
+/**
+ * An error from a cucumber run, carrying the exit code (or a spawn failure code)
+ */
+export interface RunError extends Error {
+  code?: number | string
+}
+
 interface ILastRun {
-  error: any
+  error?: RunError
   errorOutput: string
   envelopes: Envelope[]
   output: string
 }
 
 interface IRunResult {
-  error: any
+  error?: RunError
   stderr: string
   stdout: string
 }
@@ -81,7 +88,7 @@ export class World {
       const stdout = new PassThrough()
       const stderr = new PassThrough()
       const environment: IRunEnvironment = { cwd, stdout, stderr }
-      let error: any
+      let error: RunError
       for (const key of Object.keys(envOverride)) {
         process.env[key] = envOverride[key]
       }

--- a/src/api/formatters.ts
+++ b/src/api/formatters.ts
@@ -66,7 +66,7 @@ export async function initializeFormatters({
         cleanup:
           stream === stdout
             ? async () => await Promise.resolve()
-            : promisify<any>(stream.end.bind(stream)),
+            : promisify<void>(stream.end.bind(stream)),
         supportCodeLibrary,
       }
       const formatter = await FormatterBuilder.build(implementation, typeOptions)
@@ -80,7 +80,7 @@ export async function initializeFormatters({
         directory
       )
       if (stream !== stdout) {
-        cleanupFns.push(promisify<any>(stream.end.bind(stream)))
+        cleanupFns.push(promisify<void>(stream.end.bind(stream)))
       }
     }
   }

--- a/src/api/plugins.ts
+++ b/src/api/plugins.ts
@@ -8,7 +8,7 @@ import shardingPlugin from '../sharding'
 import { doesNotHaveValue } from '../value_checker'
 import type { IRunConfiguration, ISourcesCoordinates } from './types'
 
-async function importPlugin(specifier: string, cwd: string): Promise<any> {
+async function importPlugin(specifier: string, cwd: string): Promise<unknown> {
   try {
     let normalized: URL | string = specifier
     if (specifier.startsWith('.')) {
@@ -24,20 +24,20 @@ async function importPlugin(specifier: string, cwd: string): Promise<any> {
   }
 }
 
-function findPlugin(imported: any): Plugin | null {
+function findPlugin(imported: unknown): Plugin | null {
   return findPluginRecursive(imported, 3)
 }
 
-function findPluginRecursive(thing: any, depth: number): Plugin | null {
+function findPluginRecursive(thing: unknown, depth: number): Plugin | null {
   if (doesNotHaveValue(thing)) {
     return null
   }
-  if (typeof thing === 'object' && thing.type === 'plugin') {
-    return thing
+  if (typeof thing === 'object' && (thing as Plugin).type === 'plugin') {
+    return thing as Plugin
   }
   depth--
   if (depth > 0) {
-    return findPluginRecursive(thing.default, depth)
+    return findPluginRecursive((thing as { default?: unknown }).default, depth)
   }
   return null
 }

--- a/src/configuration/check_schema.ts
+++ b/src/configuration/check_schema.ts
@@ -46,7 +46,7 @@ const schema = yup.object().shape({
   worldParameters: yup.object(),
 })
 
-export function checkSchema(configuration: any): Partial<IConfiguration> {
+export function checkSchema(configuration: unknown): Partial<IConfiguration> {
   return schema.validateSync(configuration, {
     abortEarly: false,
     strict: true,

--- a/src/configuration/from_file.ts
+++ b/src/configuration/from_file.ts
@@ -60,9 +60,9 @@ export async function fromFile(
 }
 
 async function handleDefaultFunctionDefinition(
-  definitions: Record<string, any>,
+  definitions: Record<string, unknown>,
   defaultDefinition: Function
-): Promise<Record<string, any>> {
+): Promise<Record<string, unknown>> {
   if (Object.keys(definitions).length > 1) {
     throw new Error(
       'Invalid profiles specified: if a default function definition is provided, no other static profiles should be specified'
@@ -77,13 +77,17 @@ async function handleDefaultFunctionDefinition(
   }
 }
 
-async function loadFile(logger: ILogger, cwd: string, file: string): Promise<Record<string, any>> {
+async function loadFile(
+  logger: ILogger,
+  cwd: string,
+  file: string
+): Promise<Record<string, unknown>> {
   const filePath: string = path.join(cwd, file)
   const extension = path.extname(filePath)
   if (!SUPPORTED_EXTENSIONS.includes(extension)) {
     throw new Error(`Unsupported configuration file extension "${extension}"`)
   }
-  let definitions: any
+  let definitions: Record<string, unknown>
   try {
     switch (extension) {
       case '.json':

--- a/src/configuration/merge_configurations.ts
+++ b/src/configuration/merge_configurations.ts
@@ -4,7 +4,7 @@ import type { IConfiguration } from './types'
 const ADDITIVE_ARRAYS = ['format', 'import', 'loader', 'name', 'paths', 'require', 'requireModule']
 const TAG_EXPRESSIONS = ['tags', 'retryTagFilter']
 
-function mergeArrays(objValue: any[], srcValue: any[]) {
+function mergeArrays(objValue: unknown[], srcValue: unknown[]) {
   if (objValue && srcValue) {
     return [].concat(objValue, srcValue)
   }
@@ -25,12 +25,12 @@ function wrapTagExpression(raw: string) {
   return `(${raw})`
 }
 
-function customizer(objValue: any, srcValue: any, key: string): any {
+function customizer(objValue: unknown, srcValue: unknown, key: string): unknown {
   if (ADDITIVE_ARRAYS.includes(key)) {
-    return mergeArrays(objValue, srcValue)
+    return mergeArrays(objValue as unknown[], srcValue as unknown[])
   }
   if (TAG_EXPRESSIONS.includes(key)) {
-    return mergeTagExpressions(objValue, srcValue)
+    return mergeTagExpressions(objValue as string, srcValue as string)
   }
   return undefined
 }

--- a/src/environment/console_logger.ts
+++ b/src/environment/console_logger.ts
@@ -12,21 +12,21 @@ export class ConsoleLogger implements ILogger {
     this.console = new Console(this.stream)
   }
 
-  debug(message?: any, ...optionalParams: any[]): void {
+  debug(message?: unknown, ...optionalParams: unknown[]): void {
     if (this.debugEnabled) {
       this.console.debug(message, ...optionalParams)
     }
   }
 
-  error(message?: any, ...optionalParams: any[]): void {
+  error(message?: unknown, ...optionalParams: unknown[]): void {
     this.console.error(message, ...optionalParams)
   }
 
-  warn(message?: any, ...optionalParams: any[]): void {
+  warn(message?: unknown, ...optionalParams: unknown[]): void {
     this.console.warn(message, ...optionalParams)
   }
 
-  info(message?: any, ...optionalParams: any[]): void {
+  info(message?: unknown, ...optionalParams: unknown[]): void {
     this.console.info(message, ...optionalParams)
   }
 }

--- a/src/environment/types.ts
+++ b/src/environment/types.ts
@@ -7,10 +7,10 @@ import type { Writable } from 'node:stream'
  * Matches the interface of Node.js Console, for the methods it has.
  */
 export interface ILogger {
-  debug: (message?: any, ...optionalParams: any[]) => void
-  error: (message?: any, ...optionalParams: any[]) => void
-  warn: (message?: any, ...optionalParams: any[]) => void
-  info: (message?: any, ...optionalParams: any[]) => void
+  debug: (message?: unknown, ...optionalParams: unknown[]) => void
+  error: (message?: unknown, ...optionalParams: unknown[]) => void
+  warn: (message?: unknown, ...optionalParams: unknown[]) => void
+  info: (message?: unknown, ...optionalParams: unknown[]) => void
 }
 
 /**

--- a/src/formatter/builder.ts
+++ b/src/formatter/builder.ts
@@ -61,7 +61,7 @@ const FormatterBuilder = {
 
     return formatters[type]
       ? formatters[type]
-      : await FormatterBuilder.loadCustomClass('formatter', type, cwd)
+      : await FormatterBuilder.loadCustomClass<typeof Formatter>('formatter', type, cwd)
   },
 
   async getStepDefinitionSnippetBuilder({
@@ -75,7 +75,11 @@ const FormatterBuilder = {
     }
     let Syntax = JavascriptSnippetSyntax
     if (doesHaveValue(snippetSyntax)) {
-      Syntax = await FormatterBuilder.loadCustomClass('syntax', snippetSyntax, cwd)
+      Syntax = await FormatterBuilder.loadCustomClass<typeof JavascriptSnippetSyntax>(
+        'syntax',
+        snippetSyntax,
+        cwd
+      )
     }
     return new StepDefinitionSnippetBuilder({
       snippetSyntax: new Syntax(snippetInterface),
@@ -83,10 +87,14 @@ const FormatterBuilder = {
     })
   },
 
-  async loadCustomClass(type: 'formatter' | 'syntax', descriptor: string, cwd: string) {
+  async loadCustomClass<T extends Function>(
+    type: 'formatter' | 'syntax',
+    descriptor: string,
+    cwd: string
+  ): Promise<T> {
     const CustomClass = FormatterBuilder.resolveConstructor(await importCode(descriptor, cwd))
     if (doesHaveValue(CustomClass)) {
-      return CustomClass
+      return CustomClass as T
     } else {
       throw new Error(`Custom ${type} (${descriptor}) does not export a function/class`)
     }
@@ -96,19 +104,21 @@ const FormatterBuilder = {
     return await import(urlOrName.toString())
   },
 
-  resolveConstructor(ImportedCode: any) {
+  resolveConstructor(ImportedCode: unknown): Function | null {
     if (doesNotHaveValue(ImportedCode)) {
       return null
     }
     if (typeof ImportedCode === 'function') {
       return ImportedCode
-    } else if (typeof ImportedCode === 'object' && typeof ImportedCode.default === 'function') {
-      return ImportedCode.default
+    }
+    const { default: defaultExport } = ImportedCode as { default?: unknown }
+    if (typeof ImportedCode === 'object' && typeof defaultExport === 'function') {
+      return defaultExport
     } else if (
-      typeof ImportedCode.default === 'object' &&
-      typeof ImportedCode.default.default === 'function'
+      typeof defaultExport === 'object' &&
+      typeof (defaultExport as { default?: unknown })?.default === 'function'
     ) {
-      return ImportedCode.default.default
+      return (defaultExport as { default: Function }).default
     }
     return null
   },

--- a/src/formatter/find_class_or_plugin.ts
+++ b/src/formatter/find_class_or_plugin.ts
@@ -1,22 +1,24 @@
+import type { FormatterPlugin } from '../plugin'
 import { doesNotHaveValue } from '../value_checker'
+import type { FormatterImplementation } from './index'
 
-export function findClassOrPlugin(imported: any) {
+export function findClassOrPlugin(imported: unknown): FormatterImplementation | null {
   return findRecursive(imported, 3)
 }
 
-function findRecursive(thing: any, depth: number): any {
+function findRecursive(thing: unknown, depth: number): FormatterImplementation | null {
   if (doesNotHaveValue(thing)) {
     return null
   }
   if (typeof thing === 'function') {
-    return thing
+    return thing as FormatterImplementation
   }
-  if (typeof thing === 'object' && thing.type === 'formatter') {
-    return thing
+  if (typeof thing === 'object' && (thing as FormatterPlugin).type === 'formatter') {
+    return thing as FormatterImplementation
   }
   depth--
   if (depth > 0) {
-    return findRecursive(thing.default, depth)
+    return findRecursive((thing as { default?: unknown }).default, depth)
   }
   return null
 }

--- a/src/formatter/helpers/test_case_attempt_parser.ts
+++ b/src/formatter/helpers/test_case_attempt_parser.ts
@@ -157,7 +157,7 @@ export function parseTestCaseAttempt({
 
     isBeforeHook = isBeforeHook && doesHaveValue(testStep.hookId)
 
-    let keyword: any, keywordType: any, pickleStep: any
+    let keyword: string, keywordType: KeywordType, pickleStep: PickleStep
     if (doesHaveValue(testStep.pickleStepId)) {
       pickleStep = pickleStepMap[testStep.pickleStepId]
       keyword = getStepKeyword({ pickleStep, gherkinStepMap })

--- a/src/formatter/import_code.ts
+++ b/src/formatter/import_code.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-export async function importCode(specifier: string, cwd: string): Promise<any> {
+export async function importCode(specifier: string, cwd: string): Promise<unknown> {
   try {
     let normalized: URL | string = specifier
     if (specifier.startsWith('.')) {

--- a/src/formatter/index.ts
+++ b/src/formatter/index.ts
@@ -36,13 +36,14 @@ export interface FormatOptions {
   snippetInterface?: SnippetInterface
   snippetSyntax?: string
   theme?: Theme
+  // biome-ignore lint/suspicious/noExplicitAny: custom formatter options are arbitrary and read directly by formatter code
   [customKey: string]: any
 }
 
 export type FormatterImplementation = typeof Formatter | FormatterPlugin
 export type IFormatterStream = Writable
 export type IFormatterLogFn = (buffer: string | Uint8Array) => void
-export type IFormatterCleanupFn = () => Promise<any>
+export type IFormatterCleanupFn = () => Promise<unknown>
 
 export interface IFormatterOptions {
   colorFns: IColorFns

--- a/src/formatter/json_formatter.ts
+++ b/src/formatter/json_formatter.ts
@@ -55,15 +55,41 @@ export interface IJsonScenario {
   type: string
 }
 
+export interface IJsonDataTable {
+  rows: Array<{ cells: string[] }>
+}
+
+export interface IJsonDocString {
+  content: string
+  line: number
+}
+
+export type IJsonStepArgument = IJsonDataTable | IJsonDocString
+
+export interface IJsonEmbedding {
+  data: string
+  mime_type: string
+}
+
+export interface IJsonStepMatch {
+  location: string
+}
+
+export interface IJsonStepResult {
+  status: string
+  duration?: number
+  error_message?: string
+}
+
 export interface IJsonStep {
-  arguments?: any // TODO
-  embeddings?: any // TODO
+  arguments?: IJsonStepArgument[]
+  embeddings?: IJsonEmbedding[]
   hidden?: boolean
   keyword?: string // TODO, not optional
   line?: number
-  match?: any // TODO
+  match?: IJsonStepMatch
   name?: string
-  result?: any // TODO
+  result: IJsonStepResult
 }
 
 export interface IJsonTag {
@@ -112,11 +138,11 @@ export default class JsonFormatter extends Formatter {
     })
   }
 
-  convertNameToId(obj: Feature | Pickle): string {
+  convertNameToId(obj: Feature | Rule | Pickle): string {
     return obj.name.replace(/ /g, '-').toLowerCase()
   }
 
-  formatDataTable(dataTable: PickleTable): any {
+  formatDataTable(dataTable: PickleTable): IJsonDataTable {
     return {
       rows: dataTable.rows.map((row) => ({
         cells: row.cells.map((x) => x.value),
@@ -124,19 +150,19 @@ export default class JsonFormatter extends Formatter {
     }
   }
 
-  formatDocString(docString: PickleDocString, gherkinStep: Step): any {
+  formatDocString(docString: PickleDocString, gherkinStep: Step): IJsonDocString {
     return {
       content: docString.content,
       line: gherkinStep.docString.location.line,
     }
   }
 
-  formatStepArgument(stepArgument: PickleStepArgument, gherkinStep: Step): any {
+  formatStepArgument(stepArgument: PickleStepArgument, gherkinStep: Step): IJsonStepArgument[] {
     if (doesNotHaveValue(stepArgument)) {
       return []
     }
     return [
-      parseStepArgument<any>(stepArgument, {
+      parseStepArgument<IJsonStepArgument>(stepArgument, {
         dataTable: (dataTable) => this.formatDataTable(dataTable),
         docString: (docString) => this.formatDocString(docString, gherkinStep),
       }),
@@ -240,7 +266,7 @@ export default class JsonFormatter extends Formatter {
     pickle: Pickle
     gherkinExampleRuleMap: Record<string, Rule>
   }): string {
-    let parts: any[]
+    let parts: Array<Feature | Rule | Pickle>
     const rule = gherkinExampleRuleMap[pickle.astNodeIds[0]]
     if (doesHaveValue(rule)) {
       parts = [feature, rule, pickle]
@@ -258,7 +284,11 @@ export default class JsonFormatter extends Formatter {
     testStepAttachments,
     testStepResult,
   }: IBuildJsonStepOptions): IJsonStep {
-    const data: IJsonStep = {}
+    const data: IJsonStep = {
+      result: {
+        status: TestStepResultStatus[testStepResult.status].toLowerCase(),
+      },
+    }
     if (doesHaveValue(testStep.pickleStepId)) {
       const pickleStep = pickleStepMap[testStep.pickleStepId]
       data.arguments = this.formatStepArgument(
@@ -279,9 +309,6 @@ export default class JsonFormatter extends Formatter {
       data.match = { location: formatLocation(stepDefinition) }
     }
     const { message, status } = testStepResult
-    data.result = {
-      status: TestStepResultStatus[status].toLowerCase(),
-    }
     if (doesHaveValue(testStepResult.duration)) {
       data.result.duration = durationToNanoseconds(testStepResult.duration)
     }

--- a/src/formatter/usage_formatter.ts
+++ b/src/formatter/usage_formatter.ts
@@ -64,7 +64,7 @@ export default class UsageFormatter extends Formatter {
       if (matches.length > 5) {
         col1.push(`  ${(matches.length - 5).toString()} more`)
       }
-      table.push([col1.join('\n'), col2.join('\n'), col3.join('\n')] as any)
+      table.push([col1.join('\n'), col2.join('\n'), col3.join('\n')])
     })
     this.log(`${table.toString()}\n`)
   }

--- a/src/formatter/usage_json_formatter.ts
+++ b/src/formatter/usage_json_formatter.ts
@@ -26,9 +26,9 @@ export default class UsageJsonFormatter extends Formatter {
     this.log(JSON.stringify(usage, this.replacer, 2))
   }
 
-  replacer(key: string, value: any): any {
+  replacer(key: string, value: unknown): unknown {
     if (key === 'seconds') {
-      return parseInt(value, 10)
+      return parseInt(value as string, 10)
     }
     return value
   }

--- a/src/models/definition.ts
+++ b/src/models/definition.ts
@@ -6,17 +6,20 @@ import type { GherkinStepKeyword } from './gherkin_step_keyword'
 export interface IGetInvocationDataRequest {
   hookParameter: ITestCaseHookParameter
   step: PickleStep
+  // biome-ignore lint/suspicious/noExplicitAny: the world is an instance of a user-supplied constructor, so it really can be anything
   world: any
 }
 
 export interface IGetInvocationDataResponse {
   getInvalidCodeLengthMessage: () => string
+  // biome-ignore lint/suspicious/noExplicitAny: step arguments are whatever the parameter types produce
   parameters: any[]
   validCodeLengths: number[]
 }
 
 export interface IDefinitionOptions {
   timeout?: number
+  // biome-ignore lint/suspicious/noExplicitAny: opaque to us; passed straight through to the user's definition function wrapper
   wrapperOptions?: any
 }
 
@@ -93,7 +96,7 @@ export default abstract class Definition {
     )
   }
 
-  baseGetInvalidCodeLengthMessage(parameters: any[]): string {
+  baseGetInvalidCodeLengthMessage(parameters: unknown[]): string {
     return this.buildInvalidCodeLengthMessage(parameters.length, parameters.length + 1)
   }
 }

--- a/src/models/step_definition.ts
+++ b/src/models/step_definition.ts
@@ -30,7 +30,7 @@ export default class StepDefinition extends Definition implements IDefinition {
       this.expression.match(step.text).map((arg) => arg.getValue(world))
     )
     if (doesHaveValue(step.argument)) {
-      const argumentParameter = parseStepArgument<any>(step.argument, {
+      const argumentParameter = parseStepArgument<DataTable | string>(step.argument, {
         dataTable: (arg) => new DataTable(arg),
         docString: (arg) => arg.content,
       })

--- a/src/plugin/plugin_manager.ts
+++ b/src/plugin/plugin_manager.ts
@@ -90,7 +90,8 @@ export class PluginManager {
     const cleanupFn = await plugin.formatter({
       on: (key, handler) => this.registerHandler(key, handler, specifier),
       options: plugin.optionsKey
-        ? ((options as any)[plugin.optionsKey] ?? ({} as OptionsType))
+        ? (((options as Record<string, unknown>)[plugin.optionsKey] as OptionsType) ??
+          ({} as OptionsType))
         : options,
       logger: this.environment.logger,
       stream,
@@ -160,7 +161,8 @@ export class PluginManager {
       ) => this.registerTransformer(event, transformer, specifier),
       options:
         'optionsKey' in plugin && plugin.optionsKey
-          ? ((options as any)[plugin.optionsKey] ?? ({} as OptionsType))
+          ? (((options as Record<string, unknown>)[plugin.optionsKey] as OptionsType) ??
+            ({} as OptionsType))
           : options,
       logger: this.environment.logger,
       environment: {

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -137,6 +137,7 @@ export type PluginCleanup = () => PromiseLike<void> | void
  * A plugin that can subscribe to events and register transforms
  * @public
  */
+// biome-ignore lint/suspicious/noExplicitAny: options are defined by the plugin itself and really can be anything; plugins can supply a type argument to narrow
 export type Plugin<OptionsType = any> = {
   type: 'plugin'
   /**
@@ -169,6 +170,7 @@ export type InternalCoordinatorContext<OptionsType> = CoordinatorContext<Options
  * A built-in plugin with the additional ability to emit events
  * @internal
  */
+// biome-ignore lint/suspicious/noExplicitAny: options are defined by the plugin itself and really can be anything; plugins can supply a type argument to narrow
 export type InternalPlugin<OptionsType = any> = {
   type: 'plugin'
   coordinator: (
@@ -223,6 +225,7 @@ export type FormatterPluginContext<OptionsType> = {
  * A plugin that consumes Cucumber Messages and writes formatted output to a stream
  * @public
  */
+// biome-ignore lint/suspicious/noExplicitAny: options are defined by the plugin itself and really can be anything; plugins can supply a type argument to narrow
 export type FormatterPlugin<OptionsType = any> = {
   type: 'formatter'
   /**

--- a/src/runtime/scope/make_proxy.ts
+++ b/src/runtime/scope/make_proxy.ts
@@ -1,4 +1,4 @@
-export function makeProxy<T>(getThing: () => any): T {
+export function makeProxy<T extends object>(getThing: () => T): T {
   return new Proxy(
     {},
     {
@@ -6,7 +6,7 @@ export function makeProxy<T>(getThing: () => any): T {
         return Reflect.defineProperty(getThing(), property, attributes)
       },
       deleteProperty(_, property) {
-        return Reflect.get(getThing(), property)
+        return Reflect.deleteProperty(getThing(), property)
       },
       get(_, property) {
         return Reflect.get(getThing(), property, getThing())

--- a/src/runtime/scope/test_case_scope.ts
+++ b/src/runtime/scope/test_case_scope.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 import type { IWorld } from '../../support_code_library_builder/world'
 import { makeProxy } from './make_proxy'
 
+// biome-ignore lint/suspicious/noExplicitAny: world parameters come from user config and really can be anything; this internal default mirrors the public IWorld/IContext generic
 interface TestCaseScopeStore<ParametersType = any> {
   world: IWorld<ParametersType>
 }
@@ -15,6 +16,7 @@ export async function runInTestCaseScope<ResponseType>(
   return testCaseScope.run(store, callback)
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: world parameters come from user config and really can be anything; this internal default mirrors the public IWorld/IContext generic
 function getWorld<ParametersType = any>(): IWorld<ParametersType> {
   const store = testCaseScope.getStore()
   if (!store) {

--- a/src/runtime/scope/test_run_scope.ts
+++ b/src/runtime/scope/test_run_scope.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 import type { IContext } from '../../support_code_library_builder/context'
 import { makeProxy } from './make_proxy'
 
+// biome-ignore lint/suspicious/noExplicitAny: world parameters come from user config and really can be anything; this internal default mirrors the public IWorld/IContext generic
 interface TestRunScopeStore<ParametersType = any> {
   context: IContext<ParametersType>
 }
@@ -15,6 +16,7 @@ export async function runInTestRunScope<ResponseType>(
   return testRunScope.run(store, callback)
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: world parameters come from user config and really can be anything; this internal default mirrors the public IWorld/IContext generic
 function getContext<ParametersType = any>(): IContext<ParametersType> {
   const store = testRunScope.getStore()
   if (!store) {

--- a/src/runtime/step_runner.ts
+++ b/src/runtime/step_runner.ts
@@ -13,12 +13,13 @@ export interface IRunOptions {
   hookParameter: ITestCaseHookParameter
   step: PickleStep
   stepDefinition: IDefinition
+  // biome-ignore lint/suspicious/noExplicitAny: the world is an instance of a user-supplied constructor, so it really can be anything
   world: any
 }
 
 export interface RunStepResult {
   result: TestStepResult
-  error?: any
+  error?: unknown
 }
 
 export async function run({
@@ -30,7 +31,7 @@ export async function run({
   world,
 }: IRunOptions): Promise<RunStepResult> {
   const stopwatch = create().start()
-  let error: any, result: any, invocationData: IGetInvocationDataResponse
+  let error: unknown, result: unknown, invocationData: IGetInvocationDataResponse
 
   try {
     await runInTestCaseScope({ world }, async () => {
@@ -77,7 +78,9 @@ export async function run({
   }
 
   if (doesHaveValue(error)) {
-    details = formatError(error, filterStackTraces)
+    // UserCodeRunner normalises to Error|string, but a value thrown from
+    // getInvocationParameters is unconstrained
+    details = formatError(error as Error | string, filterStackTraces)
   }
 
   return {

--- a/src/runtime/test_case_runner.ts
+++ b/src/runtime/test_case_runner.ts
@@ -61,6 +61,7 @@ export default class TestCaseRunner {
   private readonly supportCodeLibrary: SupportCodeLibrary
   private readonly snippetBuilder: StepDefinitionSnippetBuilder
   private testStepResults: TestStepResult[]
+  // biome-ignore lint/suspicious/noExplicitAny: the world is an instance of a user-supplied constructor, so it really can be anything
   private world: any
   private readonly worldParameters: JsonObject
 
@@ -229,7 +230,7 @@ export default class TestCaseRunner {
     this.eventBroadcaster.emit('envelope', testCaseStarted)
     // used to determine whether a hook is a Before or After
     let didWeRunStepsYet = false
-    let error = false
+    let error: unknown = false
     for (const testStep of this.testCase.testSteps) {
       await this.aroundTestStep(testStep.id, async () => {
         if (doesHaveValue(testStep.hookId)) {
@@ -355,8 +356,8 @@ export default class TestCaseRunner {
       }
     }
 
-    let stepResult: any
-    let error: any
+    let stepResult: RunStepResult
+    let error: unknown
     let stepResults = await this.runStepHooks(this.getBeforeStepHookDefinitions(), pickleStep)
     if (getWorstTestStepResult(stepResults).status !== TestStepResultStatus.FAILED) {
       stepResult = await this.invokeStep(pickleStep, stepDefinitions[0])

--- a/src/support_code_library_builder/build_parameter_type.ts
+++ b/src/support_code_library_builder/build_parameter_type.ts
@@ -7,6 +7,7 @@ export function buildParameterType({
   transformer,
   useForSnippets,
   preferForRegexpMatch,
+  // biome-ignore lint/suspicious/noExplicitAny: the transformer returns whatever type the user's parameter type produces
 }: IParameterTypeDefinition<any>): ParameterType<any> {
   if (typeof useForSnippets !== 'boolean') {
     useForSnippets = true

--- a/src/support_code_library_builder/context.ts
+++ b/src/support_code_library_builder/context.ts
@@ -1,3 +1,4 @@
+// biome-ignore lint/suspicious/noExplicitAny: world parameters come from user config and really can be anything; users can supply a type argument to narrow
 export interface IContext<ParametersType = any> {
   readonly parameters: ParametersType
 }

--- a/src/support_code_library_builder/index.ts
+++ b/src/support_code_library_builder/index.ts
@@ -1,4 +1,8 @@
-import { CucumberExpression, RegularExpression } from '@cucumber/cucumber-expressions'
+import {
+  CucumberExpression,
+  type Expression,
+  RegularExpression,
+} from '@cucumber/cucumber-expressions'
 import type { IdGenerator, UndefinedParameterType } from '@cucumber/messages'
 import arity from 'util-arity'
 import { formatLocation } from '../formatter/helpers'
@@ -35,7 +39,7 @@ import World from './world'
 interface IStepDefinitionConfig {
   code: Function
   line: number
-  options: any
+  options: IDefineStepOptions
   order: number
   keyword: GherkinStepKeyword
   pattern: string | RegExp
@@ -43,9 +47,9 @@ interface IStepDefinitionConfig {
 }
 
 interface ITestCaseHookDefinitionConfig {
-  code: any
+  code: Function
   line: number
-  options: any
+  options: IDefineTestCaseHookOptions
   order: number
   uri: string
 }
@@ -53,7 +57,7 @@ interface ITestCaseHookDefinitionConfig {
 interface ITestStepHookDefinitionConfig {
   code: Function
   line: number
-  options: any
+  options: IDefineTestStepHookOptions
   order: number
   uri: string
 }
@@ -61,7 +65,7 @@ interface ITestStepHookDefinitionConfig {
 interface ITestRunHookDefinitionConfig {
   code: Function
   line: number
-  options: any
+  options: IDefineTestRunHookOptions
   order: number
   uri: string
 }
@@ -79,11 +83,13 @@ export class SupportCodeLibraryBuilder {
   private beforeTestStepHookDefinitionConfigs: ITestStepHookDefinitionConfig[]
   private cwd: string
   private defaultTimeout: number
+  // biome-ignore lint/suspicious/noExplicitAny: a user-supplied function whose shape we deliberately do not constrain
   private definitionFunctionWrapper: any
   private definitionOrder: number
   private newId: IdGenerator.NewId
   private parameterTypeRegistry: SourcedParameterTypeRegistry
   private stepDefinitionConfigs: IStepDefinitionConfig[]
+  // biome-ignore lint/suspicious/noExplicitAny: the world is a user-supplied constructor, so it really can be anything
   private World: any
   private parallelCanAssign: ParallelAssignmentValidator
   private status: LibraryStatus = 'PENDING'
@@ -129,8 +135,8 @@ export class SupportCodeLibraryBuilder {
       }
     }
     this.methods = new Proxy(methods, {
-      get(target: IDefineSupportCodeMethods, method: keyof IDefineSupportCodeMethods): any {
-        return (...args: any[]) => {
+      get(target: IDefineSupportCodeMethods, method: keyof IDefineSupportCodeMethods): unknown {
+        return (...args: unknown[]) => {
           checkInstall(method)
           // @ts-expect-error difficult to type this correctly
           return target[method](...args)
@@ -139,6 +145,7 @@ export class SupportCodeLibraryBuilder {
     })
   }
 
+  // biome-ignore lint/suspicious/noExplicitAny: the transformer returns whatever type the user's parameter type produces
   defineParameterType(options: IParameterTypeDefinition<any>): void {
     const parameterType = buildParameterType(options)
     const source = getDefinitionLineAndUri(this.cwd)
@@ -268,7 +275,8 @@ export class SupportCodeLibraryBuilder {
     }
   }
 
-  wrapCode({ code, wrapperOptions }: { code: Function; wrapperOptions: any }): Function {
+  // biome-ignore lint/suspicious/noExplicitAny: opaque to us; passed straight through to the user's definition function wrapper
+  wrapCode({ code, wrapperOptions }: { code: Function; wrapperOptions?: any }): Function {
     if (doesHaveValue(this.definitionFunctionWrapper)) {
       const codeLength = code.length
       const wrappedCode = this.definitionFunctionWrapper(code, wrapperOptions)
@@ -285,10 +293,7 @@ export class SupportCodeLibraryBuilder {
     canonicalIds?: string[]
   ): TestCaseHookDefinition[] {
     return configs.map(({ code, line, options, order, uri }, index) => {
-      const wrappedCode = this.wrapCode({
-        code,
-        wrapperOptions: options.wrapperOptions,
-      })
+      const wrappedCode = this.wrapCode({ code })
       return new TestCaseHookDefinition({
         code: wrappedCode,
         id: canonicalIds ? canonicalIds[index] : this.newId(),
@@ -303,10 +308,7 @@ export class SupportCodeLibraryBuilder {
 
   buildTestStepHookDefinitions(configs: ITestStepHookDefinitionConfig[]): TestStepHookDefinition[] {
     return configs.map(({ code, line, options, order, uri }) => {
-      const wrappedCode = this.wrapCode({
-        code,
-        wrapperOptions: options.wrapperOptions,
-      })
+      const wrappedCode = this.wrapCode({ code })
       return new TestStepHookDefinition({
         code: wrappedCode,
         id: this.newId(),
@@ -324,10 +326,7 @@ export class SupportCodeLibraryBuilder {
     canonicalIds?: string[]
   ): TestRunHookDefinition[] {
     return configs.map(({ code, line, options, order, uri }, index) => {
-      const wrappedCode = this.wrapCode({
-        code,
-        wrapperOptions: options.wrapperOptions,
-      })
+      const wrappedCode = this.wrapCode({ code })
       return new TestRunHookDefinition({
         code: wrappedCode,
         id: canonicalIds ? canonicalIds[index] : this.newId(),
@@ -348,7 +347,7 @@ export class SupportCodeLibraryBuilder {
     const undefinedParameterTypes: UndefinedParameterType[] = []
     this.stepDefinitionConfigs.forEach(
       ({ code, line, options, order, keyword, pattern, uri }, index) => {
-        let expression: any
+        let expression: Expression
         if (typeof pattern === 'string') {
           try {
             expression = new CucumberExpression(pattern, this.parameterTypeRegistry)

--- a/src/support_code_library_builder/types.ts
+++ b/src/support_code_library_builder/types.ts
@@ -24,6 +24,7 @@ export interface ITestCaseHookParameter {
   gherkinDocument: GherkinDocument
   pickle: Pickle
   result?: TestStepResult
+  // biome-ignore lint/suspicious/noExplicitAny: a thrown value really can be anything; users can narrow if they prefer
   error?: any
   willBeRetried?: boolean
   testCaseStartedId: string
@@ -34,6 +35,7 @@ export interface ITestStepHookParameter {
   pickle: Pickle
   pickleStep: PickleStep
   result: TestStepResult
+  // biome-ignore lint/suspicious/noExplicitAny: a thrown value really can be anything; users can narrow if they prefer
   error?: any
   testCaseStartedId: string
   testStepId: string
@@ -41,22 +43,27 @@ export interface ITestStepHookParameter {
 
 export type TestRunHookFunction = (this: {
   parameters: JsonObject
+  // biome-ignore lint/suspicious/noExplicitAny: user code can return anything, or a promise of anything; we only look for the skipped/pending sentinels
 }) => any | Promise<any>
 
 export type TestCaseHookFunction<WorldType> = (
   this: WorldType,
   arg: ITestCaseHookParameter
+  // biome-ignore lint/suspicious/noExplicitAny: user code can return anything, or a promise of anything; we only look for the skipped/pending sentinels
 ) => any | Promise<any>
 
 export type TestStepHookFunction<WorldType> = (
   this: WorldType,
   arg: ITestStepHookParameter
+  // biome-ignore lint/suspicious/noExplicitAny: user code can return anything, or a promise of anything; we only look for the skipped/pending sentinels
 ) => any | Promise<any>
 
+// biome-ignore lint/suspicious/noExplicitAny: step arguments are whatever the parameter types produce, and user code can return anything
 export type TestStepFunction<WorldType> = (this: WorldType, ...args: any[]) => any | Promise<any>
 
 export interface IDefineStepOptions {
   timeout?: number
+  // biome-ignore lint/suspicious/noExplicitAny: opaque to us; passed straight through to the user's definition function wrapper
   wrapperOptions?: any
 }
 
@@ -96,11 +103,13 @@ export type IDefineStep = (<WorldType = IWorld>(
   ) => void)
 
 export interface IDefineSupportCodeMethods {
+  // biome-ignore lint/suspicious/noExplicitAny: the transformer returns whatever type the user's parameter type produces
   defineParameterType: (options: IParameterTypeDefinition<any>) => void
   defineStep: IDefineStep
   setDefaultTimeout: (milliseconds: number) => void
   setDefinitionFunctionWrapper: (fn: Function) => void
   setParallelCanAssign: (fn: ParallelAssignmentValidator) => void
+  // biome-ignore lint/suspicious/noExplicitAny: accepts any user-supplied World constructor (a class or a plain function used with new)
   setWorldConstructor: (fn: any) => void
   After: (<WorldType = IWorld>(code: TestCaseHookFunction<WorldType>) => void) &
     (<WorldType = IWorld>(tags: string, code: TestCaseHookFunction<WorldType>) => void) &
@@ -162,6 +171,7 @@ export interface SupportCodeLibrary {
   readonly stepDefinitions: StepDefinition[]
   readonly undefinedParameterTypes: UndefinedParameterType[]
   readonly parameterTypeRegistry: SourcedParameterTypeRegistry
+  // biome-ignore lint/suspicious/noExplicitAny: the world is a user-supplied constructor, so instances really can be anything
   readonly World: any
   readonly parallelCanAssign: ParallelAssignmentValidator
 }

--- a/src/support_code_library_builder/validate_arguments.ts
+++ b/src/support_code_library_builder/validate_arguments.ts
@@ -3,7 +3,7 @@ import type { DefineStepPattern, IDefineStepOptions } from './types'
 interface IValidation {
   identifier: string
   expectedType: string
-  predicate: (args: any) => boolean
+  predicate: (args: unknown) => boolean
 }
 
 interface IDefineStepArguments {

--- a/src/support_code_library_builder/world.ts
+++ b/src/support_code_library_builder/world.ts
@@ -1,5 +1,6 @@
 import type { ICreateAttachment, ICreateLink, ICreateLog } from '../runtime/attachment_manager'
 
+// biome-ignore lint/suspicious/noExplicitAny: world parameters come from user config and really can be anything; users can supply a type argument to narrow
 export interface IWorldOptions<ParametersType = any> {
   attach: ICreateAttachment
   log: ICreateLog
@@ -7,15 +8,18 @@ export interface IWorldOptions<ParametersType = any> {
   parameters: ParametersType
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: world parameters come from user config and really can be anything; users can supply a type argument to narrow
 export interface IWorld<ParametersType = any> {
   readonly attach: ICreateAttachment
   readonly log: ICreateLog
   readonly link: ICreateLink
   readonly parameters: ParametersType
 
+  // biome-ignore lint/suspicious/noExplicitAny: user code attaches arbitrary properties to the world
   [key: string]: any
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: world parameters come from user config and really can be anything; users can supply a type argument to narrow
 export default class World<ParametersType = any> implements IWorld<ParametersType> {
   public readonly attach: ICreateAttachment
   public readonly log: ICreateLog

--- a/src/types/assertion-error-formatter/index.d.ts
+++ b/src/types/assertion-error-formatter/index.d.ts
@@ -1,3 +1,15 @@
 declare module 'assertion-error-formatter' {
-  export function format(error: Error, options?: any): string
+  type ColorFn = (value: string) => string
+
+  export interface FormatOptions {
+    colorFns?: {
+      diffAdded?: ColorFn
+      diffRemoved?: ColorFn
+      errorMessage?: ColorFn
+      errorStack?: ColorFn
+    }
+    inlineDiff?: boolean
+  }
+
+  export function format(error: Error, options?: FormatOptions): string
 }

--- a/src/types/stack-chain/index.d.ts
+++ b/src/types/stack-chain/index.d.ts
@@ -1,4 +1,0 @@
-declare module 'stack-chain' {
-  const _temp: any
-  export = _temp
-}

--- a/src/user_code_runner.ts
+++ b/src/user_code_runner.ts
@@ -4,15 +4,15 @@ import UncaughtExceptionManager from './uncaught_exception_manager'
 import { doesHaveValue } from './value_checker'
 
 export interface IRunRequest {
-  argsArray: any[]
-  thisArg: any
+  argsArray: unknown[]
+  thisArg: unknown
   fn: Function
   timeoutInMilliseconds: number
 }
 
 export interface IRunResponse {
-  error?: any
-  result?: any
+  error?: Error | string
+  result?: unknown
 }
 
 const UserCodeRunner = {
@@ -27,7 +27,7 @@ const UserCodeRunner = {
       })
     })
 
-    let fnReturn: any
+    let fnReturn: unknown
     try {
       fnReturn = fn.apply(thisArg, argsArray)
     } catch (e) {
@@ -35,9 +35,10 @@ const UserCodeRunner = {
       return { error }
     }
 
-    const racingPromises = []
+    const racingPromises: PromiseLike<unknown>[] = []
     const callbackInterface = fn.length === argsArray.length
-    const promiseInterface = doesHaveValue(fnReturn) && typeof fnReturn.then === 'function'
+    const promiseInterface =
+      doesHaveValue(fnReturn) && typeof (fnReturn as PromiseLike<unknown>).then === 'function'
 
     if (callbackInterface && promiseInterface) {
       return {
@@ -50,12 +51,12 @@ const UserCodeRunner = {
     } else if (callbackInterface) {
       racingPromises.push(callbackPromise)
     } else if (promiseInterface) {
-      racingPromises.push(fnReturn)
+      racingPromises.push(fnReturn as PromiseLike<unknown>)
     } else {
       return { result: fnReturn }
     }
 
-    let exceptionHandler: any
+    let exceptionHandler: NodeJS.UncaughtExceptionListener
     const uncaughtExceptionPromise = new Promise((_resolve, reject) => {
       exceptionHandler = reject
       UncaughtExceptionManager.registerHandler(exceptionHandler)
@@ -71,7 +72,7 @@ const UserCodeRunner = {
       finalPromise = wrapPromiseWithTimeout(finalPromise, timeoutInMilliseconds, timeoutMessage)
     }
 
-    let error: any, result: any
+    let error: Error | string, result: unknown
     try {
       result = await finalPromise
     } catch (e) {

--- a/src/user_code_runner_spec.ts
+++ b/src/user_code_runner_spec.ts
@@ -150,7 +150,7 @@ describe('UserCodeRunner', () => {
 
           // Assert
           expect(error).to.be.instanceof(Error)
-          expect(error.message).to.eql(
+          expect((error as Error).message).to.eql(
             'function timed out, ensure the callback is executed within 100 milliseconds'
           )
           expect(result).to.eql(undefined)
@@ -224,7 +224,7 @@ describe('UserCodeRunner', () => {
 
           // Assert
           expect(error).to.be.instanceOf(Error)
-          expect(error.message).to.eql('Promise rejected without a reason')
+          expect((error as Error).message).to.eql('Promise rejected without a reason')
           expect(result).to.eql(undefined)
         })
       })
@@ -242,7 +242,7 @@ describe('UserCodeRunner', () => {
 
           // Assert
           expect(error).to.be.instanceof(Error)
-          expect(error.message).to.eql(
+          expect((error as Error).message).to.eql(
             'function timed out, ensure the promise resolves within 100 milliseconds'
           )
           expect(result).to.eql(undefined)
@@ -283,7 +283,7 @@ describe('UserCodeRunner', () => {
 
         // Assert
         expect(error).to.be.instanceof(Error)
-        expect(error.message).to.eql(
+        expect((error as Error).message).to.eql(
           'function uses multiple asynchronous interfaces: callback and promise\n' +
             'to use the callback interface: do not return a promise\n' +
             'to use the promise interface: remove the last argument to the function'


### PR DESCRIPTION
### 🤔 What's changed?

Get rid of as many explicit usages of `any` as possible.

Also includes a small bug fix in our `world` proxy, which was not handling deletes properly.

### ⚡️ What's your motivation? 

Fixes #1648 

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
