### PR TITLE
test(time): use fake timers instead of real setTimeout waits

### DIFF
--- a/src/time_spec.ts
+++ b/src/time_spec.ts
@@ -1,19 +1,32 @@
+import FakeTimers, { type InstalledClock } from '@sinonjs/fake-timers'
 import { expect } from 'chai'
-import { describe, it } from 'mocha'
-import { wrapPromiseWithTimeout } from './time'
+import { afterEach, beforeEach, describe, it } from 'mocha'
+import timeMethods, { wrapPromiseWithTimeout } from './time'
 
 describe('wrapPromiseWithTimeout()', () => {
+  let clock: InstalledClock
+
+  beforeEach(() => {
+    clock = FakeTimers.withGlobal(timeMethods).install()
+  })
+
+  afterEach(() => {
+    clock.uninstall()
+  })
+
   describe('promise times out (default timeout message)', () => {
     it('rejects the promise', async () => {
       // Arrange
       const promise = new Promise((resolve) => {
-        setTimeout(resolve, 50)
+        timeMethods.setTimeout(resolve, 50)
       })
 
       // Act
+      const wrapped = wrapPromiseWithTimeout(promise, 25)
+      clock.tick(25)
       let error: Error = null
       try {
-        await wrapPromiseWithTimeout(promise, 25)
+        await wrapped
       } catch (e) {
         error = e
       }
@@ -28,13 +41,15 @@ describe('wrapPromiseWithTimeout()', () => {
     it('rejects the promise', async () => {
       // Arrange
       const promise = new Promise((resolve) => {
-        setTimeout(resolve, 50)
+        timeMethods.setTimeout(resolve, 50)
       })
 
       // Act
+      const wrapped = wrapPromiseWithTimeout(promise, 25, 'custom timeout message')
+      clock.tick(25)
       let error: Error = null
       try {
-        await wrapPromiseWithTimeout(promise, 25, 'custom timeout message')
+        await wrapped
       } catch (e) {
         error = e
       }
@@ -49,11 +64,13 @@ describe('wrapPromiseWithTimeout()', () => {
     it('resolves the promise', async () => {
       // Arrange
       const promise = new Promise<string>((resolve) => {
-        setTimeout(() => resolve('value'), 10)
+        timeMethods.setTimeout(() => resolve('value'), 10)
       })
 
       // Act
-      const result = await wrapPromiseWithTimeout(promise, 25)
+      const wrapped = wrapPromiseWithTimeout(promise, 25)
+      clock.tick(10)
+      const result = await wrapped
 
       // Assert
       expect(result).to.eql('value')


### PR DESCRIPTION
### 🤔 What's changed?

`time_spec.ts` drove `wrapPromiseWithTimeout()` with real `setTimeout` timers, so the "does not time out" case raced a 10ms resolve against a 25ms timeout. Switched to `@sinonjs/fake-timers`, same as #2874.

### ⚡️ What's your motivation?

That 10ms-vs-25ms case can flake under CI load.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the Cucumber Community Code of Conduct
- [ ] I've changed the behaviour of the code — no, test-only
- [ ] My change requires a change to the documentation
- [ ] Users should know about my change — no, no CHANGELOG entry

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
